### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.3
+
+### `@pollar/core`
+
+- **New:** `EscrowFn`, `EscrowAdapter`, and `PollarAdapters` types — generic adapter contract for wrapping external signing functions (e.g. Trustless Work SDK)
+
+### `@pollar/react`
+
+- **New:** `adapters` prop on `PollarProvider` — accepts any named set of adapters; adapter functions receive params, return an unsigned XDR, and Pollar handles signing and submission automatically
+- **New:** `createPollarAdapterHook(key)` — factory that generates a fully-typed hook (e.g. `usePollarEscrow`) mirroring the adapter's API with automatic XDR signing built in
+- **New:** Explorer link on each row in `TxHistoryModal` — opens the transaction on `stellar.expert` with the correct network (testnet/mainnet)
+- **Fix:** Unified CSS variables and base class across all modals via `shared.css` — eliminates duplicated style declarations
+- **Fix:** Transaction explorer URL in `TransactionModal` now correctly resolves network from `buildData.summary.network` before falling back to context network
+
 ## 0.5.2
 
 ### `@pollar/core`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polar-auth-monorepo",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Core authentication functions for Pollar services",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,3 +140,13 @@ export type RampsTransactionResponse =
 export type RampTxStatus = RampsTransactionResponse['status'];
 export type RampDirection = RampsTransactionResponse['direction'];
 export type PaymentInstructions = RampsOnrampResponse['paymentInstructions'];
+
+// ─── Adapter types ────────────────────────────────────────────────────────────
+
+export type EscrowFn<TParams = unknown> = (params: TParams) => Promise<{ unsignedTransaction: string }>;
+
+export type EscrowAdapter = Record<string, EscrowFn<any>>;
+
+export interface PollarAdapters {
+  [key: string]: EscrowAdapter;
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/react",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "React components for Pollar authentication",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/components/kyc-modal/KycModal.css
+++ b/packages/react/src/components/kyc-modal/KycModal.css
@@ -22,15 +22,7 @@
 
 /* ─── KYC Modal ─────────────────────────────────────────────────────────────── */
 .pollar-kyc-modal {
-  position: relative;
-  width: 100%;
   max-width: 500px;
-  border-radius: 1rem;
-  border: 1px solid var(--pollar-border);
-  padding: 2rem;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-  background-color: var(--pollar-bg);
-  box-sizing: border-box;
 }
 
 .pollar-kyc-header {
@@ -40,14 +32,14 @@
 
 .pollar-kyc-title {
   margin: 0 0 0.375rem;
-  font-size: 1.375rem;
+  font-size: var(--pollar-modal-heading-size, 1.375rem);
   font-weight: 700;
   color: var(--pollar-text);
 }
 
 .pollar-kyc-subtitle {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--pollar-modal-subtitle-size, 0.9rem);
   color: var(--pollar-muted);
 }
 
@@ -65,7 +57,7 @@
   justify-content: space-between;
   width: 100%;
   padding: 0.875rem 1rem;
-  border-radius: 0.625rem;
+  border-radius: var(--pollar-card-border-radius, 10px);
   border: 1px solid var(--pollar-border);
   background-color: var(--pollar-input-bg);
   cursor: pointer;

--- a/packages/react/src/components/kyc-modal/KycModalTemplate.tsx
+++ b/packages/react/src/components/kyc-modal/KycModalTemplate.tsx
@@ -37,17 +37,27 @@ export function KycModalTemplate({
 
   const cssVars = {
     '--pollar-accent': accentColor,
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
     '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
     '--pollar-border': isDark ? '#374151' : '#e5e7eb',
     '--pollar-text': isDark ? '#ffffff' : '#111827',
     '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
     '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
+    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
+    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
+    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
+    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-buttons-border-radius': '6px',
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
+    '--pollar-modal-padding': '2rem',
+    '--pollar-modal-heading-size': '1.375rem',
+    '--pollar-modal-subtitle-size': '0.9rem',
   } as CSSProperties;
 
   return (
-    <div className="pollar-kyc-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
+    <div className="pollar-modal-card pollar-kyc-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
       <div className="pollar-kyc-header">
         <h2 className="pollar-kyc-title">Identity verification</h2>
         <p className="pollar-kyc-subtitle">

--- a/packages/react/src/components/login-modal/LoginModal.css
+++ b/packages/react/src/components/login-modal/LoginModal.css
@@ -1,40 +1,6 @@
 /* ---- Modal card ---- */
 .pollar-modal {
-    position: relative;
-    width: 100%;
     max-width: 460px;
-    border-radius: 1rem;
-    border: 1px solid var(--pollar-border);
-    padding: 2rem;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-    background-color: var(--pollar-bg);
-    transition: all 300ms;
-    box-sizing: border-box;
-}
-
-/* ---- Back button ---- */
-.pollar-back-btn {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    padding: 0;
-    border-radius: var(--pollar-buttons-border-radius, 6px);
-    border: 1px solid var(--pollar-border);
-    background-color: transparent;
-    color: var(--pollar-muted);
-    cursor: pointer;
-    transition: all 0.15s;
-}
-
-.pollar-back-btn:hover {
-    background-color: var(--pollar-input-bg);
-    color: var(--pollar-text);
-    border-color: var(--pollar-text);
 }
 
 /* ---- Header ---- */
@@ -58,14 +24,14 @@
 
 .pollar-title {
     margin: 0 0 0.5rem;
-    font-size: 1.875rem;
+    font-size: var(--pollar-modal-heading-size, 1.375rem);
     font-weight: 700;
     color: var(--pollar-text);
 }
 
 .pollar-subtitle {
     margin: 0;
-    font-size: 1rem;
+    font-size: var(--pollar-modal-subtitle-size, 0.9rem);
     color: var(--pollar-muted);
 }
 
@@ -88,62 +54,20 @@
 
 .pollar-email-input {
     width: 100%;
-    border-radius: 0.5rem;
+    height: var(--pollar-input-height, 44px);
+    padding: 0 1rem;
+    border-radius: var(--pollar-input-border-radius, 0.5rem);
     border: 1px solid var(--pollar-border);
     background-color: var(--pollar-input-bg);
-    padding: 0.875rem 1rem;
     font-size: 1rem;
     color: var(--pollar-text);
     outline: none;
     box-sizing: border-box;
 }
 
-.pollar-email-input::placeholder {
-    color: var(--pollar-muted);
-}
-
-.pollar-email-input:focus {
-    box-shadow: 0 0 0 2px var(--pollar-accent);
-    border-color: transparent;
-}
-
-.pollar-email-input:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
-.pollar-submit-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 0.75rem;
-    width: 100%;
-    height: var(--pollar-buttons-height, 44px);
-    border: none;
-    border-radius: var(--pollar-buttons-border-radius, 0.5rem);
-    padding: 0 0.875rem;
-    font-size: 1rem;
-    font-weight: 700;
-    color: #fff;
-    background-color: var(--pollar-accent);
-    cursor: pointer;
-    transition: all 0.15s;
-    box-sizing: border-box;
-}
-
-.pollar-submit-btn:hover:not(:disabled) {
-    opacity: 0.9;
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-}
-
-.pollar-submit-btn:active:not(:disabled) {
-    transform: scale(0.98);
-}
-
-.pollar-submit-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
+.pollar-email-input::placeholder { color: var(--pollar-muted); }
+.pollar-email-input:focus { box-shadow: 0 0 0 2px var(--pollar-accent); border-color: transparent; }
+.pollar-email-input:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* ---- Divider ---- */
 .pollar-divider {

--- a/packages/react/src/components/login-modal/LoginModalTemplate.tsx
+++ b/packages/react/src/components/login-modal/LoginModalTemplate.tsx
@@ -101,16 +101,23 @@ export function LoginModalTemplate({
 
   const cssVars = {
     '--pollar-accent': accentColor,
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
     '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
     '--pollar-border': isDark ? '#374151' : '#e5e7eb',
     '--pollar-text': isDark ? '#ffffff' : '#111827',
     '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#ffffff',
+    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
     '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
     '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
     '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
+    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-buttons-border-radius': '6px',
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
+    '--pollar-modal-padding': '2rem',
+    '--pollar-modal-heading-size': '1.375rem',
+    '--pollar-modal-subtitle-size': '0.9rem',
   } as CSSProperties;
 
   const status = authStateToStatus(authState.step);
@@ -133,7 +140,7 @@ export function LoginModalTemplate({
   );
 
   return (
-    <div className="pollar-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
+    <div className="pollar-modal-card pollar-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
       <button type="button" className="pollar-close-btn" onClick={onCancel} aria-label="Close">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <path d="M18 6L6 18M6 6l12 12" />
@@ -189,7 +196,7 @@ export function LoginModalTemplate({
                 onChange={(e) => onEmailChange?.(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && onEmailSubmit?.()}
               />
-              <button type="button" disabled={isLoading || !email} className="pollar-submit-btn" onClick={onEmailSubmit}>
+              <button type="button" disabled={isLoading || !email} className="pollar-btn-primary" style={{ marginTop: '0.75rem', width: '100%' }} onClick={onEmailSubmit}>
                 Submit
               </button>
             </div>

--- a/packages/react/src/components/ramp-widget/RampWidget.css
+++ b/packages/react/src/components/ramp-widget/RampWidget.css
@@ -1,14 +1,6 @@
 /* ─── Widget container ──────────────────────────────────────────────────────── */
 .pollar-ramp-modal {
-  position: relative;
-  width: 100%;
   max-width: 480px;
-  border-radius: 1rem;
-  border: 1px solid var(--pollar-border);
-  padding: 2rem;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-  background-color: var(--pollar-bg);
-  box-sizing: border-box;
 }
 
 /* ─── Header ────────────────────────────────────────────────────────────────── */
@@ -19,14 +11,14 @@
 
 .pollar-ramp-title {
   margin: 0 0 0.375rem;
-  font-size: 1.375rem;
+  font-size: var(--pollar-modal-heading-size, 1.375rem);
   font-weight: 700;
   color: var(--pollar-text);
 }
 
 .pollar-ramp-subtitle {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--pollar-modal-subtitle-size, 0.9rem);
   color: var(--pollar-muted);
 }
 
@@ -35,7 +27,7 @@
   display: flex;
   gap: 0;
   border: 1px solid var(--pollar-border);
-  border-radius: 0.5rem;
+  border-radius: var(--pollar-input-border-radius, 0.5rem);
   overflow: hidden;
   margin-bottom: 1.25rem;
 }
@@ -74,9 +66,9 @@
 
 .pollar-ramp-input {
   width: 100%;
-  height: var(--pollar-buttons-height, 44px);
+  height: var(--pollar-input-height, 44px);
   padding: 0 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--pollar-input-border-radius, 0.5rem);
   border: 1px solid var(--pollar-border);
   background-color: var(--pollar-input-bg);
   color: var(--pollar-text);
@@ -147,7 +139,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.875rem 1rem;
-  border-radius: 0.625rem;
+  border-radius: var(--pollar-card-border-radius, 10px);
   border: 1px solid var(--pollar-border);
   background-color: var(--pollar-input-bg);
   cursor: pointer;
@@ -234,7 +226,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--pollar-card-border-radius, 10px);
   border: 1px solid var(--pollar-border);
   background-color: var(--pollar-input-bg);
 }
@@ -249,7 +241,7 @@
 
 .pollar-ramp-copy-btn {
   padding: 0.25rem 0.625rem;
-  border-radius: 4px;
+  border-radius: var(--pollar-buttons-border-radius, 6px);
   border: 1px solid var(--pollar-border);
   background: transparent;
   color: var(--pollar-muted);

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -62,13 +62,23 @@ export function RampWidgetTemplate({
 
   const cssVars = {
     '--pollar-accent': accentColor,
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
     '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
     '--pollar-border': isDark ? '#374151' : '#e5e7eb',
     '--pollar-text': isDark ? '#ffffff' : '#111827',
     '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
     '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
+    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
+    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
+    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
+    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-buttons-border-radius': '6px',
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
+    '--pollar-modal-padding': '2rem',
+    '--pollar-modal-heading-size': '1.375rem',
+    '--pollar-modal-subtitle-size': '0.9rem',
   } as CSSProperties;
 
   const stepTitle: Record<RampStep, string> = {
@@ -86,7 +96,7 @@ export function RampWidgetTemplate({
   };
 
   return (
-    <div className="pollar-ramp-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
+    <div className="pollar-modal-card pollar-ramp-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
       <div className="pollar-ramp-header">
         <h2 className="pollar-ramp-title">{stepTitle[step]}</h2>
         <p className="pollar-ramp-subtitle">{stepSubtitle[step]}</p>

--- a/packages/react/src/components/shared.css
+++ b/packages/react/src/components/shared.css
@@ -21,6 +21,37 @@
   background-color: rgba(0, 0, 0, 0.5);
 }
 
+/* ─── Modal card base (all modals extend this) ────────────────────────────────── */
+.pollar-modal-card {
+  position: relative;
+  width: 100%;
+  border-radius: 1rem;
+  border: 1px solid var(--pollar-border);
+  padding: var(--pollar-modal-padding, 1.75rem);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  background-color: var(--pollar-bg);
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+/* ─── Common input ────────────────────────────────────────────────────────────── */
+.pollar-input {
+  width: 100%;
+  height: var(--pollar-input-height, 44px);
+  padding: 0 1rem;
+  border-radius: var(--pollar-input-border-radius, 0.5rem);
+  border: 1px solid var(--pollar-border);
+  background-color: var(--pollar-input-bg);
+  color: var(--pollar-text);
+  font-size: 1rem;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.pollar-input::placeholder { color: var(--pollar-muted); }
+.pollar-input:focus { box-shadow: 0 0 0 2px var(--pollar-accent); border-color: transparent; }
+.pollar-input:disabled { opacity: 0.5; cursor: not-allowed; }
+
 /* ─── Modal header (title left, actions right) ────────────────────────────────── */
 .pollar-modal-header {
   display: flex;
@@ -42,28 +73,10 @@
   gap: 0.5rem;
 }
 
-/* ─── Close button ────────────────────────────────────────────────────────────── */
+/* ─── Icon nav buttons (close / back — shared base) ──────────────────────────── */
+.pollar-close-btn,
+.pollar-back-btn,
 .pollar-modal-close {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--pollar-muted);
-  padding: 4px;
-  display: flex;
-  align-items: center;
-  border-radius: 6px;
-  transition: color 150ms, background 150ms;
-}
-
-.pollar-modal-close:hover {
-  color: var(--pollar-text);
-  background: var(--pollar-border);
-}
-
-.pollar-close-btn {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,13 +88,28 @@
   background-color: transparent;
   color: var(--pollar-muted);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.pollar-close-btn:hover {
+.pollar-close-btn:hover,
+.pollar-back-btn:hover,
+.pollar-modal-close:hover {
   background-color: var(--pollar-input-bg);
   color: var(--pollar-text);
   border-color: var(--pollar-text);
+}
+
+/* Absolute positioned variants */
+.pollar-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.pollar-back-btn {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
 }
 
 /* ─── Refresh button ──────────────────────────────────────────────────────────── */

--- a/packages/react/src/components/transaction-modal/TransactionModal.css
+++ b/packages/react/src/components/transaction-modal/TransactionModal.css
@@ -1,15 +1,6 @@
 /* ---- Transaction modal ---- */
 .pollar-tx-modal {
-    position: relative;
-    width: 100%;
     max-width: 420px;
-    border-radius: 1rem;
-    border: 1px solid var(--pollar-border);
-    padding: 1.75rem;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-    background-color: var(--pollar-bg);
-    box-sizing: border-box;
-    font-family: inherit;
 }
 
 /* ---- Wallet spinner ---- */
@@ -75,9 +66,9 @@
 
 /* ---- Summary card ---- */
 .pollar-tx-summary {
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 10px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     padding: 1rem 1.25rem;
     margin-bottom: 1rem;
 }
@@ -117,9 +108,9 @@
 
 .pollar-tx-meta-item {
     flex: 1;
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 8px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     padding: 0.625rem 0.875rem;
 }
 
@@ -141,9 +132,9 @@
 
 /* ---- Result (success hash) ---- */
 .pollar-tx-result {
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 8px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     padding: 0.75rem 1rem;
     margin-bottom: 1rem;
     word-break: break-all;
@@ -176,7 +167,7 @@
     align-items: center;
     gap: 0.375rem;
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--pollar-buttons-border-radius, 6px);
     border: 1px solid var(--pollar-border);
     background: none;
     font-size: 0.75rem;
@@ -243,9 +234,9 @@
 .pollar-tx-xdr-content {
     margin: 0.5rem 0 0;
     padding: 0.75rem;
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 8px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     font-family: monospace;
     font-size: 0.6875rem;
     color: var(--pollar-text);
@@ -273,9 +264,9 @@
 .pollar-tx-error-details-content {
     margin: 0;
     padding: 0.75rem;
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 8px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     font-family: monospace;
     font-size: 0.6875rem;
     color: var(--pollar-error-text);

--- a/packages/react/src/components/transaction-modal/TransactionModal.tsx
+++ b/packages/react/src/components/transaction-modal/TransactionModal.tsx
@@ -19,7 +19,13 @@ export function TransactionModal({ onClose }: TransactionModalProps) {
 
   const hash = transaction.step === 'success' ? transaction.hash : null;
   const buildData = 'buildData' in transaction ? transaction.buildData : null;
-  const explorerNetwork = buildData?.summary.network?.toLowerCase().includes('testnet') ? 'testnet' : 'public';
+  const explorerNetwork = buildData?.summary.network?.toLowerCase().includes('testnet')
+    ? 'testnet'
+    : buildData
+      ? 'public'
+      : network === 'testnet'
+        ? 'testnet'
+        : 'public';
   const explorerUrl = hash ? `https://stellar.expert/explorer/${explorerNetwork}/tx/${hash}` : null;
 
   function handleSignAndSend() {

--- a/packages/react/src/components/transaction-modal/TransactionModalTemplate.tsx
+++ b/packages/react/src/components/transaction-modal/TransactionModalTemplate.tsx
@@ -47,15 +47,20 @@ export function TransactionModalTemplate({
 
   const cssVars = {
     '--pollar-accent': accentColor,
-    '--pollar-buttons-border-radius': '8px',
-    '--pollar-buttons-height': '44px',
     '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
     '--pollar-border': isDark ? '#374151' : '#e5e7eb',
     '--pollar-text': isDark ? '#ffffff' : '#111827',
     '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : 'rgba(0,0,0,0.04)',
+    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
+    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
+    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
     '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
     '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-buttons-border-radius': '6px',
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
   } as React.CSSProperties;
 
   const buildData = 'buildData' in transaction ? transaction.buildData : null;
@@ -69,7 +74,7 @@ export function TransactionModalTemplate({
   const showDetails = buildData !== null && (isBuilt || isSigning || isSuccess);
 
   return (
-    <div className="pollar-tx-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>
+    <div className="pollar-modal-card pollar-tx-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>
       <div className="pollar-modal-header">
         <h2 className="pollar-modal-title">Transaction</h2>
       </div>

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.css
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.css
@@ -70,6 +70,19 @@
     color: var(--pollar-muted);
 }
 
+.pollar-hist-item-explorer {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    color: var(--pollar-muted);
+    text-decoration: none;
+    transition: color 150ms;
+}
+
+.pollar-hist-item-explorer:hover {
+    color: var(--pollar-accent);
+}
+
 /* ---- Pagination ---- */
 .pollar-hist-pagination {
     display: flex;

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.css
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.css
@@ -1,14 +1,6 @@
 /* ---- Tx history modal ---- */
 .pollar-hist-modal {
-    width: 100%;
     max-width: 480px;
-    border-radius: 1rem;
-    border: 1px solid var(--pollar-border);
-    padding: 1.75rem;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-    background-color: var(--pollar-bg);
-    box-sizing: border-box;
-    font-family: inherit;
 }
 
 /* ---- List ---- */
@@ -27,9 +19,9 @@
     grid-template-rows: auto auto;
     column-gap: 0.75rem;
     row-gap: 0.125rem;
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 10px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     padding: 0.75rem 1rem;
 }
 
@@ -99,7 +91,7 @@
 .pollar-hist-page-btn {
     background: none;
     border: 1px solid var(--pollar-border);
-    border-radius: 6px;
+    border-radius: var(--pollar-buttons-border-radius, 6px);
     padding: 4px 10px;
     font-size: 0.75rem;
     font-weight: 500;

--- a/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
@@ -43,15 +43,20 @@ export function TxHistoryModalTemplate({
 
   const cssVars = {
     '--pollar-accent': accentColor,
-    '--pollar-buttons-border-radius': '8px',
-    '--pollar-buttons-height': '44px',
     '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
     '--pollar-border': isDark ? '#374151' : '#e5e7eb',
     '--pollar-text': isDark ? '#ffffff' : '#111827',
     '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : 'rgba(0,0,0,0.04)',
+    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
+    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
+    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
     '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
     '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-buttons-border-radius': '6px',
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
   } as CSSProperties;
 
   const isLoading = txHistory.step === 'loading';
@@ -62,7 +67,7 @@ export function TxHistoryModalTemplate({
   const showPagination = txHistory.step === 'loaded' && total > PAGE_SIZE;
 
   return (
-    <div className="pollar-hist-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>
+    <div className="pollar-modal-card pollar-hist-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>
       <div className="pollar-modal-header">
         <h2 className="pollar-modal-title">Transaction History</h2>
         <div className="pollar-modal-header-actions">

--- a/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
@@ -111,17 +111,28 @@ export function TxHistoryModalTemplate({
         {txHistory.step === 'loaded' && records.length === 0 && (
           <div className="pollar-modal-empty">No transactions yet.</div>
         )}
-        {records.map((record) => (
-          <div key={record.id} className="pollar-hist-item">
-            <span className="pollar-hist-item-summary">{record.summary}</span>
-            <StatusBadge status={record.status} />
-            <span className="pollar-hist-item-meta">
-              <span>{record.operation}</span>
-              {record.feeXlm && <span>· {record.feeXlm} XLM</span>}
-              <span>· {formatDate(record.createdAt)}</span>
-            </span>
-          </div>
-        ))}
+        {records.map((record) => {
+          const explorerUrl = `https://stellar.expert/explorer/${record.network === 'testnet' ? 'testnet' : 'public'}/tx/${record.hash}`;
+          return (
+            <div key={record.id} className="pollar-hist-item">
+              <span className="pollar-hist-item-summary">{record.summary}</span>
+              <StatusBadge status={record.status} />
+              <span className="pollar-hist-item-meta">
+                <span>{record.operation}</span>
+                {record.feeXlm && <span>· {record.feeXlm} XLM</span>}
+                <span>· {formatDate(record.createdAt)}</span>
+                <span>·</span>
+                <a className="pollar-hist-item-explorer" href={explorerUrl} target="_blank" rel="noopener noreferrer" aria-label="View on Stellar Explorer">
+                  <svg width="11" height="11" viewBox="0 0 13 13" fill="none" aria-hidden>
+                    <path d="M5 2H2a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    <path d="M8 1h4m0 0v4m0-4L6 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  Explorer
+                </a>
+              </span>
+            </div>
+          );
+        })}
       </div>
 
       {showPagination && (

--- a/packages/react/src/components/wallet-balance-modal/WalletBalanceModal.css
+++ b/packages/react/src/components/wallet-balance-modal/WalletBalanceModal.css
@@ -1,14 +1,6 @@
 /* ---- Wallet balance modal ---- */
 .pollar-bal-modal {
-    width: 100%;
     max-width: 380px;
-    border-radius: 1rem;
-    border: 1px solid var(--pollar-border);
-    padding: 1.75rem;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-    background-color: var(--pollar-bg);
-    box-sizing: border-box;
-    font-family: inherit;
 }
 
 /* ---- Address chip ---- */
@@ -16,9 +8,9 @@
     font-size: 0.75rem;
     font-family: monospace;
     color: var(--pollar-muted);
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 6px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     padding: 0.375rem 0.75rem;
     margin-bottom: 1rem;
     overflow: hidden;
@@ -38,9 +30,9 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background: var(--pollar-input-bg, rgba(0,0,0,0.04));
+    background: var(--pollar-input-bg);
     border: 1px solid var(--pollar-border);
-    border-radius: 10px;
+    border-radius: var(--pollar-card-border-radius, 10px);
     padding: 0.75rem 1rem;
 }
 

--- a/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
+++ b/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
@@ -54,15 +54,23 @@ export function WalletBalanceModalTemplate({
     '--pollar-border': isDark ? '#374151' : '#e5e7eb',
     '--pollar-text': isDark ? '#ffffff' : '#111827',
     '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : 'rgba(0,0,0,0.04)',
+    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
+    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
+    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
     '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
+    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-buttons-border-radius': '6px',
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
   } as CSSProperties;
 
   const isLoading = walletBalance.step === 'loading';
   const data = walletBalance.step === 'loaded' ? walletBalance.data : null;
 
   return (
-    <div className="pollar-bal-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>
+    <div className="pollar-modal-card pollar-bal-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>
       <div className="pollar-modal-header">
         <h2 className="pollar-modal-title">Wallet Balance</h2>
         <div className="pollar-modal-header-actions">

--- a/packages/react/src/components/wallet-button/WalletButton.css
+++ b/packages/react/src/components/wallet-button/WalletButton.css
@@ -45,7 +45,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  border-radius: 8px;
+  border-radius: 6px;
   color: #fff;
   font-size: 14px;
   font-weight: 500;
@@ -74,7 +74,7 @@
   right: 0;
   min-width: 180px;
   border: 1px solid;
-  border-radius: 8px;
+  border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   z-index: 50;

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -2,6 +2,7 @@
 
 import {
   NetworkState,
+  PollarAdapters,
   PollarApplicationConfigContent,
   PollarClient,
   PollarClientConfig,
@@ -74,6 +75,8 @@ interface PollarContextValue {
   openTxHistoryModal: () => void;
   // wallet balance
   openWalletBalanceModal: () => void;
+  // adapters
+  adapters?: PollarAdapters;
 }
 
 const PollarContext = createContext<PollarContextValue | null>(null);
@@ -81,10 +84,11 @@ const PollarContext = createContext<PollarContextValue | null>(null);
 interface PollarProviderProps {
   config: PollarClientConfig;
   styles?: PollarStyles;
+  adapters?: PollarAdapters;
   children: ReactNode;
 }
 
-export function PollarProvider({ config, styles: propStyles, children }: PollarProviderProps) {
+export function PollarProvider({ config, styles: propStyles, adapters, children }: PollarProviderProps) {
   const [pollarClient] = useState<PollarClient>(() => new PollarClient(config));
   const [networkState, setNetworkState] = useState<NetworkState>(() => pollarClient.getNetworkState());
   const [sessionState, setSessionState] = useState<PollarApplicationConfigContent | null>(null);
@@ -183,6 +187,7 @@ export function PollarProvider({ config, styles: propStyles, children }: PollarP
         setNetwork: (network: StellarNetwork) => pollarClient.setNetwork(network),
         config: remoteConfig,
         styles,
+        adapters,
       }) as PollarContextValue,
     [sessionState, remoteConfig, styles, pollarClient, transaction, txHistory, networkState, walletBalance],
   );

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 export { PollarProvider, usePollar } from './context';
+export { createPollarAdapterHook } from './usePollarAdapter';
 export type {
   AuthProviderProps,
   AuthContextValue,

--- a/packages/react/src/usePollarAdapter.ts
+++ b/packages/react/src/usePollarAdapter.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import type { EscrowAdapter } from '@pollar/core';
+import { usePollar } from './context';
+
+type WrappedAdapter<T extends EscrowAdapter> = {
+  [K in keyof T]: (params: Parameters<T[K]>[0]) => Promise<void>;
+};
+
+export function createPollarAdapterHook<T extends EscrowAdapter>(key: string) {
+  return function usePollarAdapter(): WrappedAdapter<T> {
+    const { adapters, signAndSubmitTx } = usePollar();
+    const adapter = adapters?.[key] as T | undefined;
+
+    if (!adapter) {
+      throw new Error(`No adapter "${key}" provided to PollarProvider`);
+    }
+
+    return Object.fromEntries(
+      Object.entries(adapter).map(([name, fn]) => [
+        name,
+        async (params: Parameters<typeof fn>[0]) => {
+          const { unsignedTransaction } = await fn(params);
+          await signAndSubmitTx(unsignedTransaction);
+        },
+      ]),
+    ) as WrappedAdapter<T>;
+  };
+}


### PR DESCRIPTION
## Summary
- Add generic adapter system (`EscrowFn`, `EscrowAdapter`, `PollarAdapters`) in `@pollar/core`
- Add `adapters` prop to `PollarProvider` and `createPollarAdapterHook` factory in `@pollar/react`
- Add stellar.expert explorer link per row in `TxHistoryModal`
- Unify modal CSS variables via `shared.css` and fix transaction explorer network URL

## Test plan
- [x] Pass `adapters` to `PollarProvider` with a mock escrow adapter and verify `createPollarAdapterHook` wraps calls correctly
- [x] Confirm `usePollarX()` triggers `signAndSubmitTx` with the unsigned XDR returned by the adapter function
- [x] Open `TxHistoryModal` and verify each row shows an Explorer link pointing to the correct network on stellar.expert
- [x] Verify all modals render correctly with unified CSS variables in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)