### PR TITLE
Release 0.7.2 — signTx/submitTx, outcome returns, richer TxState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,94 @@
 # Changelog
 
+## 0.7.2
+
+Adds a per-call outcome API so headless callers can `await` a transaction and
+inspect the result instead of subscribing to `onTransactionStateChange`. Adds
+split `signTx` / `submitTx` for both wallet types, a one-shot atomic path
+for custodial flows, and a richer `TransactionState` vocabulary so modal UIs
+can render every phase honestly (including the previously-elided "submitted
+to network, waiting for ledger" intermediate state). Existing `0.7.x`
+consumers that don't render `TransactionState` themselves keep working
+unchanged.
+
+### `@pollar/core` — new features
+
+- **`buildTx` and `signAndSubmitTx` now return outcomes.** Their return types
+  changed from `Promise<void>` to `Promise<BuildOutcome>` and
+  `Promise<SubmitOutcome>` respectively. The state-machine emissions (used by
+  `TransactionModal`, `SendModal`, and any consumer subscribed to
+  `onTransactionStateChange`) are preserved exactly as before. Callers that
+  previously did `await client.signAndSubmitTx(xdr)` and ignored the resolved
+  value keep working.
+- **`signTx(unsignedXdr)`** and **`submitTx(signedXdr, { submissionToken? })`** —
+  split-flow primitives that return `SignOutcome` / `SubmitOutcome`. External
+  wallets sign locally via the adapter and submit directly to Stellar RPC.
+  Custodial wallets go through new sdk-api endpoints (`/tx/sign`,
+  `/tx/submit`) so the wallet-service tracks the lifecycle and enforces
+  idempotency by `submissionToken` (mapped to `idempotencyKey` server-side).
+- **`buildAndSignAndSubmitTx(operation, params, options?)`** and its alias
+  **`runTx(...)`** — one method that picks the optimal path per wallet type:
+  - External wallets: composes `buildTx + signAndSubmitTx` client-side,
+    preserving `building → signing → success` state-machine transitions.
+  - Custodial wallets: single round-trip to `/tx/build-sign-submit`. The
+    signed XDR never leaves the backend. Skips intermediate state-machine
+    transitions — if you need granular UI feedback, use `buildTx`, `signTx`,
+    `submitTx` separately instead.
+- New result types: `BuildOutcome`, `SignOutcome`, `SubmitOutcome`,
+  `TxSignBody`, `TxSignContent`, `TxSubmitSignedBody`,
+  `TxBuildSignSubmitBody`, `TxBuildSignSubmitContent`. OpenAPI schema
+  regenerated against `sdk-api` — adds `/tx/sign`, `/tx/submit`,
+  `/tx/build-sign-submit` paths.
+
+### `@pollar/react` — new features
+
+- **Context exposes the new methods.** `usePollar()` now returns `signTx`,
+  `submitTx`, `buildAndSignAndSubmitTx`, and `runTx` in addition to the
+  existing `buildTx` / `signAndSubmitTx`. Return types match the core SDK.
+- **`usePollarAdapter` returns outcomes.** `WrappedAdapter<T>` methods now
+  resolve to `Promise<SubmitOutcome>` instead of `Promise<void>`. Adapter
+  callers can inspect `result.status` to branch on `success` / `pending` /
+  `error` without subscribing to the global state.
+
+### `TransactionState` vocabulary
+
+The `TransactionState` discriminated union grew from 6 step values to 11:
+
+**Added**:
+- `signing` (already existed but now emitted by `signTx` directly, not just `signAndSubmitTx`)
+- `signed` — signed XDR in hand, waiting for `submitTx`
+- `submitting` — pushing signed XDR to the network
+- `submitted` — Horizon ack received, ledger confirmation pending (previously misreported as `success`)
+- `signing-submitting` — compound state for `signAndSubmitTx` custodial (atomic `/tx/sign-and-send` round-trip — the SDK can't observe the sign/submit boundary inside)
+- `building-signing-submitting` — compound state for `runTx` / `buildAndSignAndSubmitTx` custodial (atomic `/tx/build-sign-submit` round-trip)
+
+**Changed**:
+- `error` now carries a required `phase: TxErrorPhase` discriminator so modals can offer "retry from this step" and label which phase failed.
+- `external?: true` flag removed from the union — it was an internal discriminator that became unnecessary once `buildData` was threaded through every transition. Custom UIs that read `state.external` should branch on the presence of `state.buildData` instead.
+
+### Migration notes
+
+- **No breaking runtime behavior for 0.5 / 0.6 / 0.7.1 consumers.** Existing
+  `await client.signAndSubmitTx(xdr)` calls keep working — only the resolved
+  value is different (was `void`, is now `SubmitOutcome`), which is fine for
+  callers that ignore it.
+- If you previously annotated `Promise<void>` explicitly somewhere
+  (`const p: Promise<void> = client.signAndSubmitTx(...)`), TypeScript will
+  flag it after upgrading. Drop the annotation or update it to
+  `Promise<SubmitOutcome>`.
+- **If you render `TransactionState` in a custom UI** (not using the built-in
+  `TransactionModal` / `SendModal`): your exhaustive `switch (state.step)`
+  will produce a TypeScript error after upgrading because it doesn't cover
+  the 5 new step values. Add cases for `signed`, `submitting`, `submitted`,
+  `signing-submitting`, `building-signing-submitting` — or add a `default`
+  branch for forward compatibility. At runtime, an unhandled step just
+  means your modal won't render anything for it; no error is thrown.
+- **`state.external` removed.** If you keyed UI off it, switch to
+  `'buildData' in state ? state.buildData : null` (the same buildData
+  threading the SDK uses internally).
+- The built-in `TransactionModal` and `SendModal` already handle every new
+  state — if you use them as-is, no UI changes needed.
+
 ## 0.7.1
 
 Patch release on top of 0.7.0 — adds a distribution-rules surface to `@pollar/core` and

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Core authentication functions for Pollar services",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -349,6 +349,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/tx/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sign an unsigned XDR (split flow)
+         * @description Sign-only step of the split build/sign/submit flow. For custodial wallets, the signed XDR is returned to the caller so it can be submitted later via POST /tx/submit. External wallets sign client-side and do not call this endpoint.
+         */
+        post: operations["postTxSign"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tx/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit a pre-signed XDR
+         * @description Submit step of the split build/sign/submit flow. Accepts a signed XDR produced by /tx/sign or by an external-wallet adapter. Goes through wallet-service /v1/tx/submit so the submission is policy-validated and idempotency-tracked.
+         */
+        post: operations["postTxSubmit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tx/build-sign-submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Atomic build + sign + submit (one round-trip)
+         * @description Server-side composition of /tx/build + /tx/sign + /tx/submit. The signed XDR never leaves the backend. Use for headless / server-driven flows that do not need intermediate state-machine transitions on the client.
+         */
+        post: operations["postTxBuildSignSubmit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tx/status": {
         parameters: {
             query?: never;
@@ -381,6 +441,46 @@ export interface paths {
          * @description Returns paginated transaction history for the authenticated SDK user. Only includes transactions submitted through Pollar. Transactions appear as PENDING immediately after /tx/build and are updated to SUCCESS or FAILED after /tx/sign-and-send.
          */
         get: operations["getTxHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/charges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a charge
+         * @description Creates a Pollar Pay point-of-sale charge for one of the application branches. Reserves a pool wallet (the address the customer pays to) and returns the payment intent.
+         */
+        post: operations["postCharges"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/charges/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get charge status
+         * @description Returns the live status of a charge. A pending charge past its window reads as expired.
+         */
+        get: operations["getChargesById"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2033,6 +2133,434 @@ export interface operations {
             };
         };
     };
+    postTxSign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    unsignedXdr: string;
+                    idempotencyKey?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed XDR + idempotency key to use with /tx/submit */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SIGNED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            signedXdr: string;
+                            idempotencyKey: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Signing error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxSubmit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    signedXdr: string;
+                    idempotencyKey?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Submit result (PENDING | SUCCESS | FAILED) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SUBMIT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            hash: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "SUCCESS" | "FAILED";
+                            resultCode?: string;
+                            message?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxBuildSignSubmit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    options?: {
+                        timeoutSec?: number;
+                        memo?: {
+                            /** @constant */
+                            type: "text";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "id";
+                            value: string;
+                        };
+                        maxFeeStroops?: number;
+                    };
+                } & ({
+                    /** @constant */
+                    operation: "payment";
+                    params: {
+                        destination: string;
+                        amount: string;
+                        asset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                    };
+                } | {
+                    /** @constant */
+                    operation: "change_trust";
+                    params: {
+                        asset: {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "liquidity_pool_shares";
+                            assetA: {
+                                /** @constant */
+                                type: "native";
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum4";
+                                code: string;
+                                issuer: string;
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum12";
+                                code: string;
+                                issuer: string;
+                            };
+                            assetB: {
+                                /** @constant */
+                                type: "native";
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum4";
+                                code: string;
+                                issuer: string;
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum12";
+                                code: string;
+                                issuer: string;
+                            };
+                        };
+                        limit?: string;
+                    };
+                } | {
+                    /** @constant */
+                    operation: "path_payment_strict_send";
+                    params: {
+                        destination: string;
+                        sendAsset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                        sendAmount: string;
+                        destAsset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                        destMin: string;
+                        /** @default [] */
+                        path?: ({
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        })[];
+                    };
+                } | {
+                    /** @constant */
+                    operation: "create_account";
+                    params: {
+                        destination: string;
+                        startingBalance: string;
+                    };
+                } | {
+                    /** @constant */
+                    operation: "invoke_contract";
+                    params: {
+                        contractId: string;
+                        method: string;
+                        /** @default [] */
+                        args?: ({
+                            /** @constant */
+                            type: "bool";
+                            value: boolean;
+                        } | {
+                            /** @constant */
+                            type: "i32";
+                            value: number;
+                        } | {
+                            /** @constant */
+                            type: "u32";
+                            value: number;
+                        } | {
+                            /** @enum {string} */
+                            type: "i64" | "u64" | "i128" | "u128" | "i256" | "u256";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "address";
+                            value: string;
+                        } | {
+                            /** @enum {string} */
+                            type: "string" | "symbol";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "bytes";
+                            /** @description Base64-encoded bytes */
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "vec";
+                            /** @description Array of ScValArg items */
+                            value: unknown[];
+                        } | {
+                            /** @constant */
+                            type: "map";
+                            /** @description Array of {key, val} ScValArg pairs */
+                            value: {
+                                key: unknown;
+                                val: unknown;
+                            }[];
+                        } | {
+                            /** @constant */
+                            type: "void";
+                        })[];
+                    };
+                }) & {
+                    idempotencyKey?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Final submit result with the original build summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SUBMIT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            hash: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "SUCCESS" | "FAILED";
+                            resultCode?: string;
+                            message?: string;
+                            summary: {
+                                title: string;
+                                lines: string[];
+                                network: string;
+                                fee: string;
+                            };
+                            estimatedFee: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Build/sign/submit error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
     getTxStatus: {
         parameters: {
             query: {
@@ -2158,6 +2686,196 @@ export interface operations {
             };
             /** @description Unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postCharges: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Charge created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_CHARGE_CREATED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            chargeId: string;
+                            walletAddress: string;
+                            reason: string;
+                            amount: string;
+                            asset: string;
+                            network: string;
+                            expiresAt: string;
+                            timeRemainingSeconds: number;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description No pool wallet available */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        chargeId: string;
+                        walletAddress: string;
+                        reason: string;
+                        amount: string;
+                        asset: string;
+                        network: string;
+                        expiresAt: string;
+                        timeRemainingSeconds: number;
+                    };
+                };
+            };
+        };
+    };
+    getChargesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Charge status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_CHARGE_STATUS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            chargeId: string;
+                            /** @enum {string} */
+                            status: "pending" | "completed" | "overpaid" | "underpaid" | "expired" | "refunded";
+                            reason: string;
+                            amountExpected: string;
+                            amountPaid: string;
+                            remaining: string;
+                            asset: string;
+                            walletAddress: string;
+                            network: string;
+                            expiresAt: string;
+                            timeRemainingSeconds: number;
+                            isExpired: boolean;
+                            feeAmount: string | null;
+                            payoutAmount: string | null;
+                            forwardTxHash: string | null;
+                            createdAt: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -18,6 +18,7 @@ import type { Storage } from '../storage/types';
 import {
   AUTH_ERROR_CODES,
   AuthState,
+  BuildOutcome,
   DistributionClaimBody,
   DistributionClaimContent,
   DistributionRule,
@@ -41,6 +42,8 @@ import {
   RampsTransactionResponse,
   RampTxStatus,
   SessionInfo,
+  SignOutcome,
+  SubmitOutcome,
   TransactionState,
   TxBuildBody,
   TxBuildContent,
@@ -254,11 +257,19 @@ export class PollarClient {
         if (newNonce) self._dpopNonce = newNonce;
 
         if (response.status !== 401) return response;
-        // Don't trigger refresh from inside the refresh endpoint itself.
-        if (request.url.includes('/auth/refresh')) return response;
 
         const wwwAuth = response.headers.get('WWW-Authenticate') ?? '';
         const isNonceChallenge = wwwAuth.includes('use_dpop_nonce');
+
+        // The refresh endpoint has special handling: don't recursively trigger
+        // refresh from inside itself. But DO honor a nonce challenge — the
+        // fresh `DPoP-Nonce` was already captured above, so a single retry
+        // with the new nonce succeeds. Any other 401 (RT expired, reused,
+        // invalid) propagates to `_doRefresh` which clears the session.
+        if (request.url.includes('/auth/refresh')) {
+          if (isNonceChallenge) return self._retryRequest(request);
+          return response;
+        }
 
         if (!isNonceChallenge) {
           try {
@@ -297,15 +308,27 @@ export class PollarClient {
     // RETRIED_HEADER guard is needed — the retry's response is returned to
     // the caller directly and never re-enters this middleware.
     const headers = new Headers(originalRequest.headers);
+    const isRefresh = originalRequest.url.includes('/auth/refresh');
 
-    const accessToken = this._session?.token?.accessToken;
-    if (accessToken) {
-      const proof = await this._buildProofForRequest(originalRequest, accessToken);
-      if (proof) {
-        headers.set('Authorization', `DPoP ${accessToken}`);
-        headers.set('DPoP', proof);
-      } else {
-        headers.set('Authorization', `Bearer ${accessToken}`);
+    if (isRefresh) {
+      // Token-endpoint proof per RFC 9449 §5 / §6.1: NO `ath`, NO
+      // Authorization header. Mirrors the initial-request branch in
+      // `onRequest`. The DPoP header is rebuilt so it picks up the fresh
+      // server-issued nonce captured in `onResponse`.
+      const proof = await this._buildProofForRequest(originalRequest, undefined);
+      headers.delete('Authorization');
+      if (proof) headers.set('DPoP', proof);
+      else headers.delete('DPoP');
+    } else {
+      const accessToken = this._session?.token?.accessToken;
+      if (accessToken) {
+        const proof = await this._buildProofForRequest(originalRequest, accessToken);
+        if (proof) {
+          headers.set('Authorization', `DPoP ${accessToken}`);
+          headers.set('DPoP', proof);
+        } else {
+          headers.set('Authorization', `Bearer ${accessToken}`);
+        }
       }
     }
 
@@ -686,14 +709,20 @@ export class PollarClient {
 
   // ─── Transactions ─────────────────────────────────────────────────────────
 
+  /**
+   * Builds an unsigned XDR. Drives `_setTransactionState` for modal-style UIs
+   * AND returns a {@link BuildOutcome} so headless callers can `await` and
+   * inspect the result without subscribing to state changes.
+   */
   async buildTx(
     operation: TxBuildBody['operation'],
     params: TxBuildBody['params'],
     options?: TxBuildBody['options'],
-  ): Promise<void> {
+  ): Promise<BuildOutcome> {
     if (!this._session?.wallet?.publicKey) {
-      this._setTransactionState({ step: 'error', details: 'No wallet connected' });
-      return;
+      const details = 'No wallet connected';
+      this._setTransactionState({ step: 'error', phase: 'building', details });
+      return { status: 'error', details };
     }
 
     const body = {
@@ -709,13 +738,15 @@ export class PollarClient {
       const { data, error } = await this._api.POST('/tx/build', { body });
       if (!error && data?.success && data.content) {
         this._setTransactionState({ step: 'built', buildData: data.content });
-      } else {
-        const details = (error as { details?: string } | undefined)?.details;
-        this._setTransactionState({ step: 'error', ...(details && { details }) });
+        return { status: 'built', buildData: data.content };
       }
+      const details = (error as { details?: string } | undefined)?.details;
+      this._setTransactionState({ step: 'error', phase: 'building', ...(details && { details }) });
+      return { status: 'error', ...(details && { details }) };
     } catch (err) {
       console.error('[PollarClient] buildTx failed', err);
-      this._setTransactionState({ step: 'error' });
+      this._setTransactionState({ step: 'error', phase: 'building' });
+      return { status: 'error' };
     }
   }
 
@@ -723,38 +754,224 @@ export class PollarClient {
     return this._walletAdapter?.type ?? null;
   }
 
-  async signAndSubmitTx(unsignedXdr: string): Promise<void> {
-    const state = this._transactionState;
-    const buildData = state?.step === 'built' ? state.buildData : state?.step === 'error' ? state.buildData : undefined;
-    const isBuiltFlow = !!buildData;
-    const stateExtra: { buildData?: TxBuildContent; external?: true } = buildData ? { buildData } : { external: true };
+  /**
+   * Signs the given unsigned XDR and returns the signed XDR.
+   *
+   * - External wallets: signs locally via the wallet adapter.
+   * - Custodial wallets: posts to `/tx/sign`. The backend signs (through
+   *   wallet-service or the app's customer-managed adapter) and returns the
+   *   signed XDR plus an `idempotencyKey` the caller should echo back to
+   *   `submitTx`.
+   *
+   * Drives `_setTransactionState`: emits `signing` while in flight and
+   * `signed` on success (or `error[phase: 'signing']` on failure). `buildData`
+   * is threaded through if the consumer previously called `buildTx`.
+   */
+  async signTx(unsignedXdr: string): Promise<SignOutcome> {
+    const buildData = this._currentBuildData();
+    this._setTransactionState({ step: 'signing', ...(buildData && { buildData }) });
 
-    this._setTransactionState({ step: 'signing', ...stateExtra });
+    if (this._walletAdapter) {
+      const accountToSign = this._session?.wallet?.publicKey;
+      const signOpts = accountToSign
+        ? { networkPassphrase: this._networkPassphrase(), accountToSign }
+        : { networkPassphrase: this._networkPassphrase() };
+      try {
+        const { signedTxXdr } = await this._walletAdapter.signTransaction(unsignedXdr, signOpts);
+        this._setTransactionState({
+          step: 'signed',
+          signedXdr: signedTxXdr,
+          ...(buildData && { buildData }),
+        });
+        return { status: 'signed', signedXdr: signedTxXdr };
+      } catch (err) {
+        const details = err instanceof Error ? err.message : undefined;
+        this._setTransactionState({
+          step: 'error',
+          phase: 'signing',
+          ...(buildData && { buildData }),
+          ...(details && { details }),
+        });
+        return { status: 'error', ...(details && { details }) };
+      }
+    }
 
-    // For both external + custodial wallets, the public key in `_session.wallet`
-    // IS the address we want to sign for. The previous code branched on
-    // `data.providers.wallet.address` but that's the same value (the wallet
-    // address from login becomes wallet.publicKey).
-    const accountToSign = this._session?.wallet?.publicKey;
+    // Custodial path: backend signs and returns the XDR + idempotencyKey.
+    const publicKey = this._session?.wallet?.publicKey ?? '';
+    try {
+      const { data, error } = await this._api.POST('/tx/sign', {
+        body: { network: this.getNetwork(), publicKey, unsignedXdr },
+      });
+      if (!error && data?.success && data.content?.signedXdr) {
+        const { signedXdr, idempotencyKey } = data.content;
+        this._setTransactionState({
+          step: 'signed',
+          signedXdr,
+          submissionToken: idempotencyKey,
+          ...(buildData && { buildData }),
+        });
+        return { status: 'signed', signedXdr, submissionToken: idempotencyKey };
+      }
+      const details = (error as { details?: string } | undefined)?.details;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'signing',
+        ...(buildData && { buildData }),
+        ...(details && { details }),
+      });
+      return { status: 'error', ...(details && { details }) };
+    } catch (err) {
+      const details = err instanceof Error ? err.message : undefined;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'signing',
+        ...(buildData && { buildData }),
+        ...(details && { details }),
+      });
+      return { status: 'error', ...(details && { details }) };
+    }
+  }
+
+  /**
+   * Submits a signed XDR.
+   *
+   * - External wallets: submits directly to Stellar via the public RPC. No
+   *   backend involvement, lowest latency. Cannot return `pending` — the RPC
+   *   call is synchronous, so the outcome is either `success` or `error`.
+   * - Custodial wallets: submits via `/tx/submit` so the wallet-service
+   *   tracks the tx lifecycle and enforces idempotency. Pass the
+   *   `submissionToken` returned by `signTx` to reuse the same idempotency
+   *   key end-to-end. May return `pending` if the network ack'd but ledger
+   *   confirmation hasn't arrived before the SDK's poll window expires.
+   *
+   * Drives `_setTransactionState`: emits `submitting` while in flight,
+   * `submitted` on Horizon ack (pending), `success` on ledger confirmation,
+   * or `error[phase: 'submitting']` on failure.
+   */
+  async submitTx(signedXdr: string, opts?: { submissionToken?: string }): Promise<SubmitOutcome> {
+    const buildData = this._currentBuildData();
+    const outcomeExtra: { buildData?: TxBuildContent } = buildData ? { buildData } : {};
+    this._setTransactionState({ step: 'submitting', signedXdr, ...(buildData && { buildData }) });
 
     if (this._walletAdapter) {
       try {
-        const signOpts = accountToSign
-          ? { networkPassphrase: this._networkPassphrase(), accountToSign }
-          : { networkPassphrase: this._networkPassphrase() };
-        const { signedTxXdr } = await this._walletAdapter.signTransaction(unsignedXdr, signOpts);
         const stellarClient = new StellarClient(this.getNetwork());
-        const result = await stellarClient.submitTransaction(signedTxXdr);
+        const result = await stellarClient.submitTransaction(signedXdr);
         if (result.success) {
-          this._setTransactionState({ step: 'success', ...stateExtra, hash: result.hash });
-        } else {
-          this._setTransactionState({ step: 'error', ...stateExtra, details: result.errorCode });
+          this._setTransactionState({ step: 'success', hash: result.hash, ...(buildData && { buildData }) });
+          return { status: 'success', hash: result.hash, ...outcomeExtra };
         }
-      } catch {
-        this._setTransactionState({ step: 'error', ...stateExtra });
+        this._setTransactionState({
+          step: 'error',
+          phase: 'submitting',
+          ...(buildData && { buildData }),
+          details: result.errorCode,
+        });
+        return {
+          status: 'error',
+          details: result.errorCode,
+          resultCode: result.errorCode,
+          ...outcomeExtra,
+        };
+      } catch (err) {
+        const details = err instanceof Error ? err.message : undefined;
+        this._setTransactionState({
+          step: 'error',
+          phase: 'submitting',
+          ...(buildData && { buildData }),
+          ...(details && { details }),
+        });
+        return { status: 'error', ...outcomeExtra, ...(details && { details }) };
       }
-      return;
     }
+
+    // Custodial path
+    const publicKey = this._session?.wallet?.publicKey ?? '';
+    try {
+      const { data, error } = await this._api.POST('/tx/submit', {
+        body: {
+          network: this.getNetwork(),
+          publicKey,
+          signedXdr,
+          ...(opts?.submissionToken && { idempotencyKey: opts.submissionToken }),
+        },
+      });
+      if (!error && data?.success && data.content) {
+        const { hash, status: backendStatus, resultCode } = data.content;
+        if (backendStatus === 'SUCCESS') {
+          this._setTransactionState({ step: 'success', hash, ...(buildData && { buildData }) });
+          return { status: 'success', hash, ...outcomeExtra };
+        }
+        if (backendStatus === 'PENDING') {
+          this._setTransactionState({ step: 'submitted', hash, ...(buildData && { buildData }) });
+          return { status: 'pending', hash, ...outcomeExtra };
+        }
+        this._setTransactionState({
+          step: 'error',
+          phase: 'submitting',
+          ...(buildData && { buildData }),
+          ...(resultCode && { details: resultCode }),
+        });
+        return {
+          status: 'error',
+          hash,
+          ...outcomeExtra,
+          ...(resultCode && { details: resultCode, resultCode }),
+        };
+      }
+      const details = (error as { details?: string } | undefined)?.details;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'submitting',
+        ...(buildData && { buildData }),
+        ...(details && { details }),
+      });
+      return { status: 'error', ...outcomeExtra, ...(details && { details }) };
+    } catch (err) {
+      const details = err instanceof Error ? err.message : undefined;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'submitting',
+        ...(buildData && { buildData }),
+        ...(details && { details }),
+      });
+      return { status: 'error', ...outcomeExtra, ...(details && { details }) };
+    }
+  }
+
+  /**
+   * Signs and submits in one logical step. Returns a {@link SubmitOutcome}.
+   *
+   * - **External wallets**: composes `signTx` + `submitTx` client-side. State
+   *   machine sees the full granular sequence `signing → signed → submitting
+   *   → success` because the underlying methods each emit.
+   * - **Custodial wallets**: atomic `/tx/sign-and-send` round-trip. State
+   *   machine emits the compound `signing-submitting` step (the SDK can't
+   *   observe when one phase ends and the next begins inside that single
+   *   backend call) and then transitions to `submitted` (Horizon ack only) or
+   *   `success` (ledger-confirmed), or `error[phase: 'signing-submitting']`.
+   */
+  async signAndSubmitTx(unsignedXdr: string): Promise<SubmitOutcome> {
+    if (this._walletAdapter) {
+      // External — the composed signTx+submitTx already emit the granular
+      // state-machine sequence. We just pass outcomes through.
+      const signed = await this.signTx(unsignedXdr);
+      if (signed.status === 'error') {
+        const buildData = this._currentBuildData();
+        return {
+          status: 'error',
+          ...(buildData && { buildData }),
+          ...(signed.details && { details: signed.details }),
+        };
+      }
+      return this.submitTx(signed.signedXdr);
+    }
+
+    // Custodial — atomic single backend call. Compound state.
+    const buildData = this._currentBuildData();
+    const outcomeExtra: { buildData?: TxBuildContent } = buildData ? { buildData } : {};
+
+    this._setTransactionState({ step: 'signing-submitting', ...(buildData && { buildData }) });
 
     const body: TxSignAndSendBody = {
       network: this.getNetwork(),
@@ -764,14 +981,141 @@ export class PollarClient {
     try {
       const { data, error } = await this._api.POST('/tx/sign-and-send', { body });
       if (!error && data?.success && data.content?.hash) {
-        this._setTransactionState({ step: 'success', ...stateExtra, hash: data.content.hash });
-      } else {
-        const details = (error as { details?: string } | undefined)?.details;
-        this._setTransactionState({ step: 'error', ...stateExtra, ...(details && { details }) });
+        const { hash, status: backendStatus, resultCode } = data.content as {
+          hash: string;
+          status: 'SUCCESS' | 'FAILED' | 'PENDING';
+          resultCode?: string;
+        };
+        if (backendStatus === 'SUCCESS') {
+          this._setTransactionState({ step: 'success', hash, ...(buildData && { buildData }) });
+          return { status: 'success', hash, ...outcomeExtra };
+        }
+        if (backendStatus === 'PENDING') {
+          this._setTransactionState({ step: 'submitted', hash, ...(buildData && { buildData }) });
+          return { status: 'pending', hash, ...outcomeExtra };
+        }
+        // backendStatus === 'FAILED'
+        this._setTransactionState({
+          step: 'error',
+          phase: 'signing-submitting',
+          ...(buildData && { buildData }),
+          ...(resultCode && { details: resultCode }),
+        });
+        return {
+          status: 'error',
+          hash,
+          ...outcomeExtra,
+          ...(resultCode && { details: resultCode, resultCode }),
+        };
       }
-    } catch {
-      this._setTransactionState({ step: 'error', ...stateExtra });
+      const details = (error as { details?: string } | undefined)?.details;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'signing-submitting',
+        ...(buildData && { buildData }),
+        ...(details && { details }),
+      });
+      return { status: 'error', ...outcomeExtra, ...(details && { details }) };
+    } catch (err) {
+      const details = err instanceof Error ? err.message : undefined;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'signing-submitting',
+        ...(buildData && { buildData }),
+        ...(details && { details }),
+      });
+      return { status: 'error', ...outcomeExtra, ...(details && { details }) };
     }
+  }
+
+  /**
+   * One-shot: build → sign → submit, returning the final {@link SubmitOutcome}.
+   *
+   * - **External wallets**: composes `buildTx` + `signAndSubmitTx` client-side.
+   *   State machine sees the full granular sequence (`building → built →
+   *   signing → signed → submitting → success`) because each composed call
+   *   emits its own transitions.
+   * - **Custodial wallets**: single round-trip to `/tx/build-sign-submit`. The
+   *   signed XDR never leaves the backend. State machine emits the compound
+   *   `building-signing-submitting` step (the SDK can't observe individual
+   *   phase boundaries inside one atomic call) and then transitions to
+   *   `submitted` / `success` / `error[phase: 'building-signing-submitting']`.
+   *
+   * If you need granular UI feedback for custodial flows (separate
+   * "Building…", "Signing…", "Submitting…" indicators), call `buildTx`,
+   * `signTx`, and `submitTx` separately instead.
+   */
+  async buildAndSignAndSubmitTx(
+    operation: TxBuildBody['operation'],
+    params: TxBuildBody['params'],
+    options?: TxBuildBody['options'],
+  ): Promise<SubmitOutcome> {
+    if (this._walletAdapter) {
+      const built = await this.buildTx(operation, params, options);
+      if (built.status === 'error') {
+        return { status: 'error', ...(built.details && { details: built.details }) };
+      }
+      return this.signAndSubmitTx(built.buildData.unsignedXdr);
+    }
+
+    // Custodial path — single backend call, compound state-machine step.
+    if (!this._session?.wallet?.publicKey) {
+      this._setTransactionState({ step: 'error', phase: 'building-signing-submitting', details: 'No wallet connected' });
+      return { status: 'error', details: 'No wallet connected' };
+    }
+    this._setTransactionState({ step: 'building-signing-submitting' });
+    try {
+      const { data, error } = await this._api.POST('/tx/build-sign-submit', {
+        body: {
+          network: this.getNetwork(),
+          publicKey: this._session.wallet.publicKey,
+          operation,
+          params,
+          options: options ?? {},
+        } as TxBuildBody & { idempotencyKey?: string },
+      });
+      if (!error && data?.success && data.content) {
+        const { hash, status: backendStatus, resultCode } = data.content;
+        if (backendStatus === 'SUCCESS') {
+          this._setTransactionState({ step: 'success', hash });
+          return { status: 'success', hash };
+        }
+        if (backendStatus === 'PENDING') {
+          this._setTransactionState({ step: 'submitted', hash });
+          return { status: 'pending', hash };
+        }
+        this._setTransactionState({
+          step: 'error',
+          phase: 'building-signing-submitting',
+          ...(resultCode && { details: resultCode }),
+        });
+        return { status: 'error', hash, ...(resultCode && { details: resultCode, resultCode }) };
+      }
+      const details = (error as { details?: string } | undefined)?.details;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'building-signing-submitting',
+        ...(details && { details }),
+      });
+      return { status: 'error', ...(details && { details }) };
+    } catch (err) {
+      const details = err instanceof Error ? err.message : undefined;
+      this._setTransactionState({
+        step: 'error',
+        phase: 'building-signing-submitting',
+        ...(details && { details }),
+      });
+      return { status: 'error', ...(details && { details }) };
+    }
+  }
+
+  /** Alias for {@link buildAndSignAndSubmitTx} — shorter "just do the thing" name. */
+  async runTx(
+    operation: TxBuildBody['operation'],
+    params: TxBuildBody['params'],
+    options?: TxBuildBody['options'],
+  ): Promise<SubmitOutcome> {
+    return this.buildAndSignAndSubmitTx(operation, params, options);
   }
 
   // ─── App config ───────────────────────────────────────────────────────────
@@ -999,5 +1343,18 @@ export class PollarClient {
     this._transactionState = next;
     console.info(`[PollarClient] transaction:${next.step}`);
     for (const cb of this._transactionStateListeners) cb(next);
+  }
+
+  /**
+   * Threads `buildData` through state transitions. When the user has already
+   * called `buildTx`, every subsequent state (signing, signed, submitting,
+   * submitted, success, error) should carry the build summary so modal UIs
+   * can keep showing "Send 5 USDC to G..." through the whole flow.
+   */
+  private _currentBuildData(): TxBuildContent | undefined {
+    const s = this._transactionState;
+    if (!s) return undefined;
+    if ('buildData' in s && s.buildData) return s.buildData;
+    return undefined;
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,6 +96,23 @@ export type TxSignAndSendBody = NonNullable<
 >['content']['application/json'];
 export type TxSignSendResponse = pollarPaths['/tx/sign-and-send']['post']['responses'][200]['content']['application/json'];
 
+// ─── Split flow (new in v0.7.2) ───────────────────────────────────────────────
+
+export type TxSignBody = NonNullable<pollarPaths['/tx/sign']['post']['requestBody']>['content']['application/json'];
+export type TxSignResponse = pollarPaths['/tx/sign']['post']['responses'][200]['content']['application/json'];
+export type TxSignContent = TxSignResponse['content'];
+
+export type TxSubmitSignedBody = NonNullable<
+  pollarPaths['/tx/submit']['post']['requestBody']
+>['content']['application/json'];
+
+export type TxBuildSignSubmitBody = NonNullable<
+  pollarPaths['/tx/build-sign-submit']['post']['requestBody']
+>['content']['application/json'];
+export type TxBuildSignSubmitResponse =
+  pollarPaths['/tx/build-sign-submit']['post']['responses'][200]['content']['application/json'];
+export type TxBuildSignSubmitContent = TxBuildSignSubmitResponse['content'];
+
 export type PollarLoginOptions =
   | { provider: 'google' }
   | { provider: 'github' }
@@ -104,13 +121,78 @@ export type PollarLoginOptions =
 
 export type TxBuildContent = TxBuildResponse['content'];
 
+/**
+ * Phases the SDK can be in across the build → sign → submit lifecycle.
+ *
+ * **Granular** steps (`building`, `signing`, `submitting`) are emitted when
+ * the SDK can directly observe that phase — i.e. when each is a separate
+ * client-driven call (`buildTx`, `signTx`, `submitTx`, external-wallet
+ * `signAndSubmitTx`).
+ *
+ * **Compound** steps (`signing-submitting`, `building-signing-submitting`)
+ * are emitted when multiple phases collapse into a single opaque backend
+ * round-trip (`signAndSubmitTx` custodial → `/tx/sign-and-send`, and `runTx`
+ * / `buildAndSignAndSubmitTx` custodial → `/tx/build-sign-submit`). The SDK
+ * can't see when one phase ends and the next begins inside that request, so
+ * it honestly reports a single fused state instead of fabricating
+ * transitions.
+ *
+ * **Terminal states** (`success`, `error`) and the post-Horizon-ack pending
+ * state (`submitted`) are shared across all paths.
+ *
+ * On `error`, the `phase` discriminator tells the consumer *where* the
+ * failure happened so modal UIs can offer "retry from this step" buttons.
+ */
 export type TransactionState =
   | { step: 'idle' }
+  // ─── Granular phases (observable per-call) ────────────────────────────
   | { step: 'building' }
   | { step: 'built'; buildData: TxBuildContent }
-  | { step: 'signing'; buildData?: TxBuildContent; external?: true }
-  | { step: 'success'; buildData?: TxBuildContent; hash: string; external?: true }
-  | { step: 'error'; details?: string; buildData?: TxBuildContent; external?: true };
+  | { step: 'signing'; buildData?: TxBuildContent }
+  | { step: 'signed'; buildData?: TxBuildContent; signedXdr: string; submissionToken?: string }
+  | { step: 'submitting'; buildData?: TxBuildContent; signedXdr?: string }
+  // ─── Compound phases (custodial-only — backend swallows the boundaries) ──
+  | { step: 'signing-submitting'; buildData?: TxBuildContent }
+  | { step: 'building-signing-submitting' }
+  // ─── Post-Horizon-ack, pre-ledger-confirm (shared) ────────────────────
+  | { step: 'submitted'; buildData?: TxBuildContent; hash: string }
+  // ─── Terminal success (shared) ────────────────────────────────────────
+  | { step: 'success'; buildData?: TxBuildContent; hash: string }
+  // ─── Terminal failure with phase context ──────────────────────────────
+  | { step: 'error'; phase: TxErrorPhase; details?: string; buildData?: TxBuildContent; signedXdr?: string };
+
+/**
+ * Identifies which phase failed when `TransactionState.step === 'error'`.
+ * Compound phase names (`signing-submitting`, `building-signing-submitting`)
+ * appear here when the failure happened inside an atomic backend call where
+ * the SDK can't isolate the failing sub-phase.
+ */
+export type TxErrorPhase =
+  | 'building'
+  | 'signing'
+  | 'submitting'
+  | 'signing-submitting'
+  | 'building-signing-submitting';
+
+/**
+ * Per-call outcomes returned by `buildTx`, `signTx`, `submitTx`,
+ * `signAndSubmitTx`, and `buildAndSignAndSubmitTx`. These are additive to
+ * `TransactionState` — the same operations still drive the state machine for
+ * modal-style UIs, but headless callers can `await` the method and inspect
+ * the returned outcome directly instead of subscribing to state changes.
+ */
+export type BuildOutcome =
+  | { status: 'built'; buildData: TxBuildContent }
+  | { status: 'error'; details?: string };
+
+export type SignOutcome =
+  | { status: 'signed'; signedXdr: string; submissionToken?: string; expiresAt?: number }
+  | { status: 'error'; details?: string };
+
+export type SubmitOutcome =
+  | { status: 'success'; hash: string; buildData?: TxBuildContent }
+  | { status: 'pending'; hash: string; buildData?: TxBuildContent }
+  | { status: 'error'; hash?: string; details?: string; resultCode?: string; buildData?: TxBuildContent };
 
 export const AUTH_ERROR_CODES = {
   SESSION_CREATE_FAILED: 'SESSION_CREATE_FAILED',

--- a/packages/privy-adapter/package.json
+++ b/packages/privy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/privy-adapter",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Stateless HTTP proxy that lets Pollar sign Stellar transactions through your Privy account, without your Privy app secret leaving your infrastructure.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "React components for Pollar authentication",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/components/send-modal/SendModal.tsx
+++ b/packages/react/src/components/send-modal/SendModal.tsx
@@ -55,12 +55,20 @@ export function SendModal({ onClose }: SendModalProps) {
         : 'public';
   const explorerUrl = hash ? `https://stellar.expert/explorer/${explorerNetwork}/tx/${hash}` : null;
 
-  const isInProgress = transaction.step === 'building' || transaction.step === 'signing';
+  const IN_FLIGHT_STEPS = [
+    'building',
+    'signing',
+    'submitting',
+    'submitted',
+    'signing-submitting',
+    'building-signing-submitting',
+  ] as const;
+  const isInProgress = (IN_FLIGHT_STEPS as readonly string[]).includes(transaction.step);
   const showBack =
     step === 'tx' && (transaction.step === 'error' || transaction.step === 'success') && !isInProgress;
 
   const txTitle =
-    transaction.step === 'signing'
+    isInProgress
       ? 'Sending…'
       : transaction.step === 'success'
         ? 'Sent!'

--- a/packages/react/src/components/transaction-modal/TxStatusView.tsx
+++ b/packages/react/src/components/transaction-modal/TxStatusView.tsx
@@ -8,10 +8,36 @@ const STATUS_MESSAGES: Record<TransactionState['step'], string> = {
   idle: '',
   building: 'Building transaction…',
   built: 'Ready to sign and send',
-  signing: 'Signing and sending transaction…',
+  signing: 'Signing transaction…',
+  signed: 'Signed — ready to submit',
+  submitting: 'Submitting transaction…',
+  submitted: 'Submitted — waiting for confirmation…',
+  'signing-submitting': 'Signing and submitting transaction…',
+  'building-signing-submitting': 'Processing transaction…',
   success: 'Transaction sent successfully',
   error: 'Transaction failed',
 };
+
+/** Step values that represent in-flight work (spinner / non-cancellable UI). */
+const IN_FLIGHT_STEPS = new Set<TransactionState['step']>([
+  'building',
+  'signing',
+  'submitting',
+  'submitted',
+  'signing-submitting',
+  'building-signing-submitting',
+]);
+
+/** Step values that should show the build summary (preview / details panel). */
+const SHOW_DETAILS_STEPS = new Set<TransactionState['step']>([
+  'built',
+  'signing',
+  'signed',
+  'submitting',
+  'submitted',
+  'signing-submitting',
+  'success',
+]);
 
 export interface TxStatusViewProps {
   transaction: TransactionState;
@@ -43,10 +69,10 @@ export function TxStatusView({
   const errorDetails = transaction.step === 'error' ? (transaction.details ?? null) : null;
 
   const isBuilt = transaction.step === 'built';
-  const isSigning = transaction.step === 'signing';
+  const isInFlight = IN_FLIGHT_STEPS.has(transaction.step);
   const isSuccess = transaction.step === 'success';
   const isError = transaction.step === 'error';
-  const showDetails = buildData !== null && (isBuilt || isSigning || isSuccess);
+  const showDetails = buildData !== null && SHOW_DETAILS_STEPS.has(transaction.step);
 
   const walletImg =
     walletType === WalletType.FREIGHTER
@@ -118,14 +144,14 @@ export function TxStatusView({
         </button>
       )}
 
-      {(isSigning || isSuccess || isError) && (
+      {(isInFlight || isSuccess || isError) && (
         <div className="pollar-tx-wallet-spinner">
           <div className="pollar-tx-spinner-ring">
             <svg
               viewBox="0 0 88 88"
               width="88"
               height="88"
-              className={`pollar-tx-spinner-svg${isSigning ? ' pollar-tx-spinner-rotating' : ''}`}
+              className={`pollar-tx-spinner-svg${isInFlight ? ' pollar-tx-spinner-rotating' : ''}`}
               aria-hidden
             >
               <circle cx="44" cy="44" r="36" fill="none" stroke="var(--pollar-border)" strokeWidth="3" />
@@ -139,9 +165,9 @@ export function TxStatusView({
                 }
                 strokeWidth="3"
                 strokeLinecap="round"
-                strokeDasharray={isSigning ? '169.6 56.6' : '999 0'}
+                strokeDasharray={isInFlight ? '169.6 56.6' : '999 0'}
                 transform="rotate(-90 44 44)"
-                style={{ transition: isSigning ? 'none' : 'stroke 400ms, stroke-dasharray 400ms' }}
+                style={{ transition: isInFlight ? 'none' : 'stroke 400ms, stroke-dasharray 400ms' }}
               />
             </svg>
             <div className="pollar-tx-wallet-icon">
@@ -149,7 +175,7 @@ export function TxStatusView({
             </div>
           </div>
 
-          {isSigning && (
+          {isInFlight && (
             <p className="pollar-tx-spinner-label">
               {walletType === WalletType.FREIGHTER
                 ? 'Waiting for Freighter…'
@@ -234,7 +260,7 @@ export function TxStatusView({
 
       <ModalStatusBanner
         message={STATUS_MESSAGES[transaction.step]}
-        status={isError ? 'ERROR' : isSigning || transaction.step === 'building' ? 'LOADING' : isSuccess ? 'SUCCESS' : 'NONE'}
+        status={isError ? 'ERROR' : isInFlight ? 'LOADING' : isSuccess ? 'SUCCESS' : 'NONE'}
       />
     </>
   );

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import {
+  BuildOutcome,
   NetworkState,
   PollarAdapters,
   PollarClient,
   PollarClientConfig,
   PollarLoginOptions,
   PollarPersistedSession,
+  SignOutcome,
   StellarNetwork,
+  SubmitOutcome,
   TransactionState,
   TxBuildBody,
   TxHistoryState,
@@ -59,8 +62,23 @@ interface PollarContextValue {
     operation: TxBuildBody['operation'],
     params: TxBuildBody['params'],
     options?: TxBuildBody['options'],
-  ) => Promise<void>;
-  signAndSubmitTx: (unsignedXdr: string) => Promise<void>;
+  ) => Promise<BuildOutcome>;
+  signAndSubmitTx: (unsignedXdr: string) => Promise<SubmitOutcome>;
+  /** External-wallet only. Custodial flows should use `signAndSubmitTx`. */
+  signTx: (unsignedXdr: string) => Promise<SignOutcome>;
+  submitTx: (signedXdr: string) => Promise<SubmitOutcome>;
+  /** One-shot: build → sign → submit. Drives the same TransactionState flow as the split calls. */
+  buildAndSignAndSubmitTx: (
+    operation: TxBuildBody['operation'],
+    params: TxBuildBody['params'],
+    options?: TxBuildBody['options'],
+  ) => Promise<SubmitOutcome>;
+  /** Alias of `buildAndSignAndSubmitTx`. */
+  runTx: (
+    operation: TxBuildBody['operation'],
+    params: TxBuildBody['params'],
+    options?: TxBuildBody['options'],
+  ) => Promise<SubmitOutcome>;
   walletType: WalletId | null;
   // network
   network: StellarNetwork;
@@ -199,6 +217,11 @@ export function PollarProvider({ config, styles: propStyles, adapters, children 
         tx: transaction,
         buildTx: (operation, params, options) => pollarClient.buildTx(operation, params, options),
         signAndSubmitTx: (unsignedXdr: string) => pollarClient.signAndSubmitTx(unsignedXdr),
+        signTx: (unsignedXdr: string) => pollarClient.signTx(unsignedXdr),
+        submitTx: (signedXdr: string) => pollarClient.submitTx(signedXdr),
+        buildAndSignAndSubmitTx: (operation, params, options) =>
+          pollarClient.buildAndSignAndSubmitTx(operation, params, options),
+        runTx: (operation, params, options) => pollarClient.runTx(operation, params, options),
         openTxModal: () => setTransactionModalOpen(true),
         // tx history
         txHistory,

--- a/packages/react/src/usePollarAdapter.ts
+++ b/packages/react/src/usePollarAdapter.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import type {  PollarAdapter } from '@pollar/core';
+import type { PollarAdapter, SubmitOutcome } from '@pollar/core';
 import { usePollar } from './context';
 
 type WrappedAdapter<T extends PollarAdapter> = {
-  [K in keyof T]: (params: Parameters<T[K]>[0]) => Promise<void>;
+  [K in keyof T]: (params: Parameters<T[K]>[0]) => Promise<SubmitOutcome>;
 };
 
 export function createPollarAdapterHook<T extends PollarAdapter>(key: string) {
@@ -21,7 +21,7 @@ export function createPollarAdapterHook<T extends PollarAdapter>(key: string) {
         name,
         async (params: Parameters<typeof fn>[0]) => {
           const { unsignedTransaction } = await fn(params);
-          await signAndSubmitTx(unsignedTransaction);
+          return signAndSubmitTx(unsignedTransaction);
         },
       ]),
     ) as WrappedAdapter<T>;

--- a/packages/stellar-wallets-kit-adapter/package.json
+++ b/packages/stellar-wallets-kit-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/stellar-wallets-kit-adapter",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Stellar Wallets Kit adapter for @pollar/core — plug additional wallet modules (xBull, Lobstr, WalletConnect, hardware wallets…) into Pollar without bundling them into @pollar/core.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- Adds per-call outcome returns to `buildTx` and `signAndSubmitTx` so headless
  callers can `await` results without subscribing to `onTransactionStateChange`.
  Return types: `Promise<void>` → `Promise<BuildOutcome>` / `Promise<SubmitOutcome>`.
- Adds split `signTx` / `submitTx` primitives for both external and custodial
  wallets. Custodial path goes through new sdk-api endpoints (`/tx/sign`,
  `/tx/submit`) with idempotency by `submissionToken`.
- Adds `buildAndSignAndSubmitTx` (alias `runTx`) — one method that picks the
  optimal path per wallet type. Custodial wallets use a single round-trip to
  `/tx/build-sign-submit` so signed XDR never leaves the backend.
- `TransactionState` vocabulary expanded from 6 → 11 step values: adds
  `signed`, `submitting`, `submitted`, `signing-submitting`,
  `building-signing-submitting`. `submitted` fixes the previously-elided
  "Horizon ack received, ledger confirmation pending" phase.
- `error` state now carries a required `phase: TxErrorPhase` discriminator
  so modals can offer "retry from this step".
- React: `usePollar()` exposes `signTx`, `submitTx`, `buildAndSignAndSubmitTx`,
  `runTx`. `WrappedAdapter<T>` methods now resolve to `Promise<SubmitOutcome>`.
- Built-in `TransactionModal` / `SendModal` handle every new state — no UI
  changes needed for consumers that use them as-is.
- Bumps `@pollar/core`, `@pollar/react`, `@pollar/privy-adapter`,
  `@pollar/stellar-wallets-kit-adapter` to `0.7.2`.

## Migration notes

- **No breaking runtime behavior for 0.5 / 0.6 / 0.7.1 consumers.** Existing
  `await client.signAndSubmitTx(xdr)` keeps working — only the resolved value
  changed (was `void`, is now `SubmitOutcome`).
- Explicit `Promise<void>` annotations on these methods will need to be
  dropped or retyped to `Promise<SubmitOutcome>`.
- Custom UIs with an exhaustive `switch (state.step)` will get a TS error
  until they handle the 5 new step values (or add a `default` branch).
- `state.external` was removed — branch on `'buildData' in state` instead.

## Test plan

- [x] `pnpm -r build` succeeds across all packages
- [x] External wallet flow: `buildTx` → `signTx` → `submitTx` emits
      `building → signed → submitting → submitted → success`
- [x] Custodial wallet flow: `runTx` emits `building-signing-submitting → success`
- [x] Custodial `signAndSubmitTx` emits `signing-submitting → success`
- [x] `error` state carries correct `phase` for failures in build / sign /
      submit phases
- [x] `TransactionModal` and `SendModal` render every new step without
      regressions on the legacy steps
- [x] `signTx` / `submitTx` idempotency: replaying the same `submissionToken`
      against `/tx/submit` returns the prior outcome instead of re-broadcasting