### PR TITLE
Release 0.8.0 — provider reshape, wallet picker slot, tx routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## 0.8.0
 
-> **⚠️ BREAKING CHANGE.** `<PollarProvider>` props are reshaped: `config` is now
-> `client` (and accepts either a `PollarClient` instance or a `PollarClientConfig`),
-> `styles` moves under `appConfig.styles`, and the remote `/applications/config`
-> fetch is now opt-out by passing `appConfig` (even `{}`). New `ui.renderWallets`
-> slot lets external picker components replace the default Freighter/Albedo list.
+> **⚠️ BREAKING CHANGES.**
+>
+> - `<PollarProvider>` props are reshaped: `config` is now `client` (and accepts
+>   either a `PollarClient` instance or a `PollarClientConfig`), `styles` moves
+>   under `appConfig.styles`, and the remote `/applications/config` fetch is now
+>   opt-out by passing `appConfig` (even `{}`). New `ui.renderWallets` slot lets
+>   external picker components replace the default Freighter/Albedo list.
+> - `@pollar/stellar-wallets-kit-adapter` now **requires** `network` — the
+>   `Networks.TESTNET` default is gone. Per-call `networkPassphrase` overrides
+>   are rejected if they don't match init.
+> - `@pollar/core` external-wallet `submitTx` no longer hits Horizon directly —
+>   all submissions route through `/tx/submit`. The same call may now resolve to
+>   `pending` instead of `success` / `error` (previously synchronous-only).
 
 ### `@pollar/react` — BREAKING
 
@@ -56,6 +64,27 @@ const client = new PollarClient({ apiKey, walletAdapter });
 <PollarProvider client={client} appConfig={{ styles: { theme: 'dark' } }}>
 ```
 
+### `@pollar/react` — fixes
+
+- **Provider props are read directly in the context value** instead of via a
+  stale ref — `<PollarProvider>` now updates without remounting when callers
+  swap `adapters` / `ui` references between renders.
+- **Timers cleared on unmount** in `<PollarProvider>` and the session change
+  effect uses explicit equality so identical sessions don't trigger spurious
+  re-renders.
+
+### `@pollar/stellar-wallets-kit-adapter` — BREAKING
+
+- **`network` is now required** on `StellarWalletsKitAdapterOptions` (and on
+  `createStellarWalletsKitBundle`). The previous `Networks.TESTNET` default is
+  gone — `ensureInit` throws if `network` is missing on first init. The kit is
+  a global singleton so picking the network silently would risk signing
+  real-looking transactions on the wrong chain. Pass `Networks.TESTNET` or
+  `Networks.PUBLIC` explicitly.
+- **Per-call `networkPassphrase` overrides are rejected** when they don't match
+  the init network. `signTransaction()` / `signAuthEntry()` throw instead of
+  silently signing on the wrong chain.
+
 ### `@pollar/stellar-wallets-kit-adapter` — new features
 
 - **`<KitWalletPicker>` and `createStellarWalletsKitBundle`** on the new
@@ -90,6 +119,12 @@ const client = new PollarClient({ apiKey, walletAdapter });
   flag the kit already populates from each module's `isAvailable()` probe).
   No second-pass probing per render.
 
+### `@pollar/stellar-wallets-kit-adapter` — fixes
+
+- **Second-init network mismatch is now flagged.** Calling
+  `stellarWalletsKit({ network })` a second time with a different network logs
+  a clear warning instead of silently keeping the first init's network.
+
 ### `@pollar/stellar-wallets-kit-adapter` — packaging
 
 - React is now an **optional peer dependency**. The root export
@@ -97,7 +132,66 @@ const client = new PollarClient({ apiKey, walletAdapter });
   `WalletAdapterResolver` continue to work without installing React.
   Only the `/picker` subpath pulls in `react` / `react-dom` / `@pollar/react`.
 - Bumped to `0.8.0`. Existing `stellarWalletsKit({ network })`-only consumers
-  do not need to change anything.
+  do not need to change anything beyond making the `network` argument
+  explicit if they were relying on the testnet default.
+
+### `@pollar/core` — BREAKING (behavior)
+
+- **`submitTx` always routes through `/tx/submit`.** External wallets no longer
+  submit directly to the public RPC; both custodial and external paths now go
+  through sdk-api. Wins:
+  - end-to-end `tx_records` persistence with full phase lifecycle so the
+    developer dashboard can show every tx at
+    `/apps/:id/monitor/transactions`,
+  - idempotency tracking via `submissionToken` (returned by `signTx`),
+  - one response shape (`SUCCESS` / `PENDING` / `FAILED`) shared by both
+    flows. External-wallet callers may now observe `pending` where they
+    previously only ever got `success` or `error`.
+
+  Cost: ~50–150 ms extra latency vs. the legacy direct-Horizon path.
+
+### `@pollar/core` — new features
+
+- **Proactive token refresh with a visibility-aware scheduler.** Tokens are
+  refreshed before they expire instead of on the first 401. The scheduler
+  pauses when the tab is hidden and resumes when it becomes visible again, so
+  background tabs don't churn refreshes.
+- **`onStorageDegrade` subscription** — opt-in telemetry hook on
+  `PollarClientConfig` (mirrored on `<PollarProvider>` config). Fires when the
+  client falls back from secure storage (e.g. IndexedDB → in-memory) so apps
+  can surface the degradation to users / dashboards.
+- **Wallet adapter resolver timeout.** `PollarClient` now times out
+  `walletAdapter(id)` resolutions so a stuck resolver can't hang the login
+  flow indefinitely. The timeout produces a regular auth error that flows
+  through the existing error surface.
+
+### `@pollar/core` — fixes
+
+- **Only idempotent methods retry after a post-refresh 401.** The auto-retry
+  path previously re-ran any method that returned 401 after a token refresh;
+  it now restricts retries to idempotent verbs (`GET`, `HEAD`, `OPTIONS`,
+  `PUT`, `DELETE`) so POST/PATCH calls aren't accidentally double-applied
+  server-side.
+- **Login abort signal threaded through the wallet resolver.** Cancelling a
+  login now also cancels the wallet adapter resolution, instead of leaving
+  the resolver running until completion.
+
+### `@pollar/privy-adapter` — fixes
+
+- **Self-heal wallet cache on stale entries.** If a cached wallet id no longer
+  exists at Privy, the adapter clears the entry and recreates it on the next
+  sign instead of repeatedly hitting Privy with a 404.
+- **Per-`userId` mutex on `POST /wallets/create`.** Concurrent wallet-creation
+  requests for the same user are serialised so the burst doesn't create
+  duplicate wallets at Privy.
+- **`PrivyClient` construction is coalesced.** Multiple concurrent first calls
+  share one client init instead of racing N parallel constructions.
+- **Raw error messages dropped from HTTP responses.** Errors from Privy and
+  internal stack traces are replaced with a generic message; the full error
+  still goes to the server logs. Package marked `"private": false` but
+  **server-side only** — importing in a browser bundle leaks credentials.
+- **`@privy-io/node` pinned to `~0.18.0`** to avoid surprise 0.19+ behaviour
+  changes mid-release.
 
 ## 0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## 0.8.0
+
+> **⚠️ BREAKING CHANGE.** `<PollarProvider>` props are reshaped: `config` is now
+> `client` (and accepts either a `PollarClient` instance or a `PollarClientConfig`),
+> `styles` moves under `appConfig.styles`, and the remote `/applications/config`
+> fetch is now opt-out by passing `appConfig` (even `{}`). New `ui.renderWallets`
+> slot lets external picker components replace the default Freighter/Albedo list.
+
+### `@pollar/react` — BREAKING
+
+- **`<PollarProvider>` shape**:
+  - `config: PollarClientConfig` → `client: PollarClient | PollarClientConfig`. Pass
+    the config inline (provider constructs the client) or a pre-built `PollarClient`
+    (testing, reusing the client outside React). The client is locked at first render.
+  - `styles?: PollarStyles` → moved under `appConfig.styles`.
+  - New `appConfig?: PollarConfig`. Presence is the opt-out switch for the remote
+    `/applications/config` fetch: if you pass it (even `{}`), no fetch happens and
+    missing fields fall back to the defaults baked into `LoginModalTemplate`. If you
+    don't pass it, the SDK fetches `/applications/config` on mount (current behavior).
+  - New `ui?: { renderWallets?: RenderWalletsSlot }`.
+- **Fetch errors are no longer silenced**. Failures of `getAppConfig()` now log via
+  `console.error('[PollarProvider] getAppConfig failed', err)` instead of swallowing.
+- **Three-level styles merge removed**. The previous
+  `{ ...fetched.styles, ...propStyles, providers: { ...remote, ...local } }` merge is
+  gone. Either pass `appConfig` (no remote) or don't (full remote). No silent overlay.
+
+### `@pollar/react` — new features
+
+- **`renderWallets` slot.** New `ui.renderWallets?: RenderWalletsSlot` prop on
+  `<PollarProvider>`. When provided, replaces the hardcoded Freighter+Albedo buttons
+  in the LoginModal wallet picker. The slot receives `{ onConnect, authState }` and
+  is expected to render a list of wallet buttons that call `onConnect(walletId)` on
+  click. Default behavior is unchanged when the slot is not provided.
+- New public types `RenderWalletsProps`, `RenderWalletsSlot` exported from the
+  package root.
+
+### Migration
+
+```tsx
+// BEFORE (0.7.x)
+<PollarProvider config={{ apiKey, walletAdapter }} styles={{ theme: 'dark' }}>
+
+// AFTER (0.8.0) — common case (no remote-config fetch)
+<PollarProvider
+  client={{ apiKey, walletAdapter }}
+  appConfig={{ styles: { theme: 'dark' } }}
+>
+
+// AFTER (0.8.0) — keep the remote /applications/config fetch
+<PollarProvider client={{ apiKey, walletAdapter }}>
+
+// AFTER (0.8.0) — power user, pre-built client
+const client = new PollarClient({ apiKey, walletAdapter });
+<PollarProvider client={client} appConfig={{ styles: { theme: 'dark' } }}>
+```
+
+### `@pollar/stellar-wallets-kit-adapter` — new features
+
+- **`<KitWalletPicker>` and `createStellarWalletsKitBundle`** on the new
+  `@pollar/stellar-wallets-kit-adapter/picker` subpath. Drop the bundle into
+  `<PollarProvider>`'s new `renderWallets` slot to render the full Stellar
+  Wallets Kit wallet list (Albedo, Bitget, CactusLink, Fordefi, Freighter,
+  Hana, HotWallet, Klever, Lobstr, OneKey, Rabet, xBull, plus any custom
+  modules):
+
+  ```tsx
+  import { createStellarWalletsKitBundle } from '@pollar/stellar-wallets-kit-adapter/picker';
+  import { Networks } from '@creit.tech/stellar-wallets-kit';
+
+  const bundle = createStellarWalletsKitBundle({
+    network: Networks.PUBLIC,
+    picker: { wallets: ['xbull', 'lobstr', 'freighter'] },
+  });
+
+  <PollarProvider
+    client={{ apiKey: '…', walletAdapter: bundle.walletAdapter }}
+    ui={{ renderWallets: bundle.renderWallets }}
+  >
+  ```
+
+- **New `picker?: KitPickerOptions`** on `StellarWalletsKitAdapterOptions`:
+  `wallets` (subset to show), `order` (`'as-given' | 'installed-first' | 'alphabetical'`),
+  `showInstalledOnly`, `labels` (per-id overrides), `layout` (`'grid' | 'list'`),
+  `theme` (`{ accent?, mode? }`). The resolver itself ignores `picker` — only
+  `<KitWalletPicker>` reads it.
+
+- **Wallet availability uses `ISupportedWallet.isAvailable` directly** (the
+  flag the kit already populates from each module's `isAvailable()` probe).
+  No second-pass probing per render.
+
+### `@pollar/stellar-wallets-kit-adapter` — packaging
+
+- React is now an **optional peer dependency**. The root export
+  (`stellarWalletsKit`) stays headless — consumers that only need the
+  `WalletAdapterResolver` continue to work without installing React.
+  Only the `/picker` subpath pulls in `react` / `react-dom` / `@pollar/react`.
+- Bumped to `0.8.0`. Existing `stellarWalletsKit({ network })`-only consumers
+  do not need to change anything.
+
 ## 0.7.2
 
 Adds a per-call outcome API so headless callers can `await` a transaction and

--- a/README.md
+++ b/README.md
@@ -181,42 +181,42 @@ npm install @pollar/stellar-wallets-kit-adapter @creit.tech/stellar-wallets-kit
 
 ## Development
 
-This monorepo uses [Turborepo](https://turbo.build/repo) for task orchestration and [pnpm](https://pnpm.io) as the
-package manager.
+This monorepo uses [Turborepo](https://turbo.build/repo) for task orchestration and [npm](https://docs.npmjs.com/cli/v10)
+workspaces as the package manager (pinned via `packageManager` in the root `package.json`).
 
 ### Prerequisites
 
 - Node.js >= 20 (matches the `engines` floor declared by every published package)
-- pnpm >= 9
+- npm >= 10
 
 ### Install dependencies
 
 ```bash
-pnpm install
+npm install
 ```
 
 ### Build all packages
 
 ```bash
-pnpm build
+npm run build
 ```
 
 ### Build in watch mode
 
 ```bash
-pnpm dev
+npm run dev
 ```
 
 ### Type-check all packages
 
 ```bash
-pnpm lint
+npm run lint
 ```
 
 ### Clean build artifacts
 
 ```bash
-pnpm clean
+npm run clean
 ```
 
 ---

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,135 @@
+# Upgrade guide
+
+## 0.7.x → 0.8.0
+
+`<PollarProvider>` is reshaped to make the wallet picker pluggable and to give
+the consumer explicit control over the remote `/applications/config` fetch.
+All changes are mechanical renames; nothing in `@pollar/core` moves.
+
+### Required changes
+
+#### 1. `config` → `client`
+
+The provider's first prop is renamed from `config` to `client`. It now accepts
+**either a `PollarClientConfig` (the current shape) or a pre-built
+`PollarClient` instance**. The provider constructs the client at first render
+in both cases.
+
+```tsx
+// BEFORE
+<PollarProvider config={{ apiKey: '…', walletAdapter }}>
+
+// AFTER (no behavior change beyond the rename)
+<PollarProvider client={{ apiKey: '…', walletAdapter }}>
+```
+
+The pre-built form is useful if you want to keep a reference to the client
+outside React (tests, server actions, jobs):
+
+```tsx
+const client = new PollarClient({ apiKey: '…', walletAdapter });
+<PollarProvider client={client}>
+```
+
+> **Note**: the client is locked at first render. Changing the prop afterwards
+> is ignored. To swap clients, unmount and remount the provider. This already
+> matched the 0.7.x behavior — it's just now explicit.
+
+#### 2. `styles` → `appConfig.styles`
+
+The top-level `styles` prop moves under a new `appConfig` block whose shape
+mirrors what `/applications/config` returns.
+
+```tsx
+// BEFORE
+<PollarProvider config={{…}} styles={{ theme: 'dark' }}>
+
+// AFTER
+<PollarProvider client={{…}} appConfig={{ styles: { theme: 'dark' } }}>
+```
+
+#### 3. The remote-config fetch is now opt-out
+
+If you pass `appConfig` (even as `{}`), the provider **skips** the `GET
+/applications/config` call entirely. Missing fields fall back to the defaults
+already baked into `LoginModalTemplate` (light theme, Pollar logo, no social
+providers, etc.).
+
+If you **don't** pass `appConfig`, the SDK fetches `/applications/config` on
+mount exactly like 0.7.x did. The previous 3-level styles merge
+(`remote.styles + propStyles + providers merge`) is removed: you now either get
+the remote config or your local one, not a hybrid.
+
+```tsx
+// Force defaults, no network call:
+<PollarProvider client={{…}} appConfig={{}}>
+
+// Keep the existing remote-config behavior:
+<PollarProvider client={{…}}>
+
+// Local override of styles, no network call:
+<PollarProvider client={{…}} appConfig={{ styles: { theme: 'dark' } }}>
+```
+
+#### 4. Remote-config errors now log to `console.error`
+
+Previously, a failed `/applications/config` fetch was silently swallowed. It
+now logs via `console.error('[PollarProvider] getAppConfig failed', err)`,
+matching how the rest of `@pollar/core` reports unexpected failures.
+
+### New: `renderWallets` slot
+
+`<PollarProvider>` accepts a new optional `ui.renderWallets` slot that
+replaces the hardcoded Freighter+Albedo list inside the LoginModal wallet
+picker. If you don't pass it, the default Freighter+Albedo list is shown
+exactly as before.
+
+```tsx
+import type { RenderWalletsSlot } from '@pollar/react';
+
+const renderWallets: RenderWalletsSlot = ({ onConnect, authState }) => (
+  <MyCustomWalletGrid onPick={onConnect} disabled={authState.step !== 'idle'} />
+);
+
+<PollarProvider client={{…}} ui={{ renderWallets }}>
+```
+
+For the common case of "drop in the Stellar Wallets Kit picker", the new
+`@pollar/stellar-wallets-kit-adapter/picker` subpath ships a ready-made
+bundle:
+
+```tsx
+import { createStellarWalletsKitBundle } from '@pollar/stellar-wallets-kit-adapter/picker';
+import { Networks } from '@creit.tech/stellar-wallets-kit';
+
+const bundle = createStellarWalletsKitBundle({
+  network: Networks.PUBLIC,
+  picker: { wallets: ['xbull', 'lobstr', 'freighter'] },
+});
+
+<PollarProvider
+  client={{ apiKey: '…', walletAdapter: bundle.walletAdapter }}
+  ui={{ renderWallets: bundle.renderWallets }}
+>
+```
+
+### `@pollar/stellar-wallets-kit-adapter` — no required changes
+
+If you already consume `stellarWalletsKit({ network })` for `walletAdapter`,
+nothing changes. The root export stays the same callable
+`WalletAdapterResolver`. React only enters the picture if you import from
+`@pollar/stellar-wallets-kit-adapter/picker`, and is declared as an optional
+peer dependency — headless consumers don't pull it in.
+
+### Why the breaking change
+
+- The previous `config: PollarClientConfig` prop leaked SDK plumbing
+  (`storage`, `keyManager`, …) into the React API. `client` is a cleaner
+  contract that also lets you reuse the constructed client outside React.
+- The previous 3-way style merge was implicit and hard to reason about
+  (props sometimes won, sometimes the remote did). The new "presence =
+  opt-out" rule is one line and predictable.
+- The wallet picker was hardcoded to Freighter+Albedo, which forced
+  `@pollar/react` to bundle wallet-specific logos and labels. The
+  `renderWallets` slot decouples the modal from any particular wallet
+  ecosystem.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11232,7 +11232,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11457,7 +11457,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12381,7 +12381,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -12392,7 +12392,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -12670,7 +12670,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -14128,7 +14128,7 @@
     },
     "packages/core": {
       "name": "@pollar/core",
-      "version": "0.6.2",
+      "version": "0.7.2",
       "dependencies": {
         "@noble/curves": "~1.9.7",
         "@stellar/freighter-api": "^2.0.0",
@@ -14156,7 +14156,7 @@
     },
     "packages/privy-adapter": {
       "name": "@pollar/privy-adapter",
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "@privy-io/node": "^0.18.0",
@@ -14392,7 +14392,7 @@
     },
     "packages/react": {
       "name": "@pollar/react",
-      "version": "0.6.2",
+      "version": "0.8.0",
       "dependencies": {
         "@pollar/core": "*",
         "qr.js": "^0.0.0"
@@ -14644,14 +14644,17 @@
     },
     "packages/stellar-wallets-kit-adapter": {
       "name": "@pollar/stellar-wallets-kit-adapter",
-      "version": "0.6.3",
+      "version": "0.8.0",
       "dependencies": {
         "@pollar/core": "*"
       },
       "devDependencies": {
         "@creit.tech/stellar-wallets-kit": "^2.2.0",
         "@eslint/js": "^9.39.4",
+        "@pollar/react": "*",
+        "@types/react": "^18.0.0",
         "eslint": "^9.39.4",
+        "react": "^18.0.0",
         "tsup": "^8.3.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.58.1"
@@ -14661,7 +14664,21 @@
       },
       "peerDependencies": {
         "@creit.tech/stellar-wallets-kit": "^2.0.0",
-        "@pollar/core": "*"
+        "@pollar/core": "*",
+        "@pollar/react": "^0.8.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pollar/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "packages/stellar-wallets-kit-adapter/node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polar-auth-monorepo",
-  "version": "0.6.2",
+  "version": "0.8.0",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "packageManager": "npm@10.9.4"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "turbo dev",
     "lint": "turbo lint",
     "clean": "turbo clean",
-    "dev:push": "npm run build && cd packages/core && yalc publish && cd ../../packages/react && yalc publish && cd ../../packages/privy-adapter && yalc publish && cd ../../packages/stellar-wallets-kit-adapter && yalc publish",
+    "dev:push": "npm run build && for pkg in core react privy-adapter stellar-wallets-kit-adapter; do (cd packages/$pkg && yalc publish) || exit 1; done",
     "core:publish": "cd packages/core && npm publish --access public",
     "privy-adapter:publish": "cd packages/privy-adapter && npm publish --access public",
     "react:publish": "cd packages/react && npm publish --access public",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,10 +2,17 @@
 
 Core SDK for [Pollar](https://pollar.xyz) — authentication and transaction utilities for Stellar-based applications.
 
-> **0.7.0 ships sender-constrained tokens via DPoP (RFC 9449), pluggable storage and key managers, automatic
-> refresh-on-401, and removes PII from persisted storage.** This is a breaking change — read
-> the [CHANGELOG](../../CHANGELOG.md) before upgrading. Requires HTTPS and
-> `sdk-api` ≥ Phase 5.
+> **0.8.0** routes every `submitTx` (custodial **and** external wallets) through
+> `/tx/submit` so the dashboard sees every transaction and idempotency is
+> tracked end-to-end. Adds proactive token refresh with a visibility-aware
+> scheduler, an `onStorageDegrade` telemetry hook, and a timeout around the
+> wallet adapter resolver. External-wallet callers may now observe `pending`
+> outcomes where they only ever got `success` / `error` before. Read the
+> [CHANGELOG](../../CHANGELOG.md) before upgrading.
+>
+> **0.7.0** ships sender-constrained tokens via DPoP (RFC 9449), pluggable
+> storage and key managers, automatic refresh-on-401, and removes PII from
+> persisted storage. Requires HTTPS and `sdk-api` ≥ Phase 5.
 
 ## Installation
 

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      // `_`-prefix marks intentionally-unused params/vars (e.g. interface-shape
+      // params kept for adapter contracts even when this implementation ignores
+      // them).
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      // `any` shows up in openapi-fetch glue + a few hand-written endpoint
+      // wrappers. Treat as a smell but not a build failure — tighten once
+      // those callsites move to proper generics.
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    ignores: ['dist/**', 'src/api/schema.d.ts'],
+  },
+);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/core",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Core authentication functions for Pollar services",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,15 +60,18 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && eslint src",
     "clean": "rm -rf dist"
   },
   "engines": {
     "node": ">=20"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "eslint": "^9.39.4",
     "tsup": "^8.3.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.58.1"
   },
   "dependencies": {
     "@noble/curves": "~1.9.7",

--- a/packages/core/src/adapters/expo-secure-store.ts
+++ b/packages/core/src/adapters/expo-secure-store.ts
@@ -48,7 +48,7 @@ export interface SecureStoreAdapterOptions {
 
 async function loadSecureStore(): Promise<SecureStoreApi> {
   try {
-    // @ts-ignore -- optional peer dep; not present when the SDK is built or
+    // @ts-expect-error -- optional peer dep; not present when the SDK is built or
     // when the SDK runs on web. Resolved at runtime in Expo / RN apps.
     const mod = await import('expo-secure-store');
     return mod as unknown as SecureStoreApi;

--- a/packages/core/src/adapters/react-native-keychain.ts
+++ b/packages/core/src/adapters/react-native-keychain.ts
@@ -58,7 +58,7 @@ export interface KeychainAdapterOptions {
 
 async function loadKeychain(): Promise<KeychainApi> {
   try {
-    // @ts-ignore -- optional peer dep; not present when the SDK is built or
+    // @ts-expect-error -- optional peer dep; not present when the SDK is built or
     // when the SDK runs on web. Resolved at runtime in React Native apps.
     const mod = await import('react-native-keychain');
     return mod as unknown as KeychainApi;

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -4,3722 +4,3692 @@
  */
 
 export interface paths {
-  '/health': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health check */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Health check */
-    get: operations['getHealth'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/session': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a client session
+         * @description Creates a pending client session that will be linked to a user after authentication.
+         */
+        post: operations["postAuthSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create a client session
-     * @description Creates a pending client session that will be linked to a user after authentication.
-     */
-    post: operations['postAuthSession'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/session/status/{clientSessionId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/session/status/{clientSessionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream client session status
+         * @description Server-Sent Events stream that emits session state every 500 ms. Closes when the session is consumed or expires.
+         */
+        get: operations["getAuthSessionStatusByClientSessionId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Stream client session status
-     * @description Server-Sent Events stream that emits session state every 500 ms. Closes when the session is consumed or expires.
-     */
-    get: operations['getAuthSessionStatusByClientSessionId'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/google': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/google": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Redirect to Google OAuth
+         * @description Redirects the user to the Google OAuth consent screen.
+         */
+        get: operations["getAuthGoogle"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Redirect to Google OAuth
-     * @description Redirects the user to the Google OAuth consent screen.
-     */
-    get: operations['getAuthGoogle'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/github': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/github": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Redirect to GitHub OAuth
+         * @description Redirects the user to the GitHub OAuth consent screen.
+         */
+        get: operations["getAuthGithub"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Redirect to GitHub OAuth
-     * @description Redirects the user to the GitHub OAuth consent screen.
-     */
-    get: operations['getAuthGithub'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/oidc': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/oidc": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Redirect to Authentik OIDC
+         * @description Redirects the user to the Authentik authorization endpoint (PKCE, per-app).
+         */
+        get: operations["getAuthOidc"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Redirect to Authentik OIDC
-     * @description Redirects the user to the Authentik authorization endpoint (PKCE, per-app).
-     */
-    get: operations['getAuthOidc'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/email': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send email verification code */
+        post: operations["postAuthEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Send email verification code */
-    post: operations['postAuthEmail'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/email/verify-code': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/email/verify-code": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Verify email code */
+        post: operations["postAuthEmailVerifyCode"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Verify email code */
-    post: operations['postAuthEmailVerifyCode'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/wallet': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/wallet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Authenticate with a Stellar wallet */
+        post: operations["postAuthWallet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Authenticate with a Stellar wallet */
-    post: operations['postAuthWallet'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/login': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Exchange a ready client session for tokens
+         * @description Finalizes authentication. The session must be in ready state.
+         */
+        post: operations["postAuthLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Exchange a ready client session for tokens
-     * @description Finalizes authentication. The session must be in ready state.
-     */
-    post: operations['postAuthLogin'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/refresh': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rotate a DPoP-bound refresh token
+         * @description Single-use rotation per RFC 9449 §5. Requires a DPoP proof (no `ath`) bound to the same key as the refresh token (`cnf.jkt`). On reuse outside the 30s grace window, the entire token family is revoked.
+         */
+        post: operations["postAuthRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Rotate a DPoP-bound refresh token
-     * @description Single-use rotation per RFC 9449 §5. Requires a DPoP proof (no `ath`) bound to the same key as the refresh token (`cnf.jkt`). On reuse outside the 30s grace window, the entire token family is revoked.
-     */
-    post: operations['postAuthRefresh'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/logout': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke the current session (or all sessions)
+         * @description Server-side logout. Default behavior revokes the refresh-token family bound to the current access token. Pass `{"everywhere":true}` to revoke every active family for the authenticated user (logout from all devices).
+         */
+        post: operations["postAuthLogout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Revoke the current session (or all sessions)
-     * @description Server-side logout. Default behavior revokes the refresh-token family bound to the current access token. Pass `{"everywhere":true}` to revoke every active family for the authenticated user (logout from all devices).
-     */
-    post: operations['postAuthLogout'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/sessions': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List active sessions for the authenticated user
+         * @description Returns one row per active refresh-token family with the metadata captured at issuance (user agent, hashed IP, optional device label). The session whose `current: true` flag matches the access token in use can be highlighted in the UI.
+         */
+        get: operations["getAuthSessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List active sessions for the authenticated user
-     * @description Returns one row per active refresh-token family with the metadata captured at issuance (user agent, hashed IP, optional device label). The session whose `current: true` flag matches the access token in use can be highlighted in the UI.
-     */
-    get: operations['getAuthSessions'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/sessions/{familyId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/sessions/{familyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke a specific session (refresh-token family) */
+        delete: operations["deleteAuthSessionsByFamilyId"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Revoke a specific session (refresh-token family) */
-    delete: operations['deleteAuthSessionsByFamilyId'];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/applications/config': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/applications/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get application config
+         * @description Returns the public configuration and branding for the application.
+         */
+        get: operations["getApplicationsConfig"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get application config
-     * @description Returns the public configuration and branding for the application.
-     */
-    get: operations['getApplicationsConfig'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/applications/{id}/logo': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/applications/{id}/logo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get application logo
+         * @description Returns the application logo as a binary image.
+         */
+        get: operations["getApplicationsByIdLogo"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get application logo
-     * @description Returns the application logo as a binary image.
-     */
-    get: operations['getApplicationsByIdLogo'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/build': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/build": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Build unsigned payment transaction
+         * @description Builds an unsigned XDR for a native XLM payment. Client must sign and submit via POST /tx/submit.
+         */
+        post: operations["postTxBuild"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Build unsigned payment transaction
-     * @description Builds an unsigned XDR for a native XLM payment. Client must sign and submit via POST /tx/submit.
-     */
-    post: operations['postTxBuild'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/sign-and-send': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/sign-and-send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sign and submit transaction
+         * @description Sends an unsigned XDR to the wallet service for signing, then submits the signed transaction to the Stellar network.
+         */
+        post: operations["postTxSignAndSend"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Sign and submit transaction
-     * @description Sends an unsigned XDR to the wallet service for signing, then submits the signed transaction to the Stellar network.
-     */
-    post: operations['postTxSignAndSend'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/sign': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sign an unsigned XDR (split flow)
+         * @description Sign-only step of the split build/sign/submit flow. For custodial wallets, the signed XDR is returned to the caller so it can be submitted later via POST /tx/submit. External wallets sign client-side and do not call this endpoint.
+         */
+        post: operations["postTxSign"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Sign an unsigned XDR (split flow)
-     * @description Sign-only step of the split build/sign/submit flow. For custodial wallets, the signed XDR is returned to the caller so it can be submitted later via POST /tx/submit. External wallets sign client-side and do not call this endpoint.
-     */
-    post: operations['postTxSign'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/submit': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit a pre-signed XDR
+         * @description Submit step of the split build/sign/submit flow. Accepts a signed XDR produced by /tx/sign or by an external-wallet adapter. Goes through wallet-service /v1/tx/submit so the submission is policy-validated and idempotency-tracked.
+         */
+        post: operations["postTxSubmit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Submit a pre-signed XDR
-     * @description Submit step of the split build/sign/submit flow. Accepts a signed XDR produced by /tx/sign or by an external-wallet adapter. Goes through wallet-service /v1/tx/submit so the submission is policy-validated and idempotency-tracked.
-     */
-    post: operations['postTxSubmit'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/build-sign-submit': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/build-sign-submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Atomic build + sign + submit (one round-trip)
+         * @description Server-side composition of /tx/build + /tx/sign + /tx/submit. The signed XDR never leaves the backend. Use for headless / server-driven flows that do not need intermediate state-machine transitions on the client.
+         */
+        post: operations["postTxBuildSignSubmit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Atomic build + sign + submit (one round-trip)
-     * @description Server-side composition of /tx/build + /tx/sign + /tx/submit. The signed XDR never leaves the backend. Use for headless / server-driven flows that do not need intermediate state-machine transitions on the client.
-     */
-    post: operations['postTxBuildSignSubmit'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/status': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get transaction status
+         * @description Returns transaction status by hash. PENDING = not yet confirmed in Horizon.
+         */
+        get: operations["getTxStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get transaction status
-     * @description Returns transaction status by hash. PENDING = not yet confirmed in Horizon.
-     */
-    get: operations['getTxStatus'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tx/history': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/tx/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get transaction history
+         * @description Returns paginated transaction history for the authenticated SDK user. Only includes transactions submitted through Pollar. Transactions appear as PENDING immediately after /tx/build and are updated to SUCCESS or FAILED after /tx/sign-and-send.
+         */
+        get: operations["getTxHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get transaction history
-     * @description Returns paginated transaction history for the authenticated SDK user. Only includes transactions submitted through Pollar. Transactions appear as PENDING immediately after /tx/build and are updated to SUCCESS or FAILED after /tx/sign-and-send.
-     */
-    get: operations['getTxHistory'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/charges': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/charges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a charge
+         * @description Creates a Pollar Pay point-of-sale charge for one of the application branches. Reserves a pool wallet (the address the customer pays to) and returns the payment intent.
+         */
+        post: operations["postCharges"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create a charge
-     * @description Creates a Pollar Pay point-of-sale charge for one of the application branches. Reserves a pool wallet (the address the customer pays to) and returns the payment intent.
-     */
-    post: operations['postCharges'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/charges/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/charges/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get charge status
+         * @description Returns the live status of a charge. A pending charge past its window reads as expired.
+         */
+        get: operations["getChargesById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get charge status
-     * @description Returns the live status of a charge. A pending charge past its window reads as expired.
-     */
-    get: operations['getChargesById'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/wallet/balance': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/wallet/balance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get wallet balances
+         * @description Returns XLM and configured asset balances for a Stellar account using Soroban RPC (no Horizon). The asset list is derived from the application's enabled assets. "available" reflects the spendable amount after minimum reserve (XLM) and selling liabilities.
+         */
+        get: operations["getWalletBalance"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get wallet balances
-     * @description Returns XLM and configured asset balances for a Stellar account using Soroban RPC (no Horizon). The asset list is derived from the application's enabled assets. "available" reflects the spendable amount after minimum reserve (XLM) and selling liabilities.
-     */
-    get: operations['getWalletBalance'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/kyc/status': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/kyc/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get KYC status
+         * @description Returns the KYC verification status of the authenticated end-user. Optionally filter by a specific provider. If no providerId is given, returns the first active verification found across all providers configured for the application.
+         */
+        get: operations["getKycStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get KYC status
-     * @description Returns the KYC verification status of the authenticated end-user. Optionally filter by a specific provider. If no providerId is given, returns the first active verification found across all providers configured for the application.
-     */
-    get: operations['getKycStatus'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/kyc/providers': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/kyc/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List available KYC providers
+         * @description Returns the KYC providers enabled for the application, filtered by the given country (ISO 3166-1 alpha-2). Use this to show the user which KYC options are available before calling POST /kyc/start.
+         */
+        get: operations["getKycProviders"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List available KYC providers
-     * @description Returns the KYC providers enabled for the application, filtered by the given country (ISO 3166-1 alpha-2). Use this to show the user which KYC options are available before calling POST /kyc/start.
-     */
-    get: operations['getKycProviders'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/kyc/start': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/kyc/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start a KYC session
+         * @description Initiates a KYC verification session with the specified provider and level. Returns a sessionId and either a kycUrl (for iframe/redirect flows) or a fields array (for form flows). The session expires in 30 minutes.
+         */
+        post: operations["postKycStart"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Start a KYC session
-     * @description Initiates a KYC verification session with the specified provider and level. Returns a sessionId and either a kycUrl (for iframe/redirect flows) or a fields array (for form flows). The session expires in 30 minutes.
-     */
-    post: operations['postKycStart'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/ramps/quote': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/ramps/quote": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get ramp quotes
+         * @description Returns available quotes for converting fiat to crypto (onramp) or crypto to fiat (offramp) for a given country, amount, and currency. Each quote includes a quoteId valid for 15 minutes. Pass the quoteId to POST /ramps/onramp or POST /ramps/offramp to execute the transaction.
+         */
+        get: operations["getRampsQuote"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get ramp quotes
-     * @description Returns available quotes for converting fiat to crypto (onramp) or crypto to fiat (offramp) for a given country, amount, and currency. Each quote includes a quoteId valid for 15 minutes. Pass the quoteId to POST /ramps/onramp or POST /ramps/offramp to execute the transaction.
-     */
-    get: operations['getRampsQuote'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/ramps/onramp': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/ramps/onramp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create onramp transaction
+         * @description Initiates a fiat-to-crypto onramp transaction using a previously obtained quoteId. Returns payment instructions (CLABE, PIX key, etc.) the user must use to send funds. The quote expires in 15 minutes — a new one must be requested after expiry.
+         */
+        post: operations["postRampsOnramp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create onramp transaction
-     * @description Initiates a fiat-to-crypto onramp transaction using a previously obtained quoteId. Returns payment instructions (CLABE, PIX key, etc.) the user must use to send funds. The quote expires in 15 minutes — a new one must be requested after expiry.
-     */
-    post: operations['postRampsOnramp'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/ramps/offramp': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/ramps/offramp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create offramp transaction
+         * @description Initiates a crypto-to-fiat offramp transaction using a previously obtained quoteId. Funds will be sent from the user's wallet to the provided bank account. The quote expires in 15 minutes.
+         */
+        post: operations["postRampsOfframp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Create offramp transaction
-     * @description Initiates a crypto-to-fiat offramp transaction using a previously obtained quoteId. Funds will be sent from the user's wallet to the provided bank account. The quote expires in 15 minutes.
-     */
-    post: operations['postRampsOfframp'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/ramps/transaction/{txId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/ramps/transaction/{txId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get ramp transaction status
+         * @description Returns the current status of an onramp or offramp transaction. Use this endpoint to poll for status updates. Only the authenticated user who created the transaction can access it.
+         */
+        get: operations["getRampsTransactionByTxId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get ramp transaction status
-     * @description Returns the current status of an onramp or offramp transaction. Use this endpoint to poll for status updates. Only the authenticated user who created the transaction can access it.
-     */
-    get: operations['getRampsTransactionByTxId'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/distribution/rules': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/distribution/rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List distribution rules
+         * @description Returns every distribution rule defined for the calling application, each decorated with a `claimable` flag and (when not claimable) a `reason` ErrorCode the SDK can map to a UI message (expired, already claimed in window, exhausted, etc.).
+         */
+        get: operations["getDistributionRules"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * List distribution rules
-     * @description Returns every distribution rule defined for the calling application, each decorated with a `claimable` flag and (when not claimable) a `reason` ErrorCode the SDK can map to a UI message (expired, already claimed in window, exhausted, etc.).
-     */
-    get: operations['getDistributionRules'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/distribution/claim': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/distribution/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Claim a distribution rule
+         * @description Executes a claim against the given rule for the authenticated sdk-user. The server runs the same claimability checks as GET /distribution/rules against fresh counts; only the txHash and amount are returned on success.
+         */
+        post: operations["postDistributionClaim"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Claim a distribution rule
-     * @description Executes a claim against the given rule for the authenticated sdk-user. The server runs the same claimability checks as GET /distribution/rules against fresh counts; only the txHash and amount are returned on success.
-     */
-    post: operations['postDistributionClaim'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: never;
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    schemas: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getHealth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Service is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_API_HEALTH_OK';
-            /** @constant */
-            success: true;
-            content: {
-              /** @constant */
-              status: 'ok';
-              version: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  postAuthSession: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Session created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_SESSION_CREATED';
-            /** @constant */
-            success: true;
-            content: {
-              clientSessionId: string;
-            };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getAuthSessionStatusByClientSessionId: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        clientSessionId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description SSE stream of session status */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'text/event-stream': {
-            status: string;
-            user: {
-              ready: boolean;
-            };
-          };
-        };
-      };
-    };
-  };
-  getAuthGoogle: {
-    parameters: {
-      query: {
-        api_key: string;
-        client_session_id: string;
-        redirect_uri: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect to Google OAuth */
-      302: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getAuthGithub: {
-    parameters: {
-      query: {
-        api_key: string;
-        client_session_id: string;
-        redirect_uri: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect to GitHub OAuth */
-      302: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getAuthOidc: {
-    parameters: {
-      query: {
-        api_key: string;
-        client_session_id: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect to Authentik */
-      302: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postAuthEmail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          clientSessionId: string;
-          /** Format: email */
-          email: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Code sent */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_EMAIL_CODE_SENT';
-            /** @constant */
-            success: true;
-            content: {
-              clientSessionId: string;
-              email: string;
-            };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postAuthEmailVerifyCode: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          clientSessionId: string;
-          code: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Code verified */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_EMAIL_CODE_VERIFIED';
-            /** @constant */
-            success: true;
-            content: {
-              clientSessionId: string;
-            };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postAuthWallet: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          clientSessionId: string;
-          walletAddress: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Wallet authenticated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_WALLET_AUTHENTICATED';
-            /** @constant */
-            success: true;
-            content: {
-              clientSessionId: string;
-              walletAddress: string;
-            };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postAuthLogin: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          clientSessionId: string;
-          dpopJwk?: {
-            /** @constant */
-            kty: 'EC';
-            /** @constant */
-            crv: 'P-256';
-            x: string;
-            y: string;
-          };
-          deviceLabel?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Authenticated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_LOGIN_SUCCESS';
-            /** @constant */
-            success: true;
-            content: {
-              clientSessionId: string;
-              userId: string | null;
-              status: string;
-              token: {
-                accessToken: string;
-                refreshToken: string;
-                expiresAt: number;
-              };
-              user: {
-                id?: string;
-                ready: boolean;
-              };
-              wallet: {
-                publicKey: string | null;
-                existsOnStellar?: boolean;
-                createdAt?: number;
-              };
-              data: {
-                mail: string;
-                first_name: string;
-                last_name: string;
-                avatar: string;
-                providers: {
-                  email: {
-                    address: string;
-                  } | null;
-                  google: {
-                    id: string;
-                  } | null;
-                  github: {
-                    id: string;
-                  } | null;
-                  wallet: {
-                    address: string;
-                  } | null;
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
                 };
-              };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_API_HEALTH_OK";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            /** @constant */
+                            status: "ok";
+                            version: string;
+                        };
+                    };
+                };
             };
-          };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  postAuthRefresh: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          refreshToken: string;
+    postAuthSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-    responses: {
-      /** @description New token pair issued */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TOKEN_REFRESHED';
-            /** @constant */
-            success: true;
-            content: {
-              token: {
-                accessToken: string;
-                refreshToken: string;
-                expiresAt: number;
-              };
+        requestBody?: never;
+        responses: {
+            /** @description Session created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_SESSION_CREATED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            clientSessionId: string;
+                        };
+                    };
+                };
             };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postAuthLogout: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          everywhere?: boolean;
-        };
-      };
-    };
-    responses: {
-      /** @description Sessions revoked */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_LOGOUT_SUCCESS';
-            /** @constant */
-            success: true;
-            content: {
-              revoked: number;
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
             };
-          };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  getAuthSessions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Sessions list */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAuthSessionStatusByClientSessionId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                clientSessionId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_SESSIONS_LIST';
-            /** @constant */
-            success: true;
+        requestBody?: never;
+        responses: {
+            /** @description SSE stream of session status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": {
+                        status: string;
+                        user: {
+                            ready: boolean;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    getAuthGoogle: {
+        parameters: {
+            query: {
+                api_key: string;
+                client_session_id: string;
+                redirect_uri: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to Google OAuth */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getAuthGithub: {
+        parameters: {
+            query: {
+                api_key: string;
+                client_session_id: string;
+                redirect_uri: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to GitHub OAuth */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getAuthOidc: {
+        parameters: {
+            query: {
+                api_key: string;
+                client_session_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to Authentik */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
             content: {
-              sessions: {
+                "application/json": {
+                    clientSessionId: string;
+                    /** Format: email */
+                    email: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Code sent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_EMAIL_CODE_SENT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            clientSessionId: string;
+                            email: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthEmailVerifyCode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    clientSessionId: string;
+                    code: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Code verified */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_EMAIL_CODE_VERIFIED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            clientSessionId: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthWallet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    clientSessionId: string;
+                    walletAddress: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Wallet authenticated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_WALLET_AUTHENTICATED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            clientSessionId: string;
+                            walletAddress: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    clientSessionId: string;
+                    dpopJwk?: {
+                        /** @constant */
+                        kty: "EC";
+                        /** @constant */
+                        crv: "P-256";
+                        x: string;
+                        y: string;
+                    };
+                    deviceLabel?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Authenticated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_LOGIN_SUCCESS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            clientSessionId: string;
+                            userId: string | null;
+                            status: string;
+                            token: {
+                                accessToken: string;
+                                refreshToken: string;
+                                expiresAt: number;
+                            };
+                            user: {
+                                id?: string;
+                                ready: boolean;
+                            };
+                            wallet: {
+                                publicKey: string | null;
+                                existsOnStellar?: boolean;
+                                createdAt?: number;
+                            };
+                            data: {
+                                mail: string;
+                                first_name: string;
+                                last_name: string;
+                                avatar: string;
+                                providers: {
+                                    email: {
+                                        address: string;
+                                    } | null;
+                                    google: {
+                                        id: string;
+                                    } | null;
+                                    github: {
+                                        id: string;
+                                    } | null;
+                                    wallet: {
+                                        address: string;
+                                    } | null;
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    refreshToken: string;
+                };
+            };
+        };
+        responses: {
+            /** @description New token pair issued */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TOKEN_REFRESHED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            token: {
+                                accessToken: string;
+                                refreshToken: string;
+                                expiresAt: number;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthLogout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    everywhere?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Sessions revoked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_LOGOUT_SUCCESS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            revoked: number;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getAuthSessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sessions list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_SESSIONS_LIST";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            sessions: {
+                                familyId: string;
+                                createdAt: string;
+                                lastUsedAt: string | null;
+                                userAgent: string | null;
+                                ipHash: string | null;
+                                deviceLabel: string | null;
+                                current: boolean;
+                                expiresAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteAuthSessionsByFamilyId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
                 familyId: string;
-                createdAt: string;
-                lastUsedAt: string | null;
-                userAgent: string | null;
-                ipHash: string | null;
-                deviceLabel: string | null;
-                current: boolean;
-                expiresAt: string;
-              }[];
             };
-          };
+            cookie?: never;
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  deleteAuthSessionsByFamilyId: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        familyId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Session revoked */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_SESSION_REVOKED';
-            /** @constant */
-            success: true;
-            content: {
-              revoked: number;
-            };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getApplicationsConfig: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Application config */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_APPLICATION_CONFIG';
-            /** @constant */
-            success: true;
-            content: {
-              application: {
-                name: string;
-              };
-              styles: {
-                theme?: string;
-                accentColor?: string;
-                logoUrl?: string;
-                emailEnabled?: boolean;
-                embeddedWallets?: boolean;
-                providers?: {
-                  google?: boolean;
-                  discord?: boolean;
-                  x?: boolean;
-                  github?: boolean;
-                  apple?: boolean;
+        requestBody?: never;
+        responses: {
+            /** @description Session revoked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
                 };
-              };
-            };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getApplicationsByIdLogo: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Logo image */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'image/*': string;
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postTxBuild: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          /** @enum {string} */
-          network: 'testnet' | 'mainnet';
-          publicKey: string;
-          options?: {
-            timeoutSec?: number;
-            memo?:
-              | {
-                  /** @constant */
-                  type: 'text';
-                  value: string;
-                }
-              | {
-                  /** @constant */
-                  type: 'id';
-                  value: string;
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_SESSION_REVOKED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            revoked: number;
+                        };
+                    };
                 };
-            maxFeeStroops?: number;
-          };
-        } & (
-          | {
-              /** @constant */
-              operation: 'payment';
-              params: {
-                destination: string;
-                amount: string;
-                asset:
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    };
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'change_trust';
-              params: {
-                asset:
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'liquidity_pool_shares';
-                      assetA:
-                        | {
-                            /** @constant */
-                            type: 'native';
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum4';
-                            code: string;
-                            issuer: string;
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum12';
-                            code: string;
-                            issuer: string;
-                          };
-                      assetB:
-                        | {
-                            /** @constant */
-                            type: 'native';
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum4';
-                            code: string;
-                            issuer: string;
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum12';
-                            code: string;
-                            issuer: string;
-                          };
-                    };
-                limit?: string;
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'path_payment_strict_send';
-              params: {
-                destination: string;
-                sendAsset:
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    };
-                sendAmount: string;
-                destAsset:
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    };
-                destMin: string;
-                /** @default [] */
-                path?: (
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    }
-                )[];
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'create_account';
-              params: {
-                destination: string;
-                startingBalance: string;
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'invoke_contract';
-              params: {
-                contractId: string;
-                method: string;
-                /** @default [] */
-                args?: (
-                  | {
-                      /** @constant */
-                      type: 'bool';
-                      value: boolean;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'i32';
-                      value: number;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'u32';
-                      value: number;
-                    }
-                  | {
-                      /** @enum {string} */
-                      type: 'i64' | 'u64' | 'i128' | 'u128' | 'i256' | 'u256';
-                      value: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'address';
-                      value: string;
-                    }
-                  | {
-                      /** @enum {string} */
-                      type: 'string' | 'symbol';
-                      value: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'bytes';
-                      /** @description Base64-encoded bytes */
-                      value: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'vec';
-                      /** @description Array of ScValArg items */
-                      value: unknown[];
-                    }
-                  | {
-                      /** @constant */
-                      type: 'map';
-                      /** @description Array of {key, val} ScValArg pairs */
-                      value: {
-                        key: unknown;
-                        val: unknown;
-                      }[];
-                    }
-                  | {
-                      /** @constant */
-                      type: 'void';
-                    }
-                )[];
-              };
-            }
-        );
-      };
-    };
-    responses: {
-      /** @description Unsigned XDR and summary */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_BUILT';
-            /** @constant */
-            success: true;
-            content: {
-              unsignedXdr: string;
-              networkPassphrase: string;
-              estimatedFee: string;
-              summary: {
-                title: string;
-                lines: string[];
-                network: string;
-                fee: string;
-              };
             };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Transaction build error */
-      502: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postTxSignAndSend: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          /** @enum {string} */
-          network: 'testnet' | 'mainnet';
-          publicKey: string;
-          unsignedXdr: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Submit result (PENDING | SUCCESS | FAILED) */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_SUBMIT';
-            /** @constant */
-            success: true;
-            content: {
-              hash: string;
-              /** @enum {string} */
-              status: 'PENDING' | 'SUCCESS' | 'FAILED';
-              resultCode?: string;
-              message?: string;
-            };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postTxSign: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          /** @enum {string} */
-          network: 'testnet' | 'mainnet';
-          publicKey: string;
-          unsignedXdr: string;
-          idempotencyKey?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Signed XDR + idempotency key to use with /tx/submit */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_SIGNED';
-            /** @constant */
-            success: true;
-            content: {
-              signedXdr: string;
-              idempotencyKey: string;
-            };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Signing error */
-      502: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postTxSubmit: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          /** @enum {string} */
-          network: 'testnet' | 'mainnet';
-          publicKey: string;
-          signedXdr: string;
-          idempotencyKey?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Submit result (PENDING | SUCCESS | FAILED) */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_SUBMIT';
-            /** @constant */
-            success: true;
-            content: {
-              hash: string;
-              /** @enum {string} */
-              status: 'PENDING' | 'SUCCESS' | 'FAILED';
-              resultCode?: string;
-              message?: string;
-            };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postTxBuildSignSubmit: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          /** @enum {string} */
-          network: 'testnet' | 'mainnet';
-          publicKey: string;
-          options?: {
-            timeoutSec?: number;
-            memo?:
-              | {
-                  /** @constant */
-                  type: 'text';
-                  value: string;
-                }
-              | {
-                  /** @constant */
-                  type: 'id';
-                  value: string;
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
                 };
-            maxFeeStroops?: number;
-          };
-        } & (
-          | {
-              /** @constant */
-              operation: 'payment';
-              params: {
-                destination: string;
-                amount: string;
-                asset:
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
                     };
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'change_trust';
-              params: {
-                asset:
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'liquidity_pool_shares';
-                      assetA:
-                        | {
-                            /** @constant */
-                            type: 'native';
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum4';
-                            code: string;
-                            issuer: string;
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum12';
-                            code: string;
-                            issuer: string;
-                          };
-                      assetB:
-                        | {
-                            /** @constant */
-                            type: 'native';
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum4';
-                            code: string;
-                            issuer: string;
-                          }
-                        | {
-                            /** @constant */
-                            type: 'credit_alphanum12';
-                            code: string;
-                            issuer: string;
-                          };
-                    };
-                limit?: string;
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'path_payment_strict_send';
-              params: {
-                destination: string;
-                sendAsset:
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    };
-                sendAmount: string;
-                destAsset:
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    };
-                destMin: string;
-                /** @default [] */
-                path?: (
-                  | {
-                      /** @constant */
-                      type: 'native';
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum4';
-                      code: string;
-                      issuer: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'credit_alphanum12';
-                      code: string;
-                      issuer: string;
-                    }
-                )[];
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'create_account';
-              params: {
-                destination: string;
-                startingBalance: string;
-              };
-            }
-          | {
-              /** @constant */
-              operation: 'invoke_contract';
-              params: {
-                contractId: string;
-                method: string;
-                /** @default [] */
-                args?: (
-                  | {
-                      /** @constant */
-                      type: 'bool';
-                      value: boolean;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'i32';
-                      value: number;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'u32';
-                      value: number;
-                    }
-                  | {
-                      /** @enum {string} */
-                      type: 'i64' | 'u64' | 'i128' | 'u128' | 'i256' | 'u256';
-                      value: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'address';
-                      value: string;
-                    }
-                  | {
-                      /** @enum {string} */
-                      type: 'string' | 'symbol';
-                      value: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'bytes';
-                      /** @description Base64-encoded bytes */
-                      value: string;
-                    }
-                  | {
-                      /** @constant */
-                      type: 'vec';
-                      /** @description Array of ScValArg items */
-                      value: unknown[];
-                    }
-                  | {
-                      /** @constant */
-                      type: 'map';
-                      /** @description Array of {key, val} ScValArg pairs */
-                      value: {
-                        key: unknown;
-                        val: unknown;
-                      }[];
-                    }
-                  | {
-                      /** @constant */
-                      type: 'void';
-                    }
-                )[];
-              };
-            }
-        ) & {
-            idempotencyKey?: string;
-          };
-      };
-    };
-    responses: {
-      /** @description Final submit result with the original build summary */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_SUBMIT';
-            /** @constant */
-            success: true;
-            content: {
-              hash: string;
-              /** @enum {string} */
-              status: 'PENDING' | 'SUCCESS' | 'FAILED';
-              resultCode?: string;
-              message?: string;
-              summary: {
-                title: string;
-                lines: string[];
-                network: string;
-                fee: string;
-              };
-              estimatedFee: string;
+                };
             };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Build/sign/submit error */
-      502: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getTxStatus: {
-    parameters: {
-      query: {
-        network: 'testnet' | 'mainnet';
-        hash: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Transaction status (PENDING si no existe aún en Horizon) */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_STATUS';
-            /** @constant */
-            success: true;
-            content: {
-              hash: string;
-              /** @enum {string} */
-              status: 'PENDING' | 'SUCCESS' | 'FAILED';
-              resultCode?: string;
-              ledger?: number;
-              message?: string;
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
             };
-          };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  getTxHistory: {
-    parameters: {
-      query?: {
-        network?: 'testnet' | 'mainnet';
-        limit?: number;
-        offset?: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Paginated list of transactions */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getApplicationsConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_TX_HISTORY';
-            /** @constant */
-            success: true;
-            content: {
-              records: {
+        requestBody?: never;
+        responses: {
+            /** @description Application config */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_APPLICATION_CONFIG";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            application: {
+                                name: string;
+                            };
+                            styles: {
+                                theme?: string;
+                                accentColor?: string;
+                                logoUrl?: string;
+                                emailEnabled?: boolean;
+                                embeddedWallets?: boolean;
+                                providers?: {
+                                    google?: boolean;
+                                    discord?: boolean;
+                                    x?: boolean;
+                                    github?: boolean;
+                                    apple?: boolean;
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getApplicationsByIdLogo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
                 id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Logo image */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/*": string;
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxBuild: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    options?: {
+                        timeoutSec?: number;
+                        memo?: {
+                            /** @constant */
+                            type: "text";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "id";
+                            value: string;
+                        };
+                        maxFeeStroops?: number;
+                    };
+                } & ({
+                    /** @constant */
+                    operation: "payment";
+                    params: {
+                        destination: string;
+                        amount: string;
+                        asset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                    };
+                } | {
+                    /** @constant */
+                    operation: "change_trust";
+                    params: {
+                        asset: {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "liquidity_pool_shares";
+                            assetA: {
+                                /** @constant */
+                                type: "native";
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum4";
+                                code: string;
+                                issuer: string;
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum12";
+                                code: string;
+                                issuer: string;
+                            };
+                            assetB: {
+                                /** @constant */
+                                type: "native";
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum4";
+                                code: string;
+                                issuer: string;
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum12";
+                                code: string;
+                                issuer: string;
+                            };
+                        };
+                        limit?: string;
+                    };
+                } | {
+                    /** @constant */
+                    operation: "path_payment_strict_send";
+                    params: {
+                        destination: string;
+                        sendAsset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                        sendAmount: string;
+                        destAsset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                        destMin: string;
+                        /** @default [] */
+                        path?: ({
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        })[];
+                    };
+                } | {
+                    /** @constant */
+                    operation: "create_account";
+                    params: {
+                        destination: string;
+                        startingBalance: string;
+                    };
+                } | {
+                    /** @constant */
+                    operation: "invoke_contract";
+                    params: {
+                        contractId: string;
+                        method: string;
+                        /** @default [] */
+                        args?: ({
+                            /** @constant */
+                            type: "bool";
+                            value: boolean;
+                        } | {
+                            /** @constant */
+                            type: "i32";
+                            value: number;
+                        } | {
+                            /** @constant */
+                            type: "u32";
+                            value: number;
+                        } | {
+                            /** @enum {string} */
+                            type: "i64" | "u64" | "i128" | "u128" | "i256" | "u256";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "address";
+                            value: string;
+                        } | {
+                            /** @enum {string} */
+                            type: "string" | "symbol";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "bytes";
+                            /** @description Base64-encoded bytes */
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "vec";
+                            /** @description Array of ScValArg items */
+                            value: unknown[];
+                        } | {
+                            /** @constant */
+                            type: "map";
+                            /** @description Array of {key, val} ScValArg pairs */
+                            value: {
+                                key: unknown;
+                                val: unknown;
+                            }[];
+                        } | {
+                            /** @constant */
+                            type: "void";
+                        })[];
+                    };
+                });
+            };
+        };
+        responses: {
+            /** @description Unsigned XDR and summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_BUILT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            unsignedXdr: string;
+                            networkPassphrase: string;
+                            estimatedFee: string;
+                            summary: {
+                                title: string;
+                                lines: string[];
+                                network: string;
+                                fee: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Transaction build error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxSignAndSend: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    unsignedXdr: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Submit result (PENDING | SUCCESS | FAILED) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SUBMIT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            hash: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "SUCCESS" | "FAILED";
+                            resultCode?: string;
+                            message?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Signing or submission error (upstream/RPC) */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxSign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    unsignedXdr: string;
+                    idempotencyKey?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed XDR + idempotency key to use with /tx/submit */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SIGNED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            signedXdr: string;
+                            idempotencyKey: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Signing error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxSubmit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    signedXdr: string;
+                    idempotencyKey?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Submit result (PENDING | SUCCESS | FAILED) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SUBMIT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            hash: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "SUCCESS" | "FAILED";
+                            resultCode?: string;
+                            message?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Submission error (RPC/network) */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postTxBuildSignSubmit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    network: "testnet" | "mainnet";
+                    publicKey: string;
+                    options?: {
+                        timeoutSec?: number;
+                        memo?: {
+                            /** @constant */
+                            type: "text";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "id";
+                            value: string;
+                        };
+                        maxFeeStroops?: number;
+                    };
+                } & ({
+                    /** @constant */
+                    operation: "payment";
+                    params: {
+                        destination: string;
+                        amount: string;
+                        asset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                    };
+                } | {
+                    /** @constant */
+                    operation: "change_trust";
+                    params: {
+                        asset: {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "liquidity_pool_shares";
+                            assetA: {
+                                /** @constant */
+                                type: "native";
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum4";
+                                code: string;
+                                issuer: string;
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum12";
+                                code: string;
+                                issuer: string;
+                            };
+                            assetB: {
+                                /** @constant */
+                                type: "native";
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum4";
+                                code: string;
+                                issuer: string;
+                            } | {
+                                /** @constant */
+                                type: "credit_alphanum12";
+                                code: string;
+                                issuer: string;
+                            };
+                        };
+                        limit?: string;
+                    };
+                } | {
+                    /** @constant */
+                    operation: "path_payment_strict_send";
+                    params: {
+                        destination: string;
+                        sendAsset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                        sendAmount: string;
+                        destAsset: {
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        };
+                        destMin: string;
+                        /** @default [] */
+                        path?: ({
+                            /** @constant */
+                            type: "native";
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum4";
+                            code: string;
+                            issuer: string;
+                        } | {
+                            /** @constant */
+                            type: "credit_alphanum12";
+                            code: string;
+                            issuer: string;
+                        })[];
+                    };
+                } | {
+                    /** @constant */
+                    operation: "create_account";
+                    params: {
+                        destination: string;
+                        startingBalance: string;
+                    };
+                } | {
+                    /** @constant */
+                    operation: "invoke_contract";
+                    params: {
+                        contractId: string;
+                        method: string;
+                        /** @default [] */
+                        args?: ({
+                            /** @constant */
+                            type: "bool";
+                            value: boolean;
+                        } | {
+                            /** @constant */
+                            type: "i32";
+                            value: number;
+                        } | {
+                            /** @constant */
+                            type: "u32";
+                            value: number;
+                        } | {
+                            /** @enum {string} */
+                            type: "i64" | "u64" | "i128" | "u128" | "i256" | "u256";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "address";
+                            value: string;
+                        } | {
+                            /** @enum {string} */
+                            type: "string" | "symbol";
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "bytes";
+                            /** @description Base64-encoded bytes */
+                            value: string;
+                        } | {
+                            /** @constant */
+                            type: "vec";
+                            /** @description Array of ScValArg items */
+                            value: unknown[];
+                        } | {
+                            /** @constant */
+                            type: "map";
+                            /** @description Array of {key, val} ScValArg pairs */
+                            value: {
+                                key: unknown;
+                                val: unknown;
+                            }[];
+                        } | {
+                            /** @constant */
+                            type: "void";
+                        })[];
+                    };
+                }) & {
+                    idempotencyKey?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Final submit result with the original build summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_SUBMIT";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            hash: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "SUCCESS" | "FAILED";
+                            resultCode?: string;
+                            message?: string;
+                            summary: {
+                                title: string;
+                                lines: string[];
+                                network: string;
+                                fee: string;
+                            };
+                            estimatedFee: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Build/sign/submit error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getTxStatus: {
+        parameters: {
+            query: {
+                network: "testnet" | "mainnet";
                 hash: string;
-                /** @enum {string} */
-                network: 'testnet' | 'mainnet';
-                /** @enum {string} */
-                status: 'PENDING' | 'SUCCESS' | 'FAILED';
-                operation: string;
-                feeXlm?: string;
-                resultCode?: string;
-                details: {
-                  [key: string]: unknown;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Transaction status (PENDING si no existe aún en Horizon) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
                 };
-                summary: string;
-                createdAt: string;
-              }[];
-              total: number;
-              limit: number;
-              offset: number;
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_STATUS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            hash: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "SUCCESS" | "FAILED";
+                            resultCode?: string;
+                            ledger?: number;
+                            message?: string;
+                        };
+                    };
+                };
             };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postCharges: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Charge created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_CHARGE_CREATED';
-            /** @constant */
-            success: true;
-            content: {
-              chargeId: string;
-              walletAddress: string;
-              reason: string;
-              amount: string;
-              asset: string;
-              network: string;
-              expiresAt: string;
-              timeRemainingSeconds: number;
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
             };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description No pool wallet available */
-      503: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            chargeId: string;
-            walletAddress: string;
-            reason: string;
-            amount: string;
-            asset: string;
-            network: string;
-            expiresAt: string;
-            timeRemainingSeconds: number;
-          };
-        };
-      };
-    };
-  };
-  getChargesById: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Charge status */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_CHARGE_STATUS';
-            /** @constant */
-            success: true;
-            content: {
-              chargeId: string;
-              /** @enum {string} */
-              status: 'pending' | 'completed' | 'overpaid' | 'underpaid' | 'expired' | 'refunded';
-              reason: string;
-              amountExpected: string;
-              amountPaid: string;
-              remaining: string;
-              asset: string;
-              walletAddress: string;
-              network: string;
-              expiresAt: string;
-              timeRemainingSeconds: number;
-              isExpired: boolean;
-              feeAmount: string | null;
-              payoutAmount: string | null;
-              forwardTxHash: string | null;
-              createdAt: string;
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
             };
-          };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  getWalletBalance: {
-    parameters: {
-      query: {
-        network: 'testnet' | 'mainnet';
-        publicKey: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Account balances */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_WALLET_BALANCE';
-            /** @constant */
-            success: true;
-            content: {
-              publicKey: string;
-              /** @enum {string} */
-              network: 'testnet' | 'mainnet';
-              exists: boolean;
-              balances: {
-                /** @enum {string} */
-                type: 'native' | 'credit_alphanum4' | 'credit_alphanum12';
-                code: string;
-                issuer?: string;
-                balance: string;
-                available: string;
-                limit?: string;
-                enabledInApp: boolean;
-                trustlineRemoved: boolean;
-              }[];
+    getTxHistory: {
+        parameters: {
+            query?: {
+                network?: "testnet" | "mainnet";
+                limit?: number;
+                offset?: number;
             };
-          };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getKycStatus: {
-    parameters: {
-      query?: {
-        providerId?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description KYC status for the authenticated user */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_KYC_STATUS';
-            /** @constant */
-            success: true;
-            content: {
-              /** @enum {string} */
-              status: 'none' | 'pending' | 'approved' | 'rejected';
-              /** @enum {string} */
-              level?: 'basic' | 'intermediate' | 'enhanced';
-              providerId: string;
-              expiresAt?: string;
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of transactions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_TX_HISTORY";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            records: {
+                                id: string;
+                                hash: string;
+                                /** @enum {string} */
+                                network: "testnet" | "mainnet";
+                                /** @enum {string} */
+                                status: "PENDING" | "SUCCESS" | "FAILED";
+                                operation: string;
+                                feeXlm?: string;
+                                resultCode?: string;
+                                details: {
+                                    [key: string]: unknown;
+                                };
+                                summary: string;
+                                createdAt: string;
+                            }[];
+                            total: number;
+                            limit: number;
+                            offset: number;
+                        };
+                    };
+                };
             };
-          };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  getKycProviders: {
-    parameters: {
-      query: {
-        country: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of KYC providers available for the country */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postCharges: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_KYC_PROVIDERS';
-            /** @constant */
-            success: true;
-            content: {
-              providers: {
+        requestBody?: never;
+        responses: {
+            /** @description Charge created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_CHARGE_CREATED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            chargeId: string;
+                            walletAddress: string;
+                            reason: string;
+                            amount: string;
+                            asset: string;
+                            network: string;
+                            expiresAt: string;
+                            timeRemainingSeconds: number;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description No pool wallet available */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        chargeId: string;
+                        walletAddress: string;
+                        reason: string;
+                        amount: string;
+                        asset: string;
+                        network: string;
+                        expiresAt: string;
+                        timeRemainingSeconds: number;
+                    };
+                };
+            };
+        };
+    };
+    getChargesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
                 id: string;
-                name: string;
-                /** @enum {string} */
-                flow: 'iframe' | 'form' | 'redirect';
-                levels: ('basic' | 'intermediate' | 'enhanced')[];
-              }[];
             };
-          };
+            cookie?: never;
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postKycStart: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          providerId: string;
-          /** @enum {string} */
-          level: 'basic' | 'intermediate' | 'enhanced';
-        };
-      };
-    };
-    responses: {
-      /** @description KYC session created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_KYC_STARTED';
-            /** @constant */
-            success: true;
-            content: {
-              sessionId: string;
-              kycUrl?: string;
-              fields?: {
-                name: string;
-                type: string;
-                required: boolean;
-              }[];
+        requestBody?: never;
+        responses: {
+            /** @description Charge status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_CHARGE_STATUS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            chargeId: string;
+                            /** @enum {string} */
+                            status: "pending" | "completed" | "overpaid" | "underpaid" | "expired" | "refunded";
+                            reason: string;
+                            amountExpected: string;
+                            amountPaid: string;
+                            remaining: string;
+                            asset: string;
+                            walletAddress: string;
+                            network: string;
+                            expiresAt: string;
+                            timeRemainingSeconds: number;
+                            isExpired: boolean;
+                            feeAmount: string | null;
+                            payoutAmount: string | null;
+                            forwardTxHash: string | null;
+                            createdAt: string;
+                        };
+                    };
+                };
             };
-          };
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Provider not found or not enabled for this application */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  getRampsQuote: {
-    parameters: {
-      query: {
-        country: string;
-        amount: number;
-        currency: string;
-        direction: 'onramp' | 'offramp';
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of available quotes sorted by recommendation. First item is the best option. */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_RAMPS_QUOTES';
-            /** @constant */
-            success: true;
-            content: {
-              quotes: {
-                quoteId: string;
-                provider: string;
-                fee: number;
-                feeCurrency: string;
-                rate: number;
-                /** @enum {string} */
-                rail: 'SPEI' | 'PIX' | 'PSE' | 'ACH';
-                /** @enum {string} */
-                protocol: 'SEP-24' | 'REST';
-                estimatedTime: string;
-                recommended: boolean;
-              }[];
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
             };
-          };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  postRampsOnramp: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          quoteId: string;
-          amount: number;
-          currency: string;
-          country: string;
-          walletAddress: string;
+    getWalletBalance: {
+        parameters: {
+            query: {
+                network: "testnet" | "mainnet";
+                publicKey: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-    responses: {
-      /** @description Onramp transaction created with payment instructions */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description Account balances */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_WALLET_BALANCE";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            publicKey: string;
+                            /** @enum {string} */
+                            network: "testnet" | "mainnet";
+                            exists: boolean;
+                            balances: {
+                                /** @enum {string} */
+                                type: "native" | "credit_alphanum4" | "credit_alphanum12";
+                                code: string;
+                                issuer?: string;
+                                balance: string;
+                                available: string;
+                                limit?: string;
+                                enabledInApp: boolean;
+                                trustlineRemoved: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_RAMPS_ONRAMP_CREATED';
-            /** @constant */
-            success: true;
+    };
+    getKycStatus: {
+        parameters: {
+            query?: {
+                providerId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description KYC status for the authenticated user */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_KYC_STATUS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            /** @enum {string} */
+                            status: "none" | "pending" | "approved" | "rejected";
+                            /** @enum {string} */
+                            level?: "basic" | "intermediate" | "enhanced";
+                            providerId: string;
+                            expiresAt?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getKycProviders: {
+        parameters: {
+            query: {
+                country: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of KYC providers available for the country */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_KYC_PROVIDERS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            providers: {
+                                id: string;
+                                name: string;
+                                /** @enum {string} */
+                                flow: "iframe" | "form" | "redirect";
+                                levels: ("basic" | "intermediate" | "enhanced")[];
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postKycStart: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
             content: {
-              txId: string;
-              provider: string;
-              /** @enum {string} */
-              status: 'pending' | 'processing' | 'completed' | 'failed';
-              paymentInstructions: {
-                /** @enum {string} */
-                type: 'CLABE' | 'PIX' | 'PSE' | 'ACH';
-                value: string;
+                "application/json": {
+                    providerId: string;
+                    /** @enum {string} */
+                    level: "basic" | "intermediate" | "enhanced";
+                };
+            };
+        };
+        responses: {
+            /** @description KYC session created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_KYC_STARTED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            sessionId: string;
+                            kycUrl?: string;
+                            fields?: {
+                                name: string;
+                                type: string;
+                                required: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Provider not found or not enabled for this application */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getRampsQuote: {
+        parameters: {
+            query: {
+                country: string;
                 amount: number;
                 currency: string;
-                expiresAt?: string;
-              };
+                direction: "onramp" | "offramp";
             };
-          };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      /** @description Validation error or quote expired */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description List of available quotes sorted by recommendation. First item is the best option. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_QUOTES";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            quotes: {
+                                quoteId: string;
+                                provider: string;
+                                fee: number;
+                                feeCurrency: string;
+                                rate: number;
+                                /** @enum {string} */
+                                rail: "SPEI" | "PIX" | "PSE" | "ACH";
+                                /** @enum {string} */
+                                protocol: "SEP-24" | "REST";
+                                estimatedTime: string;
+                                recommended: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Quote not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  postRampsOfframp: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          quoteId: string;
-          amount: number;
-          currency: string;
-          country: string;
-          walletAddress: string;
-          bankDetails: {
-            /** @enum {string} */
-            type: 'CLABE' | 'PIX' | 'PSE' | 'ACH';
-            value: string;
-          };
+    postRampsOnramp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-    responses: {
-      /** @description Offramp transaction created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_RAMPS_OFFRAMP_CREATED';
-            /** @constant */
-            success: true;
+        requestBody: {
             content: {
-              txId: string;
-              provider: string;
-              /** @enum {string} */
-              status: 'pending' | 'processing' | 'completed' | 'failed';
+                "application/json": {
+                    quoteId: string;
+                    amount: number;
+                    currency: string;
+                    country: string;
+                    walletAddress: string;
+                };
             };
-          };
         };
-      };
-      /** @description Validation error or quote expired */
-      400: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Onramp transaction created with payment instructions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_ONRAMP_CREATED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            txId: string;
+                            provider: string;
+                            /** @enum {string} */
+                            status: "pending" | "processing" | "completed" | "failed";
+                            paymentInstructions: {
+                                /** @enum {string} */
+                                type: "CLABE" | "PIX" | "PSE" | "ACH";
+                                value: string;
+                                amount: number;
+                                currency: string;
+                                expiresAt?: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Validation error or quote expired */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Quote not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Quote not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  getRampsTransactionByTxId: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Transaction ID returned by POST /ramps/onramp or POST /ramps/offramp */
-        txId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Transaction status and details */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postRampsOfframp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_RAMPS_TX_STATUS';
-            /** @constant */
-            success: true;
+        requestBody: {
             content: {
-              txId: string;
-              provider: string;
-              /** @enum {string} */
-              status: 'pending' | 'processing' | 'completed' | 'failed';
-              /** @enum {string} */
-              direction: 'onramp' | 'offramp';
-              amount: number;
-              currency: string;
-              updatedAt: string;
+                "application/json": {
+                    quoteId: string;
+                    amount: number;
+                    currency: string;
+                    country: string;
+                    walletAddress: string;
+                    bankDetails: {
+                        /** @enum {string} */
+                        type: "CLABE" | "PIX" | "PSE" | "ACH";
+                        value: string;
+                    };
+                };
             };
-          };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Offramp transaction created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_OFFRAMP_CREATED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            txId: string;
+                            provider: string;
+                            /** @enum {string} */
+                            status: "pending" | "processing" | "completed" | "failed";
+                        };
+                    };
+                };
+            };
+            /** @description Validation error or quote expired */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Quote not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
-  getDistributionRules: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of distribution rules with claimability verdict per rule */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getRampsTransactionByTxId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Transaction ID returned by POST /ramps/onramp or POST /ramps/offramp */
+                txId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_DISTRIBUTION_RULES_LIST';
-            /** @constant */
-            success: true;
+        requestBody?: never;
+        responses: {
+            /** @description Transaction status and details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_TX_STATUS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            txId: string;
+                            provider: string;
+                            /** @enum {string} */
+                            status: "pending" | "processing" | "completed" | "failed";
+                            /** @enum {string} */
+                            direction: "onramp" | "offramp";
+                            amount: number;
+                            currency: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    getDistributionRules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of distribution rules with claimability verdict per rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_DISTRIBUTION_RULES_LIST";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            rules: {
+                                id: string;
+                                name: string;
+                                assetCode: string;
+                                amount: string;
+                                /** @enum {string} */
+                                period: "DAY" | "DAY_CALENDAR" | "WEEK" | "MONTH" | "MONTH_CALENDAR" | "LIFETIME";
+                                validFrom: string | null;
+                                validUntil: string | null;
+                                claimable: boolean;
+                                reason: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+        };
+    };
+    postDistributionClaim: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
             content: {
-              rules: {
-                id: string;
-                name: string;
-                assetCode: string;
-                amount: string;
-                /** @enum {string} */
-                period: 'DAY' | 'DAY_CALENDAR' | 'WEEK' | 'MONTH' | 'MONTH_CALENDAR' | 'LIFETIME';
-                validFrom: string | null;
-                validUntil: string | null;
-                claimable: boolean;
-                reason: string | null;
-              }[];
+                "application/json": {
+                    ruleId: string;
+                };
             };
-          };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-    };
-  };
-  postDistributionClaim: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': {
-          ruleId: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Claim succeeded — payment submitted to Stellar */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            code: 'SDK_DISTRIBUTION_CLAIM_OK';
-            /** @constant */
-            success: true;
-            content: {
-              ruleId: string;
-              assetCode: string;
-              amount: string;
-              txHash: string | null;
+        responses: {
+            /** @description Claim succeeded — payment submitted to Stellar */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_DISTRIBUTION_CLAIM_OK";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            ruleId: string;
+                            assetCode: string;
+                            amount: string;
+                            txHash: string | null;
+                        };
+                    };
+                };
             };
-          };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Rule not found, user has no wallet, or application has no distribution wallet */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
+            /** @description Rule not claimable (disabled, expired, exhausted, rate-limited) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Rule not found, user has no wallet, or application has no distribution wallet */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
-      /** @description Rule not claimable (disabled, expired, exhausted, rate-limited) */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success: false;
-            code: string;
-          };
-        };
-      };
     };
-  };
 }

--- a/packages/core/src/client/auth/authenticate.ts
+++ b/packages/core/src/client/auth/authenticate.ts
@@ -12,7 +12,10 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
 
   // Pass `dpopJwk` so the server mints DPoP-bound tokens (`cnf.jkt`).
   const dpopJwk = await deps.getPublicJwk();
-  const { data, error } = await api.POST('/auth/login', {
+  // HTTP-level `error` is not handled here; the `else` branch below catches
+  // both "request failed" (data === undefined) and "request OK but body
+  // wasn't a valid session" via the same generic path.
+  const { data } = await api.POST('/auth/login', {
     body: {
       clientSessionId,
       dpopJwk,

--- a/packages/core/src/client/auth/walletFlow.ts
+++ b/packages/core/src/client/auth/walletFlow.ts
@@ -26,7 +26,12 @@ export async function loginWallet(type: WalletId, deps: FlowDeps): Promise<void>
 
   try {
     setAuthState({ step: 'connecting_wallet', walletType: type });
-    const adapter = await deps.resolveWalletAdapter(type);
+    // Wrap the resolver in `withSignal` so `cancelLogin()` exits the await
+    // even if the consumer's resolver is hung (broken extension bridge,
+    // network call, etc). The resolver itself may keep running in the
+    // background — the 5s `walletResolverTimeoutMs` in `_resolveWalletAdapter`
+    // bounds that — but the flow won't block waiting for it.
+    const adapter = await withSignal(deps.resolveWalletAdapter(type), signal);
 
     const available = await withSignal(adapter.isAvailable(), signal);
     if (!available) {

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -290,6 +290,18 @@ export class PollarClient {
           } catch {
             return response;
           }
+          // Token-expired retries (post-refresh) are only safe for idempotent
+          // methods. POST/PUT/DELETE/PATCH might have already executed
+          // server-side before auth was rejected — replaying could duplicate
+          // effects (double-create a transaction, etc.). The original 401
+          // bubbles up so the caller decides; the access token is now fresh,
+          // so a manual retry by the caller will succeed. Nonce-challenge
+          // 401s don't go through this branch (server didn't process the
+          // request), so any method retries safely above.
+          const method = request.method.toUpperCase();
+          if (method !== 'GET' && method !== 'HEAD') {
+            return response;
+          }
         }
         return self._retryRequest(request);
       },

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -9,6 +9,8 @@ import { hashApiKey } from '../lib/api-key-hash';
 import { StellarNetwork } from '../stellar/StellarClient';
 import { defaultStorage } from '../storage/autodetect';
 import type { OnStorageDegrade, Storage, StorageDegradeReason } from '../storage/types';
+import { defaultVisibilityProvider } from '../visibility/autodetect';
+import type { VisibilityProvider } from '../visibility/types';
 import {
   AUTH_ERROR_CODES,
   AuthState,
@@ -53,6 +55,9 @@ import { loginWallet } from './auth/walletFlow';
 import { readStorage, readWalletType, removeStorage, sessionStorageKey, writeStorage, writeWalletType } from './session';
 
 const isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+
+/** Renew the access token this many seconds before its `exp` to absorb clock skew + signing latency. */
+const REFRESH_SKEW_SECONDS = 60;
 
 function warnServerSide(method: string): void {
   console.warn(
@@ -106,6 +111,13 @@ export class PollarClient {
   /** Optional UI label sent to the server at /auth/login so the sessions UI
    *  can show a recognizable device name. Set via PollarClientConfig.deviceLabel. */
   private readonly _deviceLabel: string | undefined;
+  private readonly _visibilityProvider: VisibilityProvider;
+  private readonly _maxIdleMs: number | undefined;
+  /** Updated by the request middleware. Read by the silent-refresh scheduler
+   *  to skip proactive refreshes after `maxIdleMs` of no HTTP activity. */
+  private _lastRequestAt: number = Date.now();
+  private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private _visibilityUnsubscribe: (() => void) | null = null;
 
   private _transactionState: TransactionState | null = null;
   private _transactionStateListeners = new Set<(state: TransactionState) => void>();
@@ -152,6 +164,8 @@ export class PollarClient {
     this._walletAdapterResolver = config.walletAdapter ?? null;
     this._walletResolverTimeoutMs = config.walletResolverTimeoutMs ?? 5000;
     this._deviceLabel = config.deviceLabel;
+    this._visibilityProvider = config.visibilityProvider ?? defaultVisibilityProvider();
+    this._maxIdleMs = config.maxIdleMs;
 
     this._api = createApiClient(this.basePath);
     this._wireMiddlewares();
@@ -200,6 +214,13 @@ export class PollarClient {
       console.warn('[PollarClient] KeyManager init failed; DPoP unavailable for this session', err);
     }
     await this._restoreSession();
+
+    // Wire after restore so the first scheduled refresh — if any — is set up
+    // by `_restoreSession` itself, and the visibility listener only fires
+    // re-checks for transitions that happen from this point forward.
+    this._visibilityUnsubscribe = this._visibilityProvider.onChange((visible) => {
+      if (visible) void this._maybeProactiveRefresh();
+    });
   }
 
   /** Detach the cross-tab storage listener and abort any in-flight login. */
@@ -210,6 +231,11 @@ export class PollarClient {
     }
     this._loginController?.abort();
     this._loginController = null;
+    this._clearRefreshTimer();
+    if (this._visibilityUnsubscribe) {
+      this._visibilityUnsubscribe();
+      this._visibilityUnsubscribe = null;
+    }
   }
 
   // ─── Middlewares (DPoP + auto-refresh) ────────────────────────────────────
@@ -225,6 +251,7 @@ export class PollarClient {
     this._api.use({
       onRequest: async ({ request }: { request: Request }) => {
         request.headers.set('x-pollar-api-key', self.apiKey);
+        self._lastRequestAt = Date.now();
         await self._initialized;
         // Cache the body before fetch() disturbs the stream — retries can't
         // call request.clone() once the body is consumed.
@@ -439,6 +466,69 @@ export class PollarClient {
         // process but won't survive reload. Don't clear — that'd surprise
         // the user with a logout for what's essentially a storage hiccup.
       }
+      this._scheduleNextRefresh();
+    }
+  }
+
+  // ─── Silent refresh scheduler ────────────────────────────────────────────────
+
+  /**
+   * Arm a single setTimeout to fire shortly before the current access token
+   * expires. Idempotent — clearing any previous timer first. Safe to call
+   * from any session-write site (initial login, restore-from-storage, after
+   * a successful rotation). No-op if there's no session in memory.
+   *
+   * Browser/RN background-tab throttling makes long-running setTimeouts
+   * unreliable on their own; the `visibilitychange` listener compensates by
+   * re-invoking `_maybeProactiveRefresh` whenever the app comes back to the
+   * foreground, catching any timer that fired late or never fired at all.
+   */
+  private _scheduleNextRefresh(): void {
+    this._clearRefreshTimer();
+    const expiresAt = this._session?.token?.expiresAt;
+    if (typeof expiresAt !== 'number') return;
+    const dueInMs = Math.max(0, (expiresAt - Math.floor(Date.now() / 1000) - REFRESH_SKEW_SECONDS) * 1000);
+    this._refreshTimer = setTimeout(() => {
+      void this._maybeProactiveRefresh();
+    }, dueInMs);
+  }
+
+  /**
+   * Decide whether to actually run a refresh right now. Called both from the
+   * scheduler timer and from the visibility-change listener.
+   *
+   * Skip if:
+   *   - no session / no RT (nothing to refresh)
+   *   - app is hidden — wait for the visibility listener to re-trigger us
+   *   - `maxIdleMs` configured and no client request since that window — let
+   *     the next reactive 401-refresh handle it whenever the user comes back
+   *   - the AT still has more than `REFRESH_SKEW_SECONDS` of life — reschedule
+   *
+   * Otherwise call `refresh()`, which uses the existing in-flight singleton
+   * so we never collide with a reactive 401-triggered refresh. On failure,
+   * `_doRefresh` already calls `_clearSession`, so auth-state listeners see
+   * `step:'idle'` — no extra event dispatch needed here.
+   */
+  private async _maybeProactiveRefresh(): Promise<void> {
+    if (!this._session?.token?.refreshToken) return;
+    if (!this._visibilityProvider.isVisible()) return;
+    if (this._maxIdleMs !== undefined && Date.now() - this._lastRequestAt > this._maxIdleMs) return;
+    const expiresAt = this._session.token.expiresAt;
+    if (Math.floor(Date.now() / 1000) < expiresAt - REFRESH_SKEW_SECONDS) {
+      this._scheduleNextRefresh();
+      return;
+    }
+    try {
+      await this.refresh();
+    } catch (err) {
+      console.warn('[PollarClient] Proactive refresh failed; session cleared', err);
+    }
+  }
+
+  private _clearRefreshTimer(): void {
+    if (this._refreshTimer !== null) {
+      clearTimeout(this._refreshTimer);
+      this._refreshTimer = null;
     }
   }
 
@@ -1336,6 +1426,7 @@ export class PollarClient {
       // _authState would race past any onAuthStateChange subscription that
       // hasn't run yet (e.g. PollarProvider's useEffect).
       this._setAuthState({ step: 'authenticated', session: this._session });
+      this._scheduleNextRefresh();
     } else {
       console.info('[PollarClient] No session in storage');
     }
@@ -1367,10 +1458,12 @@ export class PollarClient {
 
     await writeStorage(this._storage, this.apiKeyHash, persisted);
     this._setAuthState({ step: 'authenticated', session: persisted });
+    this._scheduleNextRefresh();
   }
 
   private async _clearSession(): Promise<void> {
     console.info('[PollarClient] Session cleared');
+    this._clearRefreshTimer();
     this._session = null;
     this._profile = null;
     this._walletAdapter = null;

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -1384,10 +1384,7 @@ export class PollarClient {
       this._setAuthState({ step: 'idle' });
       return;
     }
-    if (
-      error instanceof Error &&
-      (error as { code?: string }).code === AUTH_ERROR_CODES.WALLET_RESOLVER_TIMEOUT
-    ) {
+    if (error instanceof Error && (error as { code?: string }).code === AUTH_ERROR_CODES.WALLET_RESOLVER_TIMEOUT) {
       console.error('[PollarClient]', error.message);
       this._setAuthState({
         step: 'error',

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -129,6 +129,7 @@ export class PollarClient {
 
   private _walletAdapter: WalletAdapter | null = null;
   private readonly _walletAdapterResolver: WalletAdapterResolver | null;
+  private readonly _walletResolverTimeoutMs: number;
   private _loginController: AbortController | null = null;
 
   constructor(config: PollarClientConfig) {
@@ -149,6 +150,7 @@ export class PollarClient {
       });
     this._keyManager = config.keyManager ?? defaultKeyManager(this._storage, config.apiKey);
     this._walletAdapterResolver = config.walletAdapter ?? null;
+    this._walletResolverTimeoutMs = config.walletResolverTimeoutMs ?? 5000;
     this._deviceLabel = config.deviceLabel;
 
     this._api = createApiClient(this.basePath);
@@ -1276,7 +1278,27 @@ export class PollarClient {
    */
   private async _resolveWalletAdapter(id: WalletId): Promise<WalletAdapter> {
     if (this._walletAdapterResolver) {
-      return Promise.resolve(this._walletAdapterResolver(id));
+      // Race the resolver against a timeout. A broken extension bridge can
+      // leave `walletAdapterResolver()` pending forever; without this the
+      // entire login flow would hang with no signal to the consumer. The
+      // resolver only constructs the adapter object (not the user-facing
+      // approval), so 5s is generous.
+      const timeoutMs = this._walletResolverTimeoutMs;
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(
+            Object.assign(new Error(`[PollarClient] Wallet adapter resolver for "${id}" timed out after ${timeoutMs}ms`), {
+              code: AUTH_ERROR_CODES.WALLET_RESOLVER_TIMEOUT,
+            }),
+          );
+        }, timeoutMs);
+      });
+      try {
+        return await Promise.race([Promise.resolve(this._walletAdapterResolver(id)), timeoutPromise]);
+      } finally {
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      }
     }
     if (id === WalletType.FREIGHTER) return new FreighterAdapter();
     if (id === WalletType.ALBEDO) return new AlbedoAdapter();
@@ -1289,6 +1311,19 @@ export class PollarClient {
     if (error instanceof Error && error.name === 'AbortError') {
       console.info('[PollarClient] Login cancelled');
       this._setAuthState({ step: 'idle' });
+      return;
+    }
+    if (
+      error instanceof Error &&
+      (error as { code?: string }).code === AUTH_ERROR_CODES.WALLET_RESOLVER_TIMEOUT
+    ) {
+      console.error('[PollarClient]', error.message);
+      this._setAuthState({
+        step: 'error',
+        previousStep: this._authState.step,
+        message: error.message,
+        errorCode: AUTH_ERROR_CODES.WALLET_RESOLVER_TIMEOUT,
+      });
       return;
     }
     console.error('[PollarClient] Unexpected error in auth flow', error);

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -6,7 +6,7 @@ import { buildProof } from '../dpop';
 import { defaultKeyManager } from '../keys/factory';
 import type { KeyManager } from '../keys/types';
 import { hashApiKey } from '../lib/api-key-hash';
-import { StellarClient, StellarNetwork } from '../stellar/StellarClient';
+import { StellarNetwork } from '../stellar/StellarClient';
 import { defaultStorage } from '../storage/autodetect';
 import type { OnStorageDegrade, Storage, StorageDegradeReason } from '../storage/types';
 import {
@@ -892,16 +892,18 @@ export class PollarClient {
   }
 
   /**
-   * Submits a signed XDR.
+   * Submits a signed XDR via `/tx/submit` regardless of wallet type
+   * (custodial or external). Routing through sdk-api gives us:
+   *   - End-to-end tx_records persistence with full phase lifecycle so the
+   *     developer dashboard can show every tx (both custodial and external
+   *     wallet flows) at `/apps/:id/monitor/transactions`.
+   *   - Idempotency tracking via `submissionToken` (returned by `signTx`).
+   *   - A single response shape (SUCCESS / PENDING / FAILED) shared by both
+   *     flows — previously external wallets could only return SUCCESS or
+   *     error since the direct-to-Horizon path was synchronous.
    *
-   * - External wallets: submits directly to Stellar via the public RPC. No
-   *   backend involvement, lowest latency. Cannot return `pending` — the RPC
-   *   call is synchronous, so the outcome is either `success` or `error`.
-   * - Custodial wallets: submits via `/tx/submit` so the wallet-service
-   *   tracks the tx lifecycle and enforces idempotency. Pass the
-   *   `submissionToken` returned by `signTx` to reuse the same idempotency
-   *   key end-to-end. May return `pending` if the network ack'd but ledger
-   *   confirmation hasn't arrived before the SDK's poll window expires.
+   * The extra hop adds ~50–150 ms vs. the legacy direct-Horizon path; the
+   * persistence + observability win is worth it.
    *
    * Drives `_setTransactionState`: emits `submitting` while in flight,
    * `submitted` on Horizon ack (pending), `success` on ledger confirmation,
@@ -912,39 +914,6 @@ export class PollarClient {
     const outcomeExtra: { buildData?: TxBuildContent } = buildData ? { buildData } : {};
     this._setTransactionState({ step: 'submitting', signedXdr, ...(buildData && { buildData }) });
 
-    if (this._walletAdapter) {
-      try {
-        const stellarClient = new StellarClient(this.getNetwork());
-        const result = await stellarClient.submitTransaction(signedXdr);
-        if (result.success) {
-          this._setTransactionState({ step: 'success', hash: result.hash, ...(buildData && { buildData }) });
-          return { status: 'success', hash: result.hash, ...outcomeExtra };
-        }
-        this._setTransactionState({
-          step: 'error',
-          phase: 'submitting',
-          ...(buildData && { buildData }),
-          details: result.errorCode,
-        });
-        return {
-          status: 'error',
-          details: result.errorCode,
-          resultCode: result.errorCode,
-          ...outcomeExtra,
-        };
-      } catch (err) {
-        const details = err instanceof Error ? err.message : undefined;
-        this._setTransactionState({
-          step: 'error',
-          phase: 'submitting',
-          ...(buildData && { buildData }),
-          ...(details && { details }),
-        });
-        return { status: 'error', ...outcomeExtra, ...(details && { details }) };
-      }
-    }
-
-    // Custodial path
     const publicKey = this._session?.wallet?.publicKey ?? '';
     try {
       const { data, error } = await this._api.POST('/tx/submit', {

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -8,7 +8,7 @@ import type { KeyManager } from '../keys/types';
 import { hashApiKey } from '../lib/api-key-hash';
 import { StellarClient, StellarNetwork } from '../stellar/StellarClient';
 import { defaultStorage } from '../storage/autodetect';
-import type { Storage } from '../storage/types';
+import type { OnStorageDegrade, Storage, StorageDegradeReason } from '../storage/types';
 import {
   AUTH_ERROR_CODES,
   AuthState,
@@ -117,6 +117,15 @@ export class PollarClient {
   private _authStateListeners = new Set<(state: AuthState) => void>();
   private _networkState: NetworkState = { step: 'idle' };
   private _networkStateListeners = new Set<(state: NetworkState) => void>();
+  /**
+   * Latched once the storage adapter degrades. We dedupe (the adapter only
+   * fires once anyway) and use it to replay state to late-subscribers — same
+   * pattern as `onAuthStateChange` replaying `_authState` on subscribe.
+   * Only populated when the SDK constructed the default storage adapter; if
+   * the consumer passes `config.storage`, they own degradation notifications.
+   */
+  private _storageDegraded: { reason: StorageDegradeReason; error?: unknown } | null = null;
+  private _storageDegradeListeners = new Set<OnStorageDegrade>();
 
   private _walletAdapter: WalletAdapter | null = null;
   private readonly _walletAdapterResolver: WalletAdapterResolver | null;
@@ -128,7 +137,16 @@ export class PollarClient {
     this.basePath = `${config.baseUrl || 'https://sdk.api.pollar.xyz'}/v1`;
 
     this._storage =
-      config.storage ?? defaultStorage(config.onStorageDegrade ? { onDegrade: config.onStorageDegrade } : undefined);
+      config.storage ??
+      defaultStorage({
+        onDegrade: (reason, error) => {
+          // Forward to the legacy one-shot callback (back-compat) and to any
+          // subscribers added via `client.onStorageDegrade(cb)`. Both fire
+          // exactly once because the underlying adapter dedupes.
+          config.onStorageDegrade?.(reason, error);
+          this._dispatchStorageDegrade(reason, error);
+        },
+      });
     this._keyManager = config.keyManager ?? defaultKeyManager(this._storage, config.apiKey);
     this._walletAdapterResolver = config.walletAdapter ?? null;
     this._deviceLabel = config.deviceLabel;
@@ -420,6 +438,40 @@ export class PollarClient {
     this._authStateListeners.add(cb);
     cb(this._authState);
     return () => this._authStateListeners.delete(cb);
+  }
+
+  /**
+   * Subscribe to persistent-storage degradation (Safari private mode,
+   * sandboxed iframes, quota errors, etc.). The SDK keeps running off
+   * in-memory storage after degrade, but sessions won't survive reload — a
+   * host UI typically wants to show "your session won't be saved" so the
+   * user isn't blindsided after a refresh.
+   *
+   * Fires at most once per client lifetime (the underlying adapter dedupes).
+   * Late subscribers receive the latched state synchronously on subscribe.
+   *
+   * Only fires when the SDK constructs the default storage adapter. If you
+   * pass a custom `config.storage`, wire your own notification path through
+   * that adapter's API — the SDK has no hook into it.
+   */
+  onStorageDegrade(cb: OnStorageDegrade): () => void {
+    this._storageDegradeListeners.add(cb);
+    if (this._storageDegraded) {
+      cb(this._storageDegraded.reason, this._storageDegraded.error);
+    }
+    return () => this._storageDegradeListeners.delete(cb);
+  }
+
+  private _dispatchStorageDegrade(reason: StorageDegradeReason, error?: unknown): void {
+    if (this._storageDegraded) return;
+    this._storageDegraded = { reason, error };
+    for (const cb of this._storageDegradeListeners) {
+      try {
+        cb(reason, error);
+      } catch (err) {
+        console.error('[PollarClient] onStorageDegrade listener threw', err);
+      }
+    }
   }
 
   /** PII (email, names, avatar, providers). Held in memory only — never persisted. */

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -195,6 +195,12 @@ export class PollarClient {
   // ─── Middlewares (DPoP + auto-refresh) ────────────────────────────────────
 
   private _wireMiddlewares(): void {
+    // Aliasing `this` is deliberate: every middleware callback below is an
+    // arrow function so `this` would resolve correctly, but the file reads
+    // significantly easier with one stable name across ~150 lines of
+    // request/response/refresh interleaving. Don't refactor without
+    // re-running the smoke tests for refresh coalescing + DPoP nonce flow.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     this._api.use({
       onRequest: async ({ request }: { request: Request }) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import { pollarPaths, StellarNetwork } from './index';
 import type { KeyManager } from './keys/types';
 import type { OnStorageDegrade, Storage } from './storage/types';
+import type { VisibilityProvider } from './visibility/types';
 import { WalletAdapterResolver, WalletId } from './wallets';
 
 export type PollarApplicationConfigResponse =
@@ -79,6 +80,25 @@ export interface PollarClientConfig {
    * If unset, the server-recorded `user_agent` header is the fallback.
    */
   deviceLabel?: string;
+  /**
+   * Foreground-detection signal for the silent-refresh scheduler. When the
+   * app is hidden / backgrounded, scheduled refreshes are skipped (saves
+   * network + sidesteps browser/RN background timer throttling); they run
+   * the moment visibility comes back. Defaults to a web provider in the
+   * browser (`visibilitychange` + BFCache + focus) and a noop elsewhere.
+   * React Native consumers should inject an `AppState`-backed provider —
+   * see TODO on `VisibilityProvider`.
+   */
+  visibilityProvider?: VisibilityProvider;
+  /**
+   * If set, the silent-refresh scheduler stops issuing proactive refreshes
+   * after this many milliseconds of no client-side HTTP activity. The
+   * session is not cleared — the next user action triggers a request that
+   * either reuses a still-valid access token or hits 401 → reactive
+   * refresh (transparent if the RT is still valid). Defaults to
+   * `undefined` = refresh forever as long as the app is visible.
+   */
+  maxIdleMs?: number;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,6 +65,14 @@ export interface PollarClientConfig {
    */
   walletAdapter?: WalletAdapterResolver;
   /**
+   * Maximum time (ms) the SDK waits for a `walletAdapter` resolver to return.
+   * Guards against a broken extension bridge (e.g. Freighter content-script
+   * down) hanging the login flow forever. The resolver only constructs the
+   * adapter object — it does NOT include the user-facing approval step — so
+   * a few seconds is plenty. Defaults to 5000.
+   */
+  walletResolverTimeoutMs?: number;
+  /**
    * Optional human-friendly label sent at /auth/login time and recorded on
    * the server-side refresh-token row so the user can identify it in the
    * "active sessions" UI (e.g. "iPhone — Safari", "Mac — Chrome 126").
@@ -194,6 +202,7 @@ export const AUTH_ERROR_CODES = {
   AUTH_FAILED: 'AUTH_FAILED',
   WALLET_CONNECT_FAILED: 'WALLET_CONNECT_FAILED',
   WALLET_AUTH_FAILED: 'WALLET_AUTH_FAILED',
+  WALLET_RESOLVER_TIMEOUT: 'WALLET_RESOLVER_TIMEOUT',
   UNEXPECTED_ERROR: 'UNEXPECTED_ERROR',
 } as const;
 

--- a/packages/core/src/visibility/autodetect.ts
+++ b/packages/core/src/visibility/autodetect.ts
@@ -1,0 +1,16 @@
+import { createNoopVisibilityProvider } from './noop';
+import type { VisibilityProvider } from './types';
+import { createWebVisibilityProvider } from './web';
+
+/**
+ * Picks a `VisibilityProvider` based on the runtime: browser → web provider,
+ * anything else → noop. React Native consumers should pass an `AppState`-
+ * backed provider explicitly via `PollarClientConfig.visibilityProvider`
+ * (see the TODO in `./types.ts`).
+ */
+export function defaultVisibilityProvider(): VisibilityProvider {
+  if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    return createWebVisibilityProvider();
+  }
+  return createNoopVisibilityProvider();
+}

--- a/packages/core/src/visibility/noop.ts
+++ b/packages/core/src/visibility/noop.ts
@@ -1,0 +1,13 @@
+import type { VisibilityProvider } from './types';
+
+/**
+ * Always-visible provider with no event subscriptions. Used for SSR / Node
+ * contexts where the silent-refresh scheduler should not be gated by a
+ * non-existent foreground signal. Also useful in tests.
+ */
+export function createNoopVisibilityProvider(): VisibilityProvider {
+  return {
+    isVisible: () => true,
+    onChange: () => () => {},
+  };
+}

--- a/packages/core/src/visibility/types.ts
+++ b/packages/core/src/visibility/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Pluggable "is the user looking at this app right now?" signal.
+ *
+ * Used by the silent-refresh scheduler so token renewals are skipped while
+ * the tab is hidden / the app is backgrounded — both saves network and
+ * works around aggressive `setTimeout` throttling that web browsers and RN
+ * apply to non-foreground contexts.
+ *
+ * Default web implementation listens to `visibilitychange` plus
+ * `pageshow`/`pagehide` (covers BFCache on iOS) and `focus`/`blur` (covers
+ * the cases where `visibilitychange` lags). Default for non-browser
+ * environments is a noop that always reports "visible".
+ *
+ * TODO(@pollar/react-native): when the dedicated RN package ships, it will
+ * export an `AppState`-backed provider. Until then, RN consumers can wire
+ * one inline:
+ *
+ *   import { AppState } from 'react-native';
+ *   const rnVisibility = {
+ *     isVisible: () => AppState.currentState === 'active',
+ *     onChange: (cb) => {
+ *       const sub = AppState.addEventListener('change', (s) => cb(s === 'active'));
+ *       return () => sub.remove();
+ *     },
+ *   };
+ *   new PollarClient({ apiKey, visibilityProvider: rnVisibility });
+ */
+export interface VisibilityProvider {
+  isVisible(): boolean;
+  /**
+   * Subscribe to visibility transitions. The callback receives the new
+   * visibility state (`true` = visible). Returns an unsubscribe function
+   * that must detach every listener registered by this call.
+   */
+  onChange(cb: (visible: boolean) => void): () => void;
+}

--- a/packages/core/src/visibility/web.ts
+++ b/packages/core/src/visibility/web.ts
@@ -16,8 +16,7 @@ import type { VisibilityProvider } from './types';
  * dispatched state — listeners only see real transitions.
  */
 export function createWebVisibilityProvider(): VisibilityProvider {
-  const isVisibleNow = (): boolean =>
-    typeof document === 'undefined' || document.visibilityState === 'visible';
+  const isVisibleNow = (): boolean => typeof document === 'undefined' || document.visibilityState === 'visible';
 
   return {
     isVisible: isVisibleNow,

--- a/packages/core/src/visibility/web.ts
+++ b/packages/core/src/visibility/web.ts
@@ -1,0 +1,50 @@
+import type { VisibilityProvider } from './types';
+
+/**
+ * Browser-backed visibility signal.
+ *
+ * Listens to three event sources because no single one is reliable on every
+ * browser:
+ *   - `visibilitychange` is the canonical signal but lags on Safari macOS
+ *     when switching between windows of the same app.
+ *   - `pageshow` / `pagehide` fire when the page enters/leaves BFCache on
+ *     iOS Safari — `visibilitychange` does not.
+ *   - `focus` / `blur` on window catch the macOS Safari multi-window case
+ *     and are also the most-likely-to-fire signal on older browsers.
+ *
+ * Duplicate notifications are filtered by comparing against the last
+ * dispatched state — listeners only see real transitions.
+ */
+export function createWebVisibilityProvider(): VisibilityProvider {
+  const isVisibleNow = (): boolean =>
+    typeof document === 'undefined' || document.visibilityState === 'visible';
+
+  return {
+    isVisible: isVisibleNow,
+    onChange: (cb) => {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return () => {};
+      }
+      let last = isVisibleNow();
+      const handler = (): void => {
+        const next = isVisibleNow();
+        if (next !== last) {
+          last = next;
+          cb(next);
+        }
+      };
+      document.addEventListener('visibilitychange', handler);
+      window.addEventListener('pageshow', handler);
+      window.addEventListener('pagehide', handler);
+      window.addEventListener('focus', handler);
+      window.addEventListener('blur', handler);
+      return () => {
+        document.removeEventListener('visibilitychange', handler);
+        window.removeEventListener('pageshow', handler);
+        window.removeEventListener('pagehide', handler);
+        window.removeEventListener('focus', handler);
+        window.removeEventListener('blur', handler);
+      };
+    },
+  };
+}

--- a/packages/privy-adapter/README.md
+++ b/packages/privy-adapter/README.md
@@ -1,5 +1,7 @@
 # @pollar/privy-adapter
 
+> **⚠️ Server-side only.** This package starts an HTTP server with `@hono/node-server` and reads `PRIVY_APP_SECRET` / `POLLAR_API_SECRET` from the host environment. Importing it in a browser, React Native, or any other client-side bundle will leak credentials. The bundler will also blow up on `node:crypto` / `@hono/node-server`. If you need a browser-side Privy integration, use the Privy client SDK directly — not this package.
+
 Stateless HTTP proxy that lets Pollar sign Stellar transactions through your Privy account, without your Privy `APP_SECRET` ever leaving your infrastructure.
 
 You install this package in **your own backend**, point Pollar at your adapter's URL, and it brokers each call to Privy on demand. The adapter holds no state, has no database, and exposes a small set of HTTP endpoints authenticated with a single Bearer token issued by Pollar.

--- a/packages/privy-adapter/package.json
+++ b/packages/privy-adapter/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",
-    "@privy-io/node": "^0.18.0",
+    "@privy-io/node": "~0.18.0",
     "@stellar/stellar-sdk": "^15.0.0",
     "hono": "^4.12.3",
     "lru-cache": "^11.0.2",

--- a/packages/privy-adapter/package.json
+++ b/packages/privy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/privy-adapter",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Stateless HTTP proxy that lets Pollar sign Stellar transactions through your Privy account, without your Privy app secret leaving your infrastructure.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/privy-adapter/src/index.ts
+++ b/packages/privy-adapter/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * @pollar/privy-adapter — SERVER-SIDE ONLY.
+ *
+ * This package binds an HTTP listener via `@hono/node-server` and consumes
+ * `PRIVY_APP_SECRET` + `POLLAR_API_SECRET` from the host environment. Do not
+ * import it in a browser bundle, a React Native app, or any other client-side
+ * runtime — credentials would leak and `node:*` imports would fail to bundle.
+ */
 import { serve } from '@hono/node-server';
 import { LRUCache } from 'lru-cache';
 import { createApp } from './server';

--- a/packages/privy-adapter/src/privy.ts
+++ b/packages/privy-adapter/src/privy.ts
@@ -10,6 +10,11 @@ interface CacheEntry {
 
 export const createPrivyClientFactory = (config: ResolvedAdapterConfig) => {
   let entry: CacheEntry | null = null;
+  // Coalesce concurrent expired-cache calls. Without this, two requests
+  // arriving while `entry` is null/expired would each call
+  // `config.getCredentials()` and `new PrivyClient(...)`, with the second
+  // overwriting the first — wasted creds fetch + an orphaned client.
+  let pending: Promise<PrivyClient> | null = null;
 
   return async (): Promise<PrivyClient> => {
     const now = Date.now();
@@ -18,17 +23,27 @@ export const createPrivyClientFactory = (config: ResolvedAdapterConfig) => {
       return entry.client;
     }
 
-    const { appId, appSecret } = await config.getCredentials();
-    const fingerprint = createHash('sha256').update(`${appId}:${appSecret}`).digest('hex');
+    if (pending) return pending;
 
-    if (entry && entry.fingerprint === fingerprint) {
-      // Credentials unchanged — extend TTL, keep client to avoid reconnect overhead.
-      entry.expiresAt = now + config.cacheTtlMs;
-      return entry.client;
-    }
+    pending = (async () => {
+      try {
+        const { appId, appSecret } = await config.getCredentials();
+        const fingerprint = createHash('sha256').update(`${appId}:${appSecret}`).digest('hex');
 
-    const client = new PrivyClient({ appId, appSecret, timeout: config.requestTimeoutMs });
-    entry = { fingerprint, client, expiresAt: now + config.cacheTtlMs };
-    return client;
+        if (entry && entry.fingerprint === fingerprint) {
+          // Credentials unchanged — extend TTL, keep client to avoid reconnect overhead.
+          entry.expiresAt = Date.now() + config.cacheTtlMs;
+          return entry.client;
+        }
+
+        const client = new PrivyClient({ appId, appSecret, timeout: config.requestTimeoutMs });
+        entry = { fingerprint, client, expiresAt: Date.now() + config.cacheTtlMs };
+        return client;
+      } finally {
+        pending = null;
+      }
+    })();
+
+    return pending;
   };
 };

--- a/packages/privy-adapter/src/routes/wallets-address.ts
+++ b/packages/privy-adapter/src/routes/wallets-address.ts
@@ -28,8 +28,9 @@ export const createWalletsAddressRoute = (deps: AdapterDeps) => {
       return c.var.content(SuccessCode.PRIVY_ADAPTER_WALLET_ADDRESS, { address: wallet.address });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      // Raw error to `onError` (server-side logs); HTTP response is code-only.
       deps.config.onError?.(err, { endpoint: `GET /wallets/${userId}/address`, body: null });
-      return c.var.error(ErrorCode.WALLET_LOOKUP_FAILED, 502, { reason: err.message });
+      return c.var.error(ErrorCode.WALLET_LOOKUP_FAILED, 502);
     }
   });
 

--- a/packages/privy-adapter/src/routes/wallets-create.ts
+++ b/packages/privy-adapter/src/routes/wallets-create.ts
@@ -57,8 +57,10 @@ export const createWalletsCreateRoute = (deps: AdapterDeps) => {
       return c.var.content(SuccessCode.PRIVY_ADAPTER_WALLET_EXISTS, { address: stellar.address });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      // Raw error to `onError` (server-side logs); HTTP response is code-only
+      // so Privy internals don't leak to the caller.
       deps.config.onError?.(err, { endpoint: 'POST /wallets/create', body: parsed });
-      return c.var.error(ErrorCode.WALLET_CREATION_FAILED, 502, { reason: err.message });
+      return c.var.error(ErrorCode.WALLET_CREATION_FAILED, 502);
     }
   });
 

--- a/packages/privy-adapter/src/routes/wallets-create.ts
+++ b/packages/privy-adapter/src/routes/wallets-create.ts
@@ -11,6 +11,23 @@ const BodySchema = z.object({
 export const createWalletsCreateRoute = (deps: AdapterDeps) => {
   const app = new Hono<AppEnv>();
 
+  /**
+   * In-process dedupe of concurrent create requests for the same userId.
+   *
+   * `getOrCreatePrivyUser` already handles the user-creation race (Privy
+   * returns `ConflictError` on the second `users.create`, we fall back to
+   * fetch). But for an EXISTING user without a stellar wallet, both
+   * requests fall through `findStellarWalletInUser → null` and both call
+   * `wallets().create(...)` — Privy doesn't dedupe by user, so you get two
+   * stellar wallets attached to the same Privy user, with the second
+   * overwriting the first in `walletCache`.
+   *
+   * The mutex is per-process: scaling the adapter to N replicas reintroduces
+   * the race across instances. That's an accepted trade-off — the adapter is
+   * documented as stateless beyond in-memory caches.
+   */
+  const inflight = new Map<string, Promise<{ address: string; walletCreated: boolean }>>();
+
   app.post('/', async (c) => {
     let parsed: z.infer<typeof BodySchema>;
     try {
@@ -24,37 +41,54 @@ export const createWalletsCreateRoute = (deps: AdapterDeps) => {
     const { userId } = parsed;
 
     try {
-      const privy = await deps.getPrivy();
+      let promise = inflight.get(userId);
+      if (!promise) {
+        promise = (async () => {
+          try {
+            const privy = await deps.getPrivy();
 
-      // Privy's API requires owner.user_id to be a did:privy: identifier, not
-      // Pollar's SDK user CUID. We resolve (or create) the Privy user via
-      // custom_auth linked_accounts; users.create returns the wallet inline.
-      const { user, created } = await getOrCreatePrivyUser(privy, userId, {
-        ensureStellarWallet: true,
-        timeoutMs: deps.config.requestTimeoutMs,
-      });
+            // Privy's API requires owner.user_id to be a did:privy: identifier, not
+            // Pollar's SDK user CUID. We resolve (or create) the Privy user via
+            // custom_auth linked_accounts; users.create returns the wallet inline.
+            const { user, created } = await getOrCreatePrivyUser(privy, userId, {
+              ensureStellarWallet: true,
+              timeoutMs: deps.config.requestTimeoutMs,
+            });
 
-      let stellar = findStellarWalletInUser(user);
-      let walletCreated = created && stellar !== null;
+            let stellar = findStellarWalletInUser(user);
+            let walletCreated = created && stellar !== null;
 
-      // Existing user with no stellar wallet (pre-stellar account, or wallet
-      // detached). Provision one now, owned by the resolved DID.
-      if (!stellar) {
-        const wallet = await withTimeout(
-          privy.wallets().create({ chain_type: 'stellar', owner: { user_id: user.id } }),
-          deps.config.requestTimeoutMs,
-        );
-        stellar = { id: wallet.id, address: wallet.address };
-        walletCreated = true;
+            // Existing user with no stellar wallet (pre-stellar account, or wallet
+            // detached). Provision one now, owned by the resolved DID.
+            if (!stellar) {
+              const wallet = await withTimeout(
+                privy.wallets().create({ chain_type: 'stellar', owner: { user_id: user.id } }),
+                deps.config.requestTimeoutMs,
+              );
+              stellar = { id: wallet.id, address: wallet.address };
+              walletCreated = true;
+            }
+
+            deps.walletCache.set(stellar.address, stellar.id);
+            // Fire `onWalletCreated` inside the de-duplicated block so it
+            // emits exactly once per actual creation, not once per coalesced
+            // request awaiter.
+            if (walletCreated) {
+              deps.config.onWalletCreated?.(userId, stellar.address);
+            }
+            return { address: stellar.address, walletCreated };
+          } finally {
+            inflight.delete(userId);
+          }
+        })();
+        inflight.set(userId, promise);
       }
 
-      deps.walletCache.set(stellar.address, stellar.id);
-
+      const { address, walletCreated } = await promise;
       if (walletCreated) {
-        deps.config.onWalletCreated?.(userId, stellar.address);
-        return c.var.content(SuccessCode.PRIVY_ADAPTER_WALLET_CREATED, { address: stellar.address }, 201);
+        return c.var.content(SuccessCode.PRIVY_ADAPTER_WALLET_CREATED, { address }, 201);
       }
-      return c.var.content(SuccessCode.PRIVY_ADAPTER_WALLET_EXISTS, { address: stellar.address });
+      return c.var.content(SuccessCode.PRIVY_ADAPTER_WALLET_EXISTS, { address });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       // Raw error to `onError` (server-side logs); HTTP response is code-only

--- a/packages/privy-adapter/src/routes/wallets-sign.ts
+++ b/packages/privy-adapter/src/routes/wallets-sign.ts
@@ -81,8 +81,12 @@ export const createWalletsSignRoute = (deps: AdapterDeps) => {
       return c.var.content(SuccessCode.PRIVY_ADAPTER_TX_SIGNED, { signedTxXdr });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      // Raw error goes to the host's `onError` callback for server-side logging
+      // (Privy SDK errors can include user IDs, rate-limit context, internal
+      // identifiers — none of which the caller should see). The HTTP response
+      // is intentionally code-only.
       deps.config.onError?.(err, { endpoint: 'POST /wallets/sign', body: parsed });
-      return c.var.error(ErrorCode.TX_SIGN_FAILED, 502, { reason: err.message });
+      return c.var.error(ErrorCode.TX_SIGN_FAILED, 502);
     }
   });
 

--- a/packages/privy-adapter/src/routes/wallets-sign.ts
+++ b/packages/privy-adapter/src/routes/wallets-sign.ts
@@ -66,10 +66,23 @@ export const createWalletsSignRoute = (deps: AdapterDeps) => {
       const privy = await deps.getPrivy();
       const hashHex = '0x' + tx.hash().toString('hex');
 
-      const result = await withTimeout(
-        privy.wallets().rawSign(walletId, { params: { hash: hashHex } }),
-        deps.config.requestTimeoutMs,
-      );
+      let result;
+      try {
+        result = await withTimeout(
+          privy.wallets().rawSign(walletId, { params: { hash: hashHex } }),
+          deps.config.requestTimeoutMs,
+        );
+      } catch (err) {
+        // Cache may have a stale walletId (wallet detached / deleted on
+        // Privy side between resolution and now). Evict so the next request
+        // re-resolves from Privy — this request still fails, but we don't
+        // keep returning errors for the same stale entry until TTL expires.
+        if (err instanceof NotFoundError) {
+          deps.walletCache.delete(walletAddress);
+          return c.var.error(ErrorCode.WALLET_NOT_FOUND, 404);
+        }
+        throw err;
+      }
 
       const sigHex = result.signature.startsWith('0x') ? result.signature.slice(2) : result.signature;
       const sigBytes = Buffer.from(sigHex, 'hex');

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -99,12 +99,12 @@ Context provider that initialises the Pollar client and makes it available to ch
 </PollarProvider>
 ```
 
-| Prop        | Type                                | Required | Description                                                                                                                                                                                              |
-| ----------- | ----------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`    | `PollarClient \| PollarClientConfig` | Yes      | Either a pre-built `PollarClient` (testing, reuse outside React) or a `PollarClientConfig` the provider will construct one from. **Locked at first render** — swapping after mount is ignored            |
-| `appConfig` | `PollarConfig`                       | No       | Local override of `/applications/config`. **Presence is the opt-out switch**: pass it (even `{}`) and the remote fetch is skipped. Omit it to keep the existing remote-fetch-on-mount behaviour          |
-| `ui`        | `{ renderWallets?: RenderWalletsSlot }` | No    | UI customisation slots. `renderWallets` replaces the default Freighter/Albedo buttons in `LoginModal`'s wallet picker. Receives `{ onConnect, authState }` and is expected to call `onConnect(walletId)` |
-| `adapters`  | `PollarAdapters`                     | No       | Named set of `PollarAdapter` objects (e.g. Trustless Work). See below                                                                                                                                    |
+| Prop        | Type                                    | Required | Description                                                                                                                                                                                              |
+| ----------- | --------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`    | `PollarClient \| PollarClientConfig`    | Yes      | Either a pre-built `PollarClient` (testing, reuse outside React) or a `PollarClientConfig` the provider will construct one from. **Locked at first render** — swapping after mount is ignored            |
+| `appConfig` | `PollarConfig`                          | No       | Local override of `/applications/config`. **Presence is the opt-out switch**: pass it (even `{}`) and the remote fetch is skipped. Omit it to keep the existing remote-fetch-on-mount behaviour          |
+| `ui`        | `{ renderWallets?: RenderWalletsSlot }` | No       | UI customisation slots. `renderWallets` replaces the default Freighter/Albedo buttons in `LoginModal`'s wallet picker. Receives `{ onConnect, authState }` and is expected to call `onConnect(walletId)` |
+| `adapters`  | `PollarAdapters`                        | No       | Named set of `PollarAdapter` objects (e.g. Trustless Work). See below                                                                                                                                    |
 
 > **Renamed in 0.8.0** — `config` → `client`, `styles` → `appConfig.styles`.
 > If you were passing `styles={{ ... }}` directly, move it to

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,8 +3,13 @@
 React bindings for [Pollar](https://pollar.xyz) — drop-in authentication UI, transaction modals, and hooks for
 Stellar-based applications.
 
-> **0.7.0 is a breaking change.** The context's session is now `PollarPersistedSession | null` and PII has moved to
-> `client.getUserProfile()`. Read the [CHANGELOG](../../CHANGELOG.md) before upgrading.
+> **0.8.0 reshapes `<PollarProvider>` props (breaking).** `config` → `client`
+> (now accepts a `PollarClient` instance or a `PollarClientConfig`); `styles`
+> moves under `appConfig.styles`; new `appConfig` prop is the opt-out switch
+> for the remote `/applications/config` fetch (pass it — even `{}` — to skip
+> the fetch); new `ui.renderWallets` slot replaces the default Freighter/Albedo
+> picker. Read the [CHANGELOG](../../CHANGELOG.md) and
+> [UPGRADE.md](../../UPGRADE.md) before upgrading.
 
 ## Installation
 
@@ -27,7 +32,7 @@ import { PollarProvider } from '@pollar/react';
 import '@pollar/react/styles.css';
 
 export default function App({ children }: { children: React.ReactNode }) {
-  return <PollarProvider config={{ apiKey: 'your-api-key' }}>{children}</PollarProvider>;
+  return <PollarProvider client={{ apiKey: 'your-api-key' }}>{children}</PollarProvider>;
 }
 ```
 
@@ -62,22 +67,28 @@ Context provider that initialises the Pollar client and makes it available to ch
 
 ```tsx
 <PollarProvider
-  config={{
+  client={{
     apiKey: 'your-api-key',
     baseUrl: 'https://sdk.api.pollar.xyz', // optional
     stellarNetwork: 'testnet', // optional, default: 'testnet'
-    // 0.7.0 options threaded straight through to PollarClient:
     storage, // optional, RN apps inject this
     keyManager, // optional, autodetects on web
     walletAdapter, // optional, external wallet stack
     deviceLabel: 'iPhone — Safari', // optional, shown in SessionsModal
     onStorageDegrade, // optional, telemetry hook
   }}
-  styles={
-    {
+  // Optional: pass `appConfig` (even `{}`) to skip the remote
+  // `/applications/config` fetch and use local-only styles/branding.
+  appConfig={{
+    styles: {
       /* optional style overrides */
-    }
-  }
+    },
+  }}
+  ui={{
+    // Optional: replace the default Freighter/Albedo wallet picker.
+    // See "External wallet stacks" below for a kit-powered example.
+    renderWallets: undefined,
+  }}
   adapters={
     {
       /* optional named adapter set */
@@ -88,11 +99,18 @@ Context provider that initialises the Pollar client and makes it available to ch
 </PollarProvider>
 ```
 
-| Prop       | Type                 | Required | Description                                                               |
-| ---------- | -------------------- | -------- | ------------------------------------------------------------------------- |
-| `config`   | `PollarClientConfig` | Yes      | Configuration passed verbatim to `PollarClient`                           |
-| `styles`   | `PollarStyles`       | No       | Per-app style overrides; merged on top of `appConfig.styles` from the API |
-| `adapters` | `PollarAdapters`     | No       | Named set of `PollarAdapter` objects (e.g. Trustless Work). See below     |
+| Prop        | Type                                | Required | Description                                                                                                                                                                                              |
+| ----------- | ----------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`    | `PollarClient \| PollarClientConfig` | Yes      | Either a pre-built `PollarClient` (testing, reuse outside React) or a `PollarClientConfig` the provider will construct one from. **Locked at first render** — swapping after mount is ignored            |
+| `appConfig` | `PollarConfig`                       | No       | Local override of `/applications/config`. **Presence is the opt-out switch**: pass it (even `{}`) and the remote fetch is skipped. Omit it to keep the existing remote-fetch-on-mount behaviour          |
+| `ui`        | `{ renderWallets?: RenderWalletsSlot }` | No    | UI customisation slots. `renderWallets` replaces the default Freighter/Albedo buttons in `LoginModal`'s wallet picker. Receives `{ onConnect, authState }` and is expected to call `onConnect(walletId)` |
+| `adapters`  | `PollarAdapters`                     | No       | Named set of `PollarAdapter` objects (e.g. Trustless Work). See below                                                                                                                                    |
+
+> **Renamed in 0.8.0** — `config` → `client`, `styles` → `appConfig.styles`.
+> If you were passing `styles={{ ... }}` directly, move it to
+> `appConfig={{ styles: { ... } }}` (which also opts you out of the remote
+> `/applications/config` fetch). See [UPGRADE.md](../../UPGRADE.md) for the
+> full migration matrix.
 
 ---
 
@@ -244,7 +262,7 @@ const trustlessWork: PollarAdapter = {
   release: async (params) => ({ unsignedTransaction: '…' }),
 };
 
-<PollarProvider config={{ apiKey }} adapters={{ trustlessWork }}>
+<PollarProvider client={{ apiKey }} adapters={{ trustlessWork }}>
   …
 </PollarProvider>;
 ```
@@ -273,7 +291,9 @@ function MyComponent() {
 
 ### External wallet stacks (Stellar Wallets Kit, …)
 
-Pass a `WalletAdapterResolver` to `config.walletAdapter` so Pollar can reach wallets that live outside `@pollar/core`:
+Pass a `WalletAdapterResolver` to `client.walletAdapter` so Pollar can reach
+wallets that live outside `@pollar/core`. The signing path alone (no UI
+changes):
 
 ```tsx
 import { PollarProvider } from '@pollar/react';
@@ -281,7 +301,7 @@ import { stellarWalletsKit } from '@pollar/stellar-wallets-kit-adapter';
 import { Networks } from '@creit.tech/stellar-wallets-kit';
 
 <PollarProvider
-  config={{
+  client={{
     apiKey: 'your-api-key',
     walletAdapter: stellarWalletsKit({ network: Networks.PUBLIC }),
   }}
@@ -290,7 +310,49 @@ import { Networks } from '@creit.tech/stellar-wallets-kit';
 </PollarProvider>;
 ```
 
-Then any `login({ provider: 'wallet', type: '<kit wallet id>' })` is routed through the kit.
+Then any `login({ provider: 'wallet', type: '<kit wallet id>' })` is routed
+through the kit. The built-in `LoginModal` still shows only Freighter / Albedo
+unless you also wire `ui.renderWallets` (next section).
+
+#### Showing every kit wallet in `LoginModal`
+
+The `ui.renderWallets` slot replaces the hardcoded Freighter+Albedo buttons.
+`@pollar/stellar-wallets-kit-adapter/picker` ships a bundle that builds both
+halves (signing + picker UI) from a single options object — drop both into
+`<PollarProvider>` and the kit's full wallet list (xBull, Lobstr, Rabet, …)
+renders in `LoginModal`:
+
+```tsx
+import { PollarProvider } from '@pollar/react';
+import { createStellarWalletsKitBundle } from '@pollar/stellar-wallets-kit-adapter/picker';
+import { Networks } from '@creit.tech/stellar-wallets-kit';
+
+const bundle = createStellarWalletsKitBundle({
+  network: Networks.PUBLIC,
+  picker: { wallets: ['xbull', 'lobstr', 'freighter'] }, // subset, optional
+});
+
+<PollarProvider
+  client={{ apiKey: 'your-api-key', walletAdapter: bundle.walletAdapter }}
+  ui={{ renderWallets: bundle.renderWallets }}
+>
+  {children}
+</PollarProvider>;
+```
+
+If you only want a custom picker (no kit), `renderWallets` is just a function
+of `{ onConnect, authState }` — return whatever JSX you want and call
+`onConnect(walletId)` when the user picks a wallet:
+
+```tsx
+ui={{
+  renderWallets: ({ onConnect, authState }) => (
+    <button disabled={authState.step !== 'idle'} onClick={() => onConnect('xbull')}>
+      xBull
+    </button>
+  ),
+}}
+```
 
 ---
 
@@ -318,6 +380,10 @@ import type {
   AuthModalProps,
   PollarConfig,
   PollarStyles,
+
+  // 0.8.0 — wallet picker slot
+  RenderWalletsProps,
+  RenderWalletsSlot,
 
   // Template props
   SendModalTemplateProps,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/react",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "React components for Pollar authentication",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/components/login-modal/LoginModal.tsx
+++ b/packages/react/src/components/login-modal/LoginModal.tsx
@@ -7,6 +7,8 @@ import { LoginModalTemplate } from './LoginModalTemplate';
 import '../shared.css';
 import './LoginModal.css';
 
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
 interface LoginModalProps {
   onClose: () => void;
 }

--- a/packages/react/src/components/login-modal/LoginModal.tsx
+++ b/packages/react/src/components/login-modal/LoginModal.tsx
@@ -22,9 +22,10 @@ export function LoginModal({ onClose }: LoginModalProps) {
 
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const autoCloseTimer = useRef<TimeoutHandle | null>(null);
 
   useEffect(() => {
-    return getClient().onAuthStateChange((next) => {
+    const unsubscribe = getClient().onAuthStateChange((next) => {
       setAuthState(next);
       if (next.step === 'entering_email' && pendingEmail.current) {
         getClient().sendEmailCode(pendingEmail.current);
@@ -34,9 +35,19 @@ export function LoginModal({ onClose }: LoginModalProps) {
         setCodeInputKey((k) => k + 1);
       }
       if (next.step === 'authenticated') {
-        setTimeout(onCloseRef.current, 1000);
+        autoCloseTimer.current = setTimeout(() => {
+          autoCloseTimer.current = null;
+          onCloseRef.current();
+        }, 1000);
       }
     });
+    return () => {
+      unsubscribe();
+      if (autoCloseTimer.current !== null) {
+        clearTimeout(autoCloseTimer.current);
+        autoCloseTimer.current = null;
+      }
+    };
   }, [getClient]);
 
   const { theme = 'light', accentColor = '#005DB4', logoUrl, emailEnabled, embeddedWallets, providers } = styles;

--- a/packages/react/src/components/login-modal/LoginModal.tsx
+++ b/packages/react/src/components/login-modal/LoginModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AUTH_ERROR_CODES, AuthState, WalletType } from '@pollar/core';
+import { AUTH_ERROR_CODES, AuthState, WalletId } from '@pollar/core';
 import { useEffect, useRef, useState } from 'react';
 import { usePollar } from '../../context';
 import { LoginModalTemplate } from './LoginModalTemplate';
@@ -13,7 +13,7 @@ interface LoginModalProps {
 
 export function LoginModal({ onClose }: LoginModalProps) {
   const [email, setEmail] = useState('');
-  const { getClient, styles, appConfig: config } = usePollar();
+  const { getClient, styles, appConfig: config, renderWallets } = usePollar();
   const [authState, setAuthState] = useState<AuthState>(() => getClient().getAuthState());
   const [codeInputKey, setCodeInputKey] = useState(0);
   const pendingEmail = useRef<string | null>(null);
@@ -55,7 +55,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
     getClient().login({ provider });
   }
 
-  function handleWalletConnect(type: WalletType) {
+  function handleWalletConnect(type: WalletId) {
     getClient().loginWallet(type);
   }
 
@@ -95,8 +95,8 @@ export function LoginModal({ onClose }: LoginModalProps) {
         onEmailChange={setEmail}
         onEmailSubmit={handleEmailSubmit}
         onSocialLogin={handleSocialLogin}
-        onFreighterConnect={() => handleWalletConnect(WalletType.FREIGHTER)}
-        onAlbedoConnect={() => handleWalletConnect(WalletType.ALBEDO)}
+        onWalletConnect={handleWalletConnect}
+        {...(renderWallets !== undefined && { renderWallets })}
         authState={authState}
         codeInputKey={codeInputKey}
         onCodeSubmit={handleVerifyCode}

--- a/packages/react/src/components/login-modal/LoginModalTemplate.tsx
+++ b/packages/react/src/components/login-modal/LoginModalTemplate.tsx
@@ -1,14 +1,46 @@
 'use client';
 
-import { AUTH_ERROR_CODES, AuthState } from '@pollar/core';
+import { AUTH_ERROR_CODES, AuthState, WalletId, WalletType } from '@pollar/core';
 
 type StateStatus = 'NONE' | 'LOADING' | 'SUCCESS' | 'ERROR';
 import { type CSSProperties, useState } from 'react';
 import { LOGO_ALBEDO, LOGO_FREIGHTER, LOGO_POLLAR } from '../../constants';
+import type { RenderWalletsSlot } from '../../types';
 import { ModalStatusBanner, PollarModalFooter } from '../commons';
 import { EmailCodeInput } from './EmailCodeInput';
 import { GithubButton } from './GithubButton';
 import { GoogleButton } from './GoogleButton';
+
+function DefaultFreighterAlbedoButtons({
+  onConnect,
+  isLoading,
+}: {
+  onConnect: (id: WalletId) => void;
+  isLoading: boolean;
+}) {
+  return (
+    <div className="pollar-wallet-list">
+      <button
+        type="button"
+        disabled={isLoading}
+        className="pollar-wallet-list-btn"
+        onClick={() => onConnect(WalletType.FREIGHTER)}
+      >
+        <img src={LOGO_FREIGHTER} alt="Freighter" className="pollar-wallet-list-icon" />
+        <span className="pollar-wallet-list-name">Freighter</span>
+      </button>
+      <button
+        type="button"
+        disabled={isLoading}
+        className="pollar-wallet-list-btn"
+        onClick={() => onConnect(WalletType.ALBEDO)}
+      >
+        <img src={LOGO_ALBEDO} alt="Albedo" className="pollar-wallet-list-icon" />
+        <span className="pollar-wallet-list-name">Albedo</span>
+      </button>
+    </div>
+  );
+}
 
 const AUTH_STATE_MESSAGES: Record<AuthState['step'], string> = {
   idle: '',
@@ -63,8 +95,9 @@ interface LoginModalTemplateProps {
   onEmailChange?: (email: string) => void;
   onEmailSubmit?: () => void;
   onSocialLogin?: (provider: 'google' | 'github') => void;
-  onFreighterConnect?: () => void;
-  onAlbedoConnect?: () => void;
+  onWalletConnect: (id: WalletId) => void;
+  /** Optional override for the wallet picker view. Defaults to a Freighter+Albedo list. */
+  renderWallets?: RenderWalletsSlot;
   authState: AuthState;
   codeInputKey?: number;
   onCodeSubmit?: (code: string) => void;
@@ -85,8 +118,8 @@ export function LoginModalTemplate({
   onEmailChange,
   onEmailSubmit,
   onSocialLogin,
-  onFreighterConnect,
-  onAlbedoConnect,
+  onWalletConnect,
+  renderWallets,
   authState,
   codeInputKey,
   onCodeSubmit,
@@ -178,16 +211,10 @@ export function LoginModalTemplate({
       ) : showWalletPicker ? (
         <>
           <BackButton onClick={() => setShowWalletPicker(false)} />
-          <div className="pollar-wallet-list">
-            <button type="button" disabled={isLoading} className="pollar-wallet-list-btn" onClick={onFreighterConnect}>
-              <img src={LOGO_FREIGHTER} alt="Freighter" className="pollar-wallet-list-icon" />
-              <span className="pollar-wallet-list-name">Freighter</span>
-            </button>
-            <button type="button" disabled={isLoading} className="pollar-wallet-list-btn" onClick={onAlbedoConnect}>
-              <img src={LOGO_ALBEDO} alt="Albedo" className="pollar-wallet-list-icon" />
-              <span className="pollar-wallet-list-name">Albedo</span>
-            </button>
-          </div>
+          {renderWallets
+            ? renderWallets({ onConnect: onWalletConnect, authState })
+            : <DefaultFreighterAlbedoButtons onConnect={onWalletConnect} isLoading={isLoading} />
+          }
         </>
       ) : (
         <>

--- a/packages/react/src/components/login-modal/LoginModalTemplate.tsx
+++ b/packages/react/src/components/login-modal/LoginModalTemplate.tsx
@@ -11,13 +11,7 @@ import { EmailCodeInput } from './EmailCodeInput';
 import { GithubButton } from './GithubButton';
 import { GoogleButton } from './GoogleButton';
 
-function DefaultFreighterAlbedoButtons({
-  onConnect,
-  isLoading,
-}: {
-  onConnect: (id: WalletId) => void;
-  isLoading: boolean;
-}) {
+function DefaultFreighterAlbedoButtons({ onConnect, isLoading }: { onConnect: (id: WalletId) => void; isLoading: boolean }) {
   return (
     <div className="pollar-wallet-list">
       <button
@@ -211,10 +205,11 @@ export function LoginModalTemplate({
       ) : showWalletPicker ? (
         <>
           <BackButton onClick={() => setShowWalletPicker(false)} />
-          {renderWallets
-            ? renderWallets({ onConnect: onWalletConnect, authState })
-            : <DefaultFreighterAlbedoButtons onConnect={onWalletConnect} isLoading={isLoading} />
-          }
+          {renderWallets ? (
+            renderWallets({ onConnect: onWalletConnect, authState })
+          ) : (
+            <DefaultFreighterAlbedoButtons onConnect={onWalletConnect} isLoading={isLoading} />
+          )}
         </>
       ) : (
         <>

--- a/packages/react/src/components/receive-modal/ReceiveModal.tsx
+++ b/packages/react/src/components/receive-modal/ReceiveModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePollar } from '../../context';
 import '../shared.css';
 import './ReceiveModal.css';
@@ -14,12 +14,24 @@ export function ReceiveModal({ onClose }: ReceiveModalProps) {
   const { walletAddress, styles } = usePollar();
   const { theme = 'light', accentColor = '#005DB4' } = styles;
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    },
+    [],
+  );
 
   function handleCopy() {
     if (!walletAddress) return;
     navigator.clipboard.writeText(walletAddress).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null;
+        setCopied(false);
+      }, 2000);
     });
   }
 

--- a/packages/react/src/components/send-modal/SendModal.tsx
+++ b/packages/react/src/components/send-modal/SendModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { WalletBalanceRecord } from '@pollar/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePollar } from '../../context';
 import '../shared.css';
 import '../transaction-modal/TransactionModal.css';
@@ -40,10 +40,18 @@ export function SendModal({ onClose }: SendModalProps) {
   const [showXdr, setShowXdr] = useState(false);
   const [copied, setCopied] = useState(false);
   const [formError, setFormError] = useState('');
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     void refreshWalletBalance();
   }, [refreshWalletBalance]);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    },
+    [],
+  );
 
   const balanceData = walletBalance.step === 'loaded' ? walletBalance.data : null;
   const allAssets = balanceData?.balances ?? [];
@@ -116,7 +124,11 @@ export function SendModal({ onClose }: SendModalProps) {
     if (!hash) return;
     navigator.clipboard.writeText(hash).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null;
+        setCopied(false);
+      }, 2000);
     });
   }
 

--- a/packages/react/src/components/transaction-modal/TransactionModal.tsx
+++ b/packages/react/src/components/transaction-modal/TransactionModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePollar } from '../../context';
 import '../shared.css';
 import './TransactionModal.css';
@@ -16,6 +16,14 @@ export function TransactionModal({ onClose }: TransactionModalProps) {
 
   const [showXdr, setShowXdr] = useState(false);
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    },
+    [],
+  );
 
   const hash = transaction.step === 'success' ? transaction.hash : null;
   const buildData = 'buildData' in transaction ? transaction.buildData : null;
@@ -38,7 +46,11 @@ export function TransactionModal({ onClose }: TransactionModalProps) {
     if (!hash) return;
     navigator.clipboard.writeText(hash).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null;
+        setCopied(false);
+      }, 2000);
     });
   }
 

--- a/packages/react/src/components/wallet-button/WalletButton.tsx
+++ b/packages/react/src/components/wallet-button/WalletButton.tsx
@@ -21,6 +21,7 @@ export function WalletButton() {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isInProgress = transaction.step === 'building' || transaction.step === 'signing';
 
   const { theme = 'light', accentColor = '#005DB4' } = styles;
@@ -39,11 +40,22 @@ export function WalletButton() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    },
+    [],
+  );
+
   async function handleCopy() {
     if (!walletAddress) return;
     await navigator.clipboard.writeText(walletAddress);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => {
+      copyTimerRef.current = null;
+      setCopied(false);
+    }, 1500);
   }
 
   function handleLogout() {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -37,6 +37,31 @@ const DEFAULT_APP_CONFIG: PollarConfig = {
   styles: {},
 };
 
+/**
+ * Compares the fields of a persisted session that actually drive UI re-renders.
+ * Replaces a per-listener `JSON.stringify(...) !== JSON.stringify(...)` call —
+ * cheaper, allocation-free, and explicit about what counts as "changed".
+ *
+ * If a field is added to `PollarPersistedSession` that consumers read through
+ * context, list it here too.
+ */
+function sessionsEqual(
+  a: PollarPersistedSession | null,
+  b: PollarPersistedSession | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.clientSessionId === b.clientSessionId &&
+    a.userId === b.userId &&
+    a.status === b.status &&
+    a.token?.accessToken === b.token?.accessToken &&
+    a.token?.refreshToken === b.token?.refreshToken &&
+    a.token?.expiresAt === b.token?.expiresAt &&
+    a.wallet?.publicKey === b.wallet?.publicKey
+  );
+}
+
 interface PollarContextValue {
   walletAddress: string;
   getClient: () => PollarClient;
@@ -186,7 +211,7 @@ export function PollarProvider({
   useEffect(() => {
     return pollarClient.onAuthStateChange((authState) => {
       if (authState.step === 'authenticated') {
-        setSessionState((prev) => (JSON.stringify(prev) !== JSON.stringify(authState.session) ? authState.session : prev));
+        setSessionState((prev) => (sessionsEqual(prev, authState.session) ? prev : authState.session));
       } else if (authState.step === 'idle') {
         setSessionState(null);
       }

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -17,7 +17,7 @@ import {
   WalletBalanceState,
   WalletId,
 } from '@pollar/core';
-import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { ModalErrorBoundary } from './components/commons';
 import { DistributionRulesModal } from './components/distribution-rules-modal/DistributionRulesModal';
 import { KycModal } from './components/kyc-modal/KycModal';
@@ -205,18 +205,14 @@ export function PollarProvider({ client, appConfig: appConfigProp, ui, adapters,
   const [sessionsModalOpen, setSessionsModalOpen] = useState(false);
   const [distributionRulesModalOpen, setDistributionRulesModalOpen] = useState(false);
 
-  const adaptersRef = useRef(adapters);
-  adaptersRef.current = adapters;
-
-  const renderWalletsRef = useRef(ui?.renderWallets);
-  renderWalletsRef.current = ui?.renderWallets;
-
   // PII (incl. providers.wallet.address) lives on `client.getUserProfile()`, not on the
   // persisted session. For both external and custodial wallets, `wallet.publicKey`
   // already holds the on-chain address we care about.
   const walletAddress = sessionState?.wallet?.publicKey || '';
   const getClient = useCallback(() => pollarClient, [pollarClient]);
   const refreshWalletBalance = useCallback(() => pollarClient.refreshBalance(walletAddress), [pollarClient, walletAddress]);
+
+  const renderWallets = ui?.renderWallets;
 
   const contextValue: PollarContextValue = useMemo(
     () => {
@@ -269,8 +265,8 @@ export function PollarProvider({ client, appConfig: appConfigProp, ui, adapters,
         // config
         appConfig: resolvedConfig,
         styles,
-        renderWallets: renderWalletsRef.current,
-        adapters: adaptersRef.current,
+        renderWallets,
+        adapters,
       }) as PollarContextValue;
     },
     [
@@ -283,6 +279,8 @@ export function PollarProvider({ client, appConfig: appConfigProp, ui, adapters,
       refreshWalletBalance,
       networkState,
       resolvedConfig,
+      adapters,
+      renderWallets,
     ],
   );
 

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -29,19 +29,12 @@ import { SessionsModal } from './components/sessions-modal/SessionsModal';
 import { TransactionModal } from './components/transaction-modal/TransactionModal';
 import { TxHistoryModal } from './components/tx-history-modal/TxHistoryModal';
 import { WalletBalanceModal } from './components/wallet-balance-modal/WalletBalanceModal';
-import type { PollarConfig, PollarStyles } from './types';
+import type { PollarConfig, PollarStyles, RenderWalletsSlot } from './types';
 
-const emptyResponse = {
-  application: {
-    name: '',
-  },
+const DEFAULT_APP_CONFIG: PollarConfig = {
+  application: { name: '' },
   styles: {},
 };
-
-async function fetchRemoteConfig(client: PollarClient): Promise<PollarConfig> {
-  const content = await client.getAppConfig();
-  return (content as PollarConfig | null) ?? emptyResponse;
-}
 
 interface PollarContextValue {
   walletAddress: string;
@@ -55,6 +48,8 @@ interface PollarContextValue {
   openSessionsModal: () => void;
   appConfig: PollarConfig;
   styles: PollarStyles;
+  /** UI slot for wallet picker (forwarded from provider props). */
+  renderWallets?: RenderWalletsSlot;
   // transactions
   openTxModal: () => void;
   tx: TransactionState;
@@ -111,24 +106,41 @@ interface PollarContextValue {
 const PollarContext = createContext<PollarContextValue | null>(null);
 
 interface PollarProviderProps {
-  config: PollarClientConfig;
-  styles?: PollarStyles;
+  /**
+   * Either a pre-built `PollarClient` instance (useful for testing or for
+   * reusing the same client outside React) or a `PollarClientConfig` that the
+   * provider will use to construct one on mount.
+   *
+   * The client is locked at first render: changing this prop afterwards is
+   * ignored. To swap clients, unmount and remount the provider.
+   */
+  client: PollarClient | PollarClientConfig;
+  /**
+   * Local override of the `/applications/config` response. If provided (even
+   * `{}`), the remote fetch is skipped and missing fields fall back to the
+   * defaults in `LoginModalTemplate`. If `undefined`, the SDK fetches
+   * `/applications/config` on mount.
+   */
+  appConfig?: PollarConfig;
+  /** UI customization slots. */
+  ui?: {
+    /** Replaces the default Freighter/Albedo wallet picker. */
+    renderWallets?: RenderWalletsSlot;
+  };
   adapters?: PollarAdapters;
   children: ReactNode;
 }
 
-export function PollarProvider({ config, styles: propStyles, adapters, children }: PollarProviderProps) {
-  const [pollarClient] = useState<PollarClient>(() => new PollarClient(config));
+export function PollarProvider({ client, appConfig: appConfigProp, ui, adapters, children }: PollarProviderProps) {
+  const [pollarClient] = useState<PollarClient>(() =>
+    client instanceof PollarClient ? client : new PollarClient(client),
+  );
   const [networkState, setNetworkState] = useState<NetworkState>(() => pollarClient.getNetworkState());
   const [sessionState, setSessionState] = useState<PollarPersistedSession | null>(null);
   const [transaction, setTransaction] = useState<TransactionState>({ step: 'idle' });
   const [txHistory, setTxHistory] = useState<TxHistoryState>({ step: 'idle' });
   const [walletBalance, setWalletBalance] = useState<WalletBalanceState>({ step: 'idle' });
-  const [remoteConfig, setRemoteConfig] = useState<PollarConfig>(emptyResponse);
-  const [styles, setStyles] = useState<PollarStyles>(propStyles ?? {});
-
-  const propStylesRef = useRef(propStyles);
-  propStylesRef.current = propStyles;
+  const [resolvedConfig, setResolvedConfig] = useState<PollarConfig>(() => appConfigProp ?? DEFAULT_APP_CONFIG);
 
   useEffect(() => {
     return pollarClient.onTransactionStateChange(setTransaction);
@@ -158,21 +170,24 @@ export function PollarProvider({ config, styles: propStyles, adapters, children 
     });
   }, [pollarClient]);
 
+  // Presence of `appConfig` is the opt-out: if the consumer passes it (even
+  // `{}`), we trust them and skip the remote fetch.
   useEffect(() => {
-    const propStyles = propStylesRef.current;
-    fetchRemoteConfig(pollarClient)
+    if (appConfigProp !== undefined) return;
+    let cancelled = false;
+    pollarClient
+      .getAppConfig()
       .then((fetched) => {
-        setRemoteConfig(fetched);
-        setStyles({
-          ...fetched.styles,
-          ...propStyles,
-          providers: { ...fetched.styles?.providers, ...propStyles?.providers },
-        });
+        if (cancelled || !fetched) return;
+        setResolvedConfig(fetched as PollarConfig);
       })
-      .catch(() => {
-        setStyles(propStyles ?? {});
+      .catch((err) => {
+        console.error('[PollarProvider] getAppConfig failed', err);
       });
-  }, [pollarClient]);
+    return () => {
+      cancelled = true;
+    };
+  }, [pollarClient, appConfigProp]);
 
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [transactionModalOpen, setTransactionModalOpen] = useState(false);
@@ -193,6 +208,9 @@ export function PollarProvider({ config, styles: propStyles, adapters, children 
   const adaptersRef = useRef(adapters);
   adaptersRef.current = adapters;
 
+  const renderWalletsRef = useRef(ui?.renderWallets);
+  renderWalletsRef.current = ui?.renderWallets;
+
   // PII (incl. providers.wallet.address) lives on `client.getUserProfile()`, not on the
   // persisted session. For both external and custodial wallets, `wallet.publicKey`
   // already holds the on-chain address we care about.
@@ -201,8 +219,9 @@ export function PollarProvider({ config, styles: propStyles, adapters, children 
   const refreshWalletBalance = useCallback(() => pollarClient.refreshBalance(walletAddress), [pollarClient, walletAddress]);
 
   const contextValue: PollarContextValue = useMemo(
-    () =>
-      ({
+    () => {
+      const styles: PollarStyles = resolvedConfig.styles ?? {};
+      return ({
         // session
         walletAddress,
         isAuthenticated: !!walletAddress,
@@ -248,10 +267,12 @@ export function PollarProvider({ config, styles: propStyles, adapters, children 
         // ramp
         openRampModal: () => setRampModalOpen(true),
         // config
-        appConfig: remoteConfig,
+        appConfig: resolvedConfig,
         styles,
+        renderWallets: renderWalletsRef.current,
         adapters: adaptersRef.current,
-      }) as PollarContextValue,
+      }) as PollarContextValue;
+    },
     [
       walletAddress,
       pollarClient,
@@ -261,8 +282,7 @@ export function PollarProvider({ config, styles: propStyles, adapters, children 
       walletBalance,
       refreshWalletBalance,
       networkState,
-      remoteConfig,
-      styles,
+      resolvedConfig,
     ],
   );
 

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -3,6 +3,7 @@
 import {
   BuildOutcome,
   NetworkState,
+  OnStorageDegrade,
   PollarAdapters,
   PollarClient,
   PollarClientConfig,
@@ -128,10 +129,27 @@ interface PollarProviderProps {
     renderWallets?: RenderWalletsSlot;
   };
   adapters?: PollarAdapters;
+  /**
+   * Notified when persistent storage silently degrades to in-memory mode
+   * (Safari private browsing quota errors, sandboxed iframes, etc.). Use this
+   * to surface a UI hint that the session won't survive a reload, log to
+   * telemetry, or fall back to a different storage strategy.
+   *
+   * Fires at most once per provider lifetime; late mounts get the latched
+   * state replayed on subscribe.
+   */
+  onStorageDegrade?: OnStorageDegrade;
   children: ReactNode;
 }
 
-export function PollarProvider({ client, appConfig: appConfigProp, ui, adapters, children }: PollarProviderProps) {
+export function PollarProvider({
+  client,
+  appConfig: appConfigProp,
+  ui,
+  adapters,
+  onStorageDegrade,
+  children,
+}: PollarProviderProps) {
   const [pollarClient] = useState<PollarClient>(() =>
     client instanceof PollarClient ? client : new PollarClient(client),
   );
@@ -159,6 +177,11 @@ export function PollarProvider({ client, appConfig: appConfigProp, ui, adapters,
       setNetworkState(state);
     });
   }, [pollarClient]);
+
+  useEffect(() => {
+    if (!onStorageDegrade) return;
+    return pollarClient.onStorageDegrade(onStorageDegrade);
+  }, [pollarClient, onStorageDegrade]);
 
   useEffect(() => {
     return pollarClient.onAuthStateChange((authState) => {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -45,10 +45,7 @@ const DEFAULT_APP_CONFIG: PollarConfig = {
  * If a field is added to `PollarPersistedSession` that consumers read through
  * context, list it here too.
  */
-function sessionsEqual(
-  a: PollarPersistedSession | null,
-  b: PollarPersistedSession | null,
-): boolean {
+function sessionsEqual(a: PollarPersistedSession | null, b: PollarPersistedSession | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   return (
@@ -175,9 +172,7 @@ export function PollarProvider({
   onStorageDegrade,
   children,
 }: PollarProviderProps) {
-  const [pollarClient] = useState<PollarClient>(() =>
-    client instanceof PollarClient ? client : new PollarClient(client),
-  );
+  const [pollarClient] = useState<PollarClient>(() => (client instanceof PollarClient ? client : new PollarClient(client)));
   const [networkState, setNetworkState] = useState<NetworkState>(() => pollarClient.getNetworkState());
   const [sessionState, setSessionState] = useState<PollarPersistedSession | null>(null);
   const [transaction, setTransaction] = useState<TransactionState>({ step: 'idle' });
@@ -262,75 +257,71 @@ export function PollarProvider({
 
   const renderWallets = ui?.renderWallets;
 
-  const contextValue: PollarContextValue = useMemo(
-    () => {
-      const styles: PollarStyles = resolvedConfig.styles ?? {};
-      return ({
-        // session
-        walletAddress,
-        isAuthenticated: !!walletAddress,
-        walletType: pollarClient.getWalletType(),
-        // client
-        getClient,
-        // auth
-        login: (options: PollarLoginOptions) => pollarClient.login(options),
-        logout: () => pollarClient.logout(),
-        openLoginModal: () => setLoginModalOpen(true),
-        // transactions
-        tx: transaction,
-        buildTx: (operation, params, options) => pollarClient.buildTx(operation, params, options),
-        signAndSubmitTx: (unsignedXdr: string) => pollarClient.signAndSubmitTx(unsignedXdr),
-        signTx: (unsignedXdr: string) => pollarClient.signTx(unsignedXdr),
-        submitTx: (signedXdr: string) => pollarClient.submitTx(signedXdr),
-        buildAndSignAndSubmitTx: (operation, params, options) =>
-          pollarClient.buildAndSignAndSubmitTx(operation, params, options),
-        runTx: (operation, params, options) => pollarClient.runTx(operation, params, options),
-        openTxModal: () => setTransactionModalOpen(true),
-        // tx history
-        txHistory,
-        openTxHistoryModal: () => setTxHistoryModalOpen(true),
-        // wallet balance
-        walletBalance,
-        refreshWalletBalance,
-        openWalletBalanceModal: () => setWalletBalanceModalOpen(true),
-        // send / receive
-        openSendModal: () => setSendModalOpen(true),
-        openReceiveModal: () => setReceiveModalOpen(true),
-        // sessions
-        openSessionsModal: () => setSessionsModalOpen(true),
-        // distribution
-        openDistributionRulesModal: () => setDistributionRulesModalOpen(true),
-        // network
-        network: networkState.step === 'connected' ? networkState.network : 'testnet',
-        setNetwork: (network: StellarNetwork) => pollarClient.setNetwork(network),
-        // kyc
-        openKycModal: (options = {}) => {
-          setKycModalOptions(options);
-          setKycModalOpen(true);
-        },
-        // ramp
-        openRampModal: () => setRampModalOpen(true),
-        // config
-        appConfig: resolvedConfig,
-        styles,
-        renderWallets,
-        adapters,
-      }) as PollarContextValue;
-    },
-    [
+  const contextValue: PollarContextValue = useMemo(() => {
+    const styles: PollarStyles = resolvedConfig.styles ?? {};
+    return {
+      // session
       walletAddress,
-      pollarClient,
+      isAuthenticated: !!walletAddress,
+      walletType: pollarClient.getWalletType(),
+      // client
       getClient,
-      transaction,
+      // auth
+      login: (options: PollarLoginOptions) => pollarClient.login(options),
+      logout: () => pollarClient.logout(),
+      openLoginModal: () => setLoginModalOpen(true),
+      // transactions
+      tx: transaction,
+      buildTx: (operation, params, options) => pollarClient.buildTx(operation, params, options),
+      signAndSubmitTx: (unsignedXdr: string) => pollarClient.signAndSubmitTx(unsignedXdr),
+      signTx: (unsignedXdr: string) => pollarClient.signTx(unsignedXdr),
+      submitTx: (signedXdr: string) => pollarClient.submitTx(signedXdr),
+      buildAndSignAndSubmitTx: (operation, params, options) => pollarClient.buildAndSignAndSubmitTx(operation, params, options),
+      runTx: (operation, params, options) => pollarClient.runTx(operation, params, options),
+      openTxModal: () => setTransactionModalOpen(true),
+      // tx history
       txHistory,
+      openTxHistoryModal: () => setTxHistoryModalOpen(true),
+      // wallet balance
       walletBalance,
       refreshWalletBalance,
-      networkState,
-      resolvedConfig,
-      adapters,
+      openWalletBalanceModal: () => setWalletBalanceModalOpen(true),
+      // send / receive
+      openSendModal: () => setSendModalOpen(true),
+      openReceiveModal: () => setReceiveModalOpen(true),
+      // sessions
+      openSessionsModal: () => setSessionsModalOpen(true),
+      // distribution
+      openDistributionRulesModal: () => setDistributionRulesModalOpen(true),
+      // network
+      network: networkState.step === 'connected' ? networkState.network : 'testnet',
+      setNetwork: (network: StellarNetwork) => pollarClient.setNetwork(network),
+      // kyc
+      openKycModal: (options = {}) => {
+        setKycModalOptions(options);
+        setKycModalOpen(true);
+      },
+      // ramp
+      openRampModal: () => setRampModalOpen(true),
+      // config
+      appConfig: resolvedConfig,
+      styles,
       renderWallets,
-    ],
-  );
+      adapters,
+    } as PollarContextValue;
+  }, [
+    walletAddress,
+    pollarClient,
+    getClient,
+    transaction,
+    txHistory,
+    walletBalance,
+    refreshWalletBalance,
+    networkState,
+    resolvedConfig,
+    adapters,
+    renderWallets,
+  ]);
 
   return (
     <PollarContext.Provider value={contextValue}>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,8 @@ export type {
   AuthModalProps,
   PollarStyles,
   PollarConfig,
+  RenderWalletsProps,
+  RenderWalletsSlot,
 } from './types';
 export { WalletButton } from './components/wallet-button/WalletButton';
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,9 +1,29 @@
-import { PollarApplicationConfigContent, PollarClientConfig, PollarLoginOptions, pollarPaths } from '@pollar/core';
+import { AuthState, PollarApplicationConfigContent, PollarClientConfig, PollarLoginOptions, WalletId, pollarPaths } from '@pollar/core';
+import type { ReactNode } from 'react';
 
 type ConfigResponse = pollarPaths['/applications/config']['get']['responses'][200]['content']['application/json'];
 export type PollarConfig = ConfigResponse['content'];
 
 export type PollarStyles = PollarConfig['styles'];
+
+/**
+ * Props passed by `@pollar/react` to a `renderWallets` slot. External wallet
+ * picker components receive these and call `onConnect(id)` when the user picks
+ * a wallet; `@pollar/react` wraps that into `client.loginWallet(id)`.
+ */
+export interface RenderWalletsProps {
+  /** Wrapper around `client.loginWallet(id)`. */
+  onConnect: (id: WalletId) => void;
+  /** Current auth state — picker can disable buttons / surface loading. */
+  authState: AuthState;
+}
+
+/**
+ * Signature for the `ui.renderWallets` slot on `<PollarProvider>`. When
+ * provided, replaces the default Freighter/Albedo buttons in the LoginModal
+ * with whatever the slot returns (typically a kit-powered wallet grid).
+ */
+export type RenderWalletsSlot = (props: RenderWalletsProps) => ReactNode;
 
 export interface AuthProviderProps {
   config: PollarClientConfig;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,11 @@
-import { AuthState, PollarApplicationConfigContent, PollarClientConfig, PollarLoginOptions, WalletId, pollarPaths } from '@pollar/core';
+import {
+  AuthState,
+  PollarApplicationConfigContent,
+  PollarClientConfig,
+  PollarLoginOptions,
+  WalletId,
+  pollarPaths,
+} from '@pollar/core';
 import type { ReactNode } from 'react';
 
 type ConfigResponse = pollarPaths['/applications/config']['get']['responses'][200]['content']['application/json'];

--- a/packages/stellar-wallets-kit-adapter/README.md
+++ b/packages/stellar-wallets-kit-adapter/README.md
@@ -49,7 +49,7 @@ The kit is a global singleton. `stellarWalletsKit(...)` returns a resolver and `
 
 ## Default wallets
 
-Calling `stellarWalletsKit()` with no `modules` argument enables every module that loads without extra configuration:
+Calling `stellarWalletsKit({ network })` with no `modules` argument enables every module that loads without extra configuration:
 
 | Module             | Wallet id (`WalletId`) | Type               |
 | ------------------ | ---------------------- | ------------------ |

--- a/packages/stellar-wallets-kit-adapter/README.md
+++ b/packages/stellar-wallets-kit-adapter/README.md
@@ -36,7 +36,7 @@ import { stellarWalletsKit } from '@pollar/stellar-wallets-kit-adapter';
 import { Networks } from '@creit.tech/stellar-wallets-kit';
 
 <PollarProvider
-  config={{
+  client={{
     apiKey: 'your-api-key',
     walletAdapter: stellarWalletsKit({ network: Networks.TESTNET }),
   }}
@@ -45,7 +45,17 @@ import { Networks } from '@creit.tech/stellar-wallets-kit';
 </PollarProvider>;
 ```
 
+This wires the **signing path** but the built-in `LoginModal` still shows
+only Freighter / Albedo. To render the kit's full wallet list (xBull, Lobstr,
+Rabet, …) inside `LoginModal`, also pass the picker — see
+[Wallet picker UI (`/picker`)](#wallet-picker-ui-picker) below.
+
 The kit is a global singleton. `stellarWalletsKit(...)` returns a resolver and `StellarWalletsKit.init(...)` is called once on the first `loginWallet` call.
+
+> **0.8.0** — `network` is **required**. The previous `Networks.TESTNET`
+> default was removed because the kit is a global singleton, and silently
+> picking testnet for the consumer risked signing real-looking transactions
+> on the wrong chain. Pass `Networks.TESTNET` or `Networks.PUBLIC` explicitly.
 
 ## Default wallets
 
@@ -106,8 +116,12 @@ Trimming the default list (e.g. only Freighter + Albedo for a SEP-43 dapp) works
 
 ```ts
 interface StellarWalletsKitAdapterOptions {
-  /** Stellar network used for signing. Defaults to `Networks.TESTNET`. */
-  network?: Networks;
+  /**
+   * Stellar network used for signing. **Required** as of 0.8.0 — the kit is a
+   * global singleton, so the network must be chosen explicitly to avoid
+   * cross-chain signing accidents.
+   */
+  network: Networks;
 
   /**
    * Wallet modules the kit can drive. Defaults to every module that works
@@ -115,6 +129,28 @@ interface StellarWalletsKitAdapterOptions {
    * replaces the default — include modules you want explicitly.
    */
   modules?: ModuleInterface[];
+
+  /**
+   * Picker-specific options. Only consumed by `<KitWalletPicker>` /
+   * `createStellarWalletsKitBundle` (the `/picker` subpath). The resolver
+   * itself ignores them.
+   */
+  picker?: KitPickerOptions;
+}
+
+interface KitPickerOptions {
+  /** Subset of wallet ids to show. Defaults to every wallet the kit reports. */
+  wallets?: string[];
+  /** Render order. Default `'as-given'` (the kit's own order). */
+  order?: 'as-given' | 'installed-first' | 'alphabetical';
+  /** Hide wallets whose `isAvailable` is false. Default `false`. */
+  showInstalledOnly?: boolean;
+  /** Per-wallet label overrides. Key = wallet id. */
+  labels?: Record<string, string>;
+  /** Visual layout. Default `'grid'`. */
+  layout?: 'grid' | 'list';
+  /** Theme passthrough — applied as CSS custom properties on the picker root. */
+  theme?: { accent?: string; mode?: 'light' | 'dark' };
 }
 ```
 
@@ -140,6 +176,71 @@ The adapter implements `WalletAdapter` from `@pollar/core`:
 | `signAuthEntry(xdr, opts)`   | `setWallet(id)` → `signAuthEntry(xdr, opts)`   |
 
 `setWallet` is called before every operation so a single `StellarWalletsKit.init({ modules })` covers many wallets — `PollarClient` resolves a fresh adapter instance per `WalletId`, and the kit routes to the correct module under the hood.
+
+## Wallet picker UI (`/picker`)
+
+The `/picker` subpath ships a React component that renders the kit's full
+wallet list inside Pollar's `LoginModal`. It plugs into the
+`ui.renderWallets` slot on `<PollarProvider>` (new in `@pollar/react@0.8.0`).
+
+> **React is an optional peer dep.** Only the `/picker` subpath pulls in
+> `react` / `react-dom` / `@pollar/react`. Headless consumers of
+> `stellarWalletsKit({ network })` keep working with zero React in the bundle.
+
+### Bundle helper
+
+`createStellarWalletsKitBundle` builds both halves of the integration
+(signing resolver + picker slot) from a single options object, so the picker
+can only show wallets that signing actually supports:
+
+```tsx
+import { PollarProvider } from '@pollar/react';
+import { createStellarWalletsKitBundle } from '@pollar/stellar-wallets-kit-adapter/picker';
+import { Networks } from '@creit.tech/stellar-wallets-kit';
+
+const bundle = createStellarWalletsKitBundle({
+  network: Networks.PUBLIC,
+  // Optional — subset, order, layout, theme, labels: see `KitPickerOptions`
+  picker: { wallets: ['xbull', 'lobstr', 'freighter'], layout: 'list' },
+});
+
+<PollarProvider
+  client={{ apiKey: 'your-api-key', walletAdapter: bundle.walletAdapter }}
+  ui={{ renderWallets: bundle.renderWallets }}
+>
+  {/* your app */}
+</PollarProvider>;
+```
+
+### Picker component directly
+
+If you already build the `walletAdapter` yourself (e.g. composing a custom
+resolver), use `<KitWalletPicker>` directly inside a `renderWallets` slot:
+
+```tsx
+import { KitWalletPicker } from '@pollar/stellar-wallets-kit-adapter/picker';
+import { Networks } from '@creit.tech/stellar-wallets-kit';
+
+<PollarProvider
+  client={{ apiKey: '…', walletAdapter: myResolver }}
+  ui={{
+    renderWallets: ({ onConnect, authState }) => (
+      <KitWalletPicker
+        onConnect={onConnect}
+        authState={authState}
+        network={Networks.PUBLIC}
+        picker={{ wallets: ['xbull', 'lobstr'], showInstalledOnly: true }}
+      />
+    ),
+  }}
+>
+  {children}
+</PollarProvider>;
+```
+
+`<KitWalletPicker>` will lazily call `ensureInit({ network, modules })` on
+mount, so it works whether or not `stellarWalletsKit(...)` has already been
+called elsewhere — both share the same kit singleton.
 
 ## Direct adapter access
 

--- a/packages/stellar-wallets-kit-adapter/package.json
+++ b/packages/stellar-wallets-kit-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/stellar-wallets-kit-adapter",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Stellar Wallets Kit adapter for @pollar/core — plug additional wallet modules (xBull, Lobstr, WalletConnect, hardware wallets…) into Pollar without bundling them into @pollar/core.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -14,6 +14,16 @@
       "require": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
+      }
+    },
+    "./picker": {
+      "import": {
+        "types": "./dist/picker.d.mts",
+        "default": "./dist/picker.mjs"
+      },
+      "require": {
+        "types": "./dist/picker.d.ts",
+        "default": "./dist/picker.js"
       }
     }
   },
@@ -32,7 +42,15 @@
   },
   "peerDependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.0.0",
-    "@pollar/core": "*"
+    "@pollar/core": "*",
+    "@pollar/react": "^0.8.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@pollar/react": { "optional": true },
+    "react": { "optional": true },
+    "react-dom": { "optional": true }
   },
   "dependencies": {
     "@pollar/core": "*"
@@ -40,7 +58,10 @@
   "devDependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.2.0",
     "@eslint/js": "^9.39.4",
+    "@pollar/react": "*",
+    "@types/react": "^18.0.0",
     "eslint": "^9.39.4",
+    "react": "^18.0.0",
     "tsup": "^8.3.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.1"

--- a/packages/stellar-wallets-kit-adapter/package.json
+++ b/packages/stellar-wallets-kit-adapter/package.json
@@ -48,9 +48,15 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
-    "@pollar/react": { "optional": true },
-    "react": { "optional": true },
-    "react-dom": { "optional": true }
+    "@pollar/react": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@pollar/core": "*"

--- a/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
+++ b/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
@@ -8,6 +8,7 @@ import type {
   WalletAdapter,
   WalletId,
 } from '@pollar/core';
+import { getInitNetwork } from './factory';
 
 /**
  * Wraps Stellar Wallets Kit so it satisfies the `@pollar/core` `WalletAdapter`
@@ -66,9 +67,13 @@ export class StellarWalletsKitAdapter implements WalletAdapter {
   }
 
   async signTransaction(xdr: string, options?: SignTransactionOptions): Promise<SignTransactionResponse> {
+    if (options?.networkPassphrase !== undefined && options.networkPassphrase !== getInitNetwork()) {
+      throw new Error(
+        `[StellarWalletsKit] networkPassphrase override "${options.networkPassphrase}" does not match the network configured at init ("${getInitNetwork()}"). The kit is a global singleton — configure one network at \`stellarWalletsKit({ network })\` and use that for every call.`,
+      );
+    }
     StellarWalletsKit.setWallet(String(this.type));
     const result = await StellarWalletsKit.signTransaction(xdr, {
-      ...(options?.networkPassphrase !== undefined && { networkPassphrase: options.networkPassphrase }),
       ...(options?.accountToSign !== undefined && { address: options.accountToSign }),
     });
     return { signedTxXdr: result.signedTxXdr };

--- a/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
+++ b/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
@@ -25,14 +25,17 @@ export class StellarWalletsKitAdapter implements WalletAdapter {
   }
 
   async isAvailable(): Promise<boolean> {
+    // `refreshSupportedWallets()` probes every module's own `isAvailable()`
+    // hook (modules promise <1000ms per the kit contract) and returns a
+    // static snapshot. This avoids the old false-positive where we always
+    // claimed availability and let `connect()` fail later — the picker / UI
+    // can now short-circuit on `wallet_not_installed` immediately.
     try {
-      StellarWalletsKit.setWallet(String(this.type));
-      // The kit doesn't expose a top-level `isAvailable`; once the module is
-      // selected, attempting an address fetch is the cheapest probe — but it
-      // can pop UI on some wallets. Return true and let `connect()` surface
-      // the real availability error if any.
-      return true;
-    } catch {
+      const supported = await StellarWalletsKit.refreshSupportedWallets();
+      const wallet = supported.find((w) => w.id === String(this.type));
+      return wallet?.isAvailable ?? false;
+    } catch (err) {
+      console.warn(`[StellarWalletsKit] isAvailable probe failed for "${this.type}"`, err);
       return false;
     }
   }

--- a/packages/stellar-wallets-kit-adapter/src/factory.ts
+++ b/packages/stellar-wallets-kit-adapter/src/factory.ts
@@ -95,7 +95,17 @@ export function buildDefaultModules(): ModuleInterface[] {
  * first-time init path `network` is required and we throw if it's absent.
  */
 export function ensureInit(options: Partial<StellarWalletsKitAdapterOptions>): void {
-  if (initialised) return;
+  if (initialised) {
+    // The kit is a global singleton — a second call with a different network
+    // would be silently ignored. Warn so the developer notices the
+    // misconfiguration instead of debugging wrong-chain signatures later.
+    if (options.network && options.network !== initNetwork) {
+      console.warn(
+        `[StellarWalletsKit] Already initialised with network "${initNetwork}". Ignoring attempted reconfiguration to "${options.network}". The kit is a global singleton — reload the page to change networks.`,
+      );
+    }
+    return;
+  }
   if (!options.network) {
     throw new Error(
       '[StellarWalletsKit] `network` is required — pass `Networks.TESTNET` or `Networks.PUBLIC` to `stellarWalletsKit({ network })`. The kit is a global singleton, so the network has to be chosen explicitly at init.',

--- a/packages/stellar-wallets-kit-adapter/src/factory.ts
+++ b/packages/stellar-wallets-kit-adapter/src/factory.ts
@@ -14,6 +14,26 @@ import { xBullModule } from '@creit.tech/stellar-wallets-kit/modules/xbull';
 import type { WalletAdapterResolver, WalletId } from '@pollar/core';
 import { StellarWalletsKitAdapter } from './StellarWalletsKitAdapter';
 
+/**
+ * Options that shape `<KitWalletPicker>` (from the `/picker` subpath). Kept on
+ * `StellarWalletsKitAdapterOptions` so `createStellarWalletsKitBundle()` can
+ * receive everything (network + modules + UI) in one call.
+ */
+export interface KitPickerOptions {
+  /** Subset of wallet ids to show. Defaults to every wallet the kit reports. */
+  wallets?: string[];
+  /** Render order. Default `'as-given'` (the kit's own order). */
+  order?: 'as-given' | 'installed-first' | 'alphabetical';
+  /** Hide wallets whose `isAvailable` is false. Default `false`. */
+  showInstalledOnly?: boolean;
+  /** Per-wallet label overrides. Key = wallet id. */
+  labels?: Record<string, string>;
+  /** Visual layout. Default `'grid'`. */
+  layout?: 'grid' | 'list';
+  /** Theme passthrough — applied as CSS custom properties on the picker root. */
+  theme?: { accent?: string; mode?: 'light' | 'dark' };
+}
+
 export interface StellarWalletsKitAdapterOptions {
   /**
    * Stellar network the kit will use for signing. Defaults to `Networks.TESTNET`.
@@ -33,11 +53,18 @@ export interface StellarWalletsKitAdapterOptions {
    * ```
    */
   modules?: ModuleInterface[];
+  /**
+   * Picker-specific options. Only consumed by `<KitWalletPicker>` /
+   * `createStellarWalletsKitBundle` (the `/picker` subpath). The resolver
+   * itself ignores them.
+   */
+  picker?: KitPickerOptions;
 }
 
 let initialised = false;
 
-function buildDefaultModules(): ModuleInterface[] {
+/** @internal — used by the `/picker` subpath. */
+export function buildDefaultModules(): ModuleInterface[] {
   return [
     new AlbedoModule(),
     new BitgetModule(),
@@ -54,7 +81,8 @@ function buildDefaultModules(): ModuleInterface[] {
   ];
 }
 
-function ensureInit(options: StellarWalletsKitAdapterOptions): void {
+/** @internal — used by the `/picker` subpath. */
+export function ensureInit(options: StellarWalletsKitAdapterOptions): void {
   if (initialised) return;
   StellarWalletsKit.init({
     network: options.network ?? Networks.TESTNET,

--- a/packages/stellar-wallets-kit-adapter/src/factory.ts
+++ b/packages/stellar-wallets-kit-adapter/src/factory.ts
@@ -36,9 +36,13 @@ export interface KitPickerOptions {
 
 export interface StellarWalletsKitAdapterOptions {
   /**
-   * Stellar network the kit will use for signing. Defaults to `Networks.TESTNET`.
+   * Stellar network the kit will use for signing. Required — there is no
+   * default. The kit is a global singleton, so picking the network silently
+   * for a consumer would risk signing real-looking transactions on the wrong
+   * chain (testnet xdr signed on mainnet, etc.). Pass `Networks.TESTNET` or
+   * `Networks.PUBLIC` explicitly.
    */
-  network?: Networks;
+  network: Networks;
   /**
    * Wallet modules the kit should drive. Defaults to every module that works
    * out of the box (Albedo, Bitget, CactusLink, Fordefi, Freighter, Hana,
@@ -62,6 +66,7 @@ export interface StellarWalletsKitAdapterOptions {
 }
 
 let initialised = false;
+let initNetwork: Networks | null = null;
 
 /** @internal — used by the `/picker` subpath. */
 export function buildDefaultModules(): ModuleInterface[] {
@@ -81,14 +86,35 @@ export function buildDefaultModules(): ModuleInterface[] {
   ];
 }
 
-/** @internal — used by the `/picker` subpath. */
-export function ensureInit(options: StellarWalletsKitAdapterOptions): void {
+/**
+ * @internal — used by the `/picker` subpath.
+ *
+ * Accepts `Partial<...>` because the picker may be mounted in a flow where
+ * `stellarWalletsKit({ network })` has already initialised the kit elsewhere;
+ * in that case the call no-ops and the missing `network` is fine. On the
+ * first-time init path `network` is required and we throw if it's absent.
+ */
+export function ensureInit(options: Partial<StellarWalletsKitAdapterOptions>): void {
   if (initialised) return;
+  if (!options.network) {
+    throw new Error(
+      '[StellarWalletsKit] `network` is required — pass `Networks.TESTNET` or `Networks.PUBLIC` to `stellarWalletsKit({ network })`. The kit is a global singleton, so the network has to be chosen explicitly at init.',
+    );
+  }
   StellarWalletsKit.init({
-    network: options.network ?? Networks.TESTNET,
+    network: options.network,
     modules: options.modules ?? buildDefaultModules(),
   });
+  initNetwork = options.network;
   initialised = true;
+}
+
+/** @internal — used by `StellarWalletsKitAdapter` to reject per-call network overrides that don't match init. */
+export function getInitNetwork(): Networks {
+  if (initNetwork === null) {
+    throw new Error('[StellarWalletsKit] not initialised — call `stellarWalletsKit({ network })` first');
+  }
+  return initNetwork;
 }
 
 /**
@@ -107,7 +133,7 @@ export function ensureInit(options: StellarWalletsKitAdapterOptions): void {
  * });
  * ```
  */
-export function stellarWalletsKit(options: StellarWalletsKitAdapterOptions = {}): WalletAdapterResolver {
+export function stellarWalletsKit(options: StellarWalletsKitAdapterOptions): WalletAdapterResolver {
   return (id: WalletId) => {
     ensureInit(options);
     return new StellarWalletsKitAdapter(id);

--- a/packages/stellar-wallets-kit-adapter/src/index.ts
+++ b/packages/stellar-wallets-kit-adapter/src/index.ts
@@ -1,3 +1,3 @@
 export { StellarWalletsKitAdapter } from './StellarWalletsKitAdapter';
 export { stellarWalletsKit } from './factory';
-export type { StellarWalletsKitAdapterOptions } from './factory';
+export type { KitPickerOptions, StellarWalletsKitAdapterOptions } from './factory';

--- a/packages/stellar-wallets-kit-adapter/src/picker/KitWalletPicker.tsx
+++ b/packages/stellar-wallets-kit-adapter/src/picker/KitWalletPicker.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  type ISupportedWallet,
-  type ModuleInterface,
-  type Networks,
-  StellarWalletsKit,
-} from '@creit.tech/stellar-wallets-kit';
+import { type ISupportedWallet, type ModuleInterface, type Networks, StellarWalletsKit } from '@creit.tech/stellar-wallets-kit';
 import type { RenderWalletsProps } from '@pollar/react';
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import { ensureInit, type KitPickerOptions } from '../factory';
@@ -16,19 +11,9 @@ export interface KitWalletPickerProps extends RenderWalletsProps {
   picker?: KitPickerOptions;
 }
 
-const CONNECTING_STEPS = new Set([
-  'connecting_wallet',
-  'authenticating_wallet',
-  'authenticating',
-]);
+const CONNECTING_STEPS = new Set(['connecting_wallet', 'authenticating_wallet', 'authenticating']);
 
-export function KitWalletPicker({
-  onConnect,
-  authState,
-  network,
-  modules,
-  picker = {},
-}: KitWalletPickerProps) {
+export function KitWalletPicker({ onConnect, authState, network, modules, picker = {} }: KitWalletPickerProps) {
   const [wallets, setWallets] = useState<ISupportedWallet[] | null>(null);
   const warnedRef = useRef<Set<string>>(new Set());
 
@@ -54,12 +39,7 @@ export function KitWalletPicker({
 
   const filtered = useMemo(() => {
     if (!wallets) return null;
-    const {
-      wallets: allowedIds,
-      order = 'as-given',
-      showInstalledOnly = false,
-      labels,
-    } = picker;
+    const { wallets: allowedIds, order = 'as-given', showInstalledOnly = false, labels } = picker;
 
     const byId = new Map(wallets.map((w) => [w.id, w]));
     let result: ISupportedWallet[];
@@ -73,9 +53,7 @@ export function KitWalletPicker({
           result.push(w);
         } else if (!warnedRef.current.has(id)) {
           warnedRef.current.add(id);
-          console.warn(
-            `[KitWalletPicker] wallet id "${id}" not present in the active kit modules — skipped`,
-          );
+          console.warn(`[KitWalletPicker] wallet id "${id}" not present in the active kit modules — skipped`);
         }
       }
     } else {
@@ -146,17 +124,9 @@ export function KitWalletPicker({
             style={buttonStyle(layout, disabled)}
             title={!w.isAvailable && !picker.showInstalledOnly ? `${label} not detected` : label}
           >
-            <img
-              src={w.icon}
-              alt=""
-              width={32}
-              height={32}
-              style={{ borderRadius: 6, opacity: w.isAvailable ? 1 : 0.5 }}
-            />
+            <img src={w.icon} alt="" width={32} height={32} style={{ borderRadius: 6, opacity: w.isAvailable ? 1 : 0.5 }} />
             <span style={{ fontSize: '0.85rem', fontWeight: 500 }}>{label}</span>
-            {!w.isAvailable && (
-              <span style={{ fontSize: '0.7rem', opacity: 0.6 }}>not installed</span>
-            )}
+            {!w.isAvailable && <span style={{ fontSize: '0.7rem', opacity: 0.6 }}>not installed</span>}
           </button>
         );
       })}

--- a/packages/stellar-wallets-kit-adapter/src/picker/KitWalletPicker.tsx
+++ b/packages/stellar-wallets-kit-adapter/src/picker/KitWalletPicker.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import {
+  type ISupportedWallet,
+  type ModuleInterface,
+  type Networks,
+  StellarWalletsKit,
+} from '@creit.tech/stellar-wallets-kit';
+import type { RenderWalletsProps } from '@pollar/react';
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
+import { ensureInit, type KitPickerOptions } from '../factory';
+
+export interface KitWalletPickerProps extends RenderWalletsProps {
+  network?: Networks;
+  modules?: ModuleInterface[];
+  picker?: KitPickerOptions;
+}
+
+const CONNECTING_STEPS = new Set([
+  'connecting_wallet',
+  'authenticating_wallet',
+  'authenticating',
+]);
+
+export function KitWalletPicker({
+  onConnect,
+  authState,
+  network,
+  modules,
+  picker = {},
+}: KitWalletPickerProps) {
+  const [wallets, setWallets] = useState<ISupportedWallet[] | null>(null);
+  const warnedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    const initOpts: { network?: Networks; modules?: ModuleInterface[] } = {};
+    if (network !== undefined) initOpts.network = network;
+    if (modules !== undefined) initOpts.modules = modules;
+    ensureInit(initOpts);
+    StellarWalletsKit.refreshSupportedWallets()
+      .then((list) => {
+        if (cancelled) return;
+        setWallets(list);
+      })
+      .catch((err) => {
+        console.error('[KitWalletPicker] refreshSupportedWallets failed', err);
+        if (!cancelled) setWallets([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network, modules]);
+
+  const filtered = useMemo(() => {
+    if (!wallets) return null;
+    const {
+      wallets: allowedIds,
+      order = 'as-given',
+      showInstalledOnly = false,
+      labels,
+    } = picker;
+
+    const byId = new Map(wallets.map((w) => [w.id, w]));
+    let result: ISupportedWallet[];
+
+    if (allowedIds && allowedIds.length > 0) {
+      // Honor `as-given` order from the allowedIds; warn once for unknowns.
+      result = [];
+      for (const id of allowedIds) {
+        const w = byId.get(id);
+        if (w) {
+          result.push(w);
+        } else if (!warnedRef.current.has(id)) {
+          warnedRef.current.add(id);
+          console.warn(
+            `[KitWalletPicker] wallet id "${id}" not present in the active kit modules — skipped`,
+          );
+        }
+      }
+    } else {
+      result = [...wallets];
+    }
+
+    if (showInstalledOnly) {
+      result = result.filter((w) => w.isAvailable);
+    }
+
+    if (order === 'alphabetical') {
+      result = [...result].sort((a, b) => labelOf(a, labels).localeCompare(labelOf(b, labels)));
+    } else if (order === 'installed-first') {
+      result = [...result].sort((a, b) => {
+        if (a.isAvailable === b.isAvailable) return 0;
+        return a.isAvailable ? -1 : 1;
+      });
+    }
+    // 'as-given' keeps whatever order we built above.
+
+    return result;
+  }, [wallets, picker]);
+
+  const isBusy = CONNECTING_STEPS.has(authState.step);
+  const layout = picker.layout ?? 'grid';
+  const theme = picker.theme;
+  const rootStyle: CSSProperties = {
+    display: layout === 'list' ? 'flex' : 'grid',
+    flexDirection: layout === 'list' ? 'column' : undefined,
+    gridTemplateColumns: layout === 'grid' ? 'repeat(auto-fill, minmax(140px, 1fr))' : undefined,
+    gap: '0.5rem',
+    width: '100%',
+    ...(theme?.accent !== undefined && { ['--pollar-accent' as never]: theme.accent }),
+    ...(theme?.mode === 'dark' && { colorScheme: 'dark' as const }),
+  };
+
+  // Still loading the wallet list.
+  if (filtered === null) {
+    return (
+      <div role="status" aria-busy="true" style={{ padding: '1rem', textAlign: 'center', fontSize: '0.9rem' }}>
+        Loading wallets…
+      </div>
+    );
+  }
+
+  // Empty state: showInstalledOnly hid every wallet, or the filter list is empty.
+  if (filtered.length === 0) {
+    return (
+      <div style={{ padding: '1rem', textAlign: 'center', fontSize: '0.9rem' }}>
+        {picker.showInstalledOnly
+          ? 'No supported Stellar wallets detected. Install Freighter / xBull / Lobstr to continue.'
+          : 'No wallets to show.'}
+      </div>
+    );
+  }
+
+  return (
+    <div style={rootStyle}>
+      {filtered.map((w) => {
+        const label = labelOf(w, picker.labels);
+        const disabled = isBusy || (picker.showInstalledOnly ? false : !w.isAvailable);
+        return (
+          <button
+            key={w.id}
+            type="button"
+            disabled={disabled}
+            onClick={() => onConnect(w.id)}
+            style={buttonStyle(layout, disabled)}
+            title={!w.isAvailable && !picker.showInstalledOnly ? `${label} not detected` : label}
+          >
+            <img
+              src={w.icon}
+              alt=""
+              width={32}
+              height={32}
+              style={{ borderRadius: 6, opacity: w.isAvailable ? 1 : 0.5 }}
+            />
+            <span style={{ fontSize: '0.85rem', fontWeight: 500 }}>{label}</span>
+            {!w.isAvailable && (
+              <span style={{ fontSize: '0.7rem', opacity: 0.6 }}>not installed</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function labelOf(w: ISupportedWallet, labels: Record<string, string> | undefined): string {
+  return labels?.[w.id] ?? w.name;
+}
+
+function buttonStyle(layout: 'grid' | 'list', disabled: boolean): CSSProperties {
+  const base: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.55 : 1,
+    background: 'transparent',
+    border: '1px solid var(--pollar-border, #e5e7eb)',
+    borderRadius: 'var(--pollar-buttons-border-radius, 6px)',
+    color: 'var(--pollar-text, inherit)',
+    padding: '0.6rem',
+    gap: '0.6rem',
+  };
+  if (layout === 'list') {
+    return { ...base, justifyContent: 'flex-start', width: '100%', height: 'var(--pollar-buttons-height, 44px)' };
+  }
+  return { ...base, flexDirection: 'column', justifyContent: 'center', textAlign: 'center', minHeight: 92 };
+}

--- a/packages/stellar-wallets-kit-adapter/src/picker/bundle.tsx
+++ b/packages/stellar-wallets-kit-adapter/src/picker/bundle.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import type { WalletAdapterResolver } from '@pollar/core';
+import type { RenderWalletsSlot } from '@pollar/react';
+import { stellarWalletsKit, type StellarWalletsKitAdapterOptions } from '../factory';
+import { KitWalletPicker } from './KitWalletPicker';
+
+export interface StellarWalletsKitBundle {
+  /** Pass to `PollarClientConfig.walletAdapter`. */
+  walletAdapter: WalletAdapterResolver;
+  /** Pass to `<PollarProvider ui={{ renderWallets }}>`. */
+  renderWallets: RenderWalletsSlot;
+}
+
+/**
+ * One-shot helper that builds both halves of the integration from a single
+ * options object: the `walletAdapter` (a `WalletAdapterResolver` for the SDK)
+ * and `renderWallets` (a slot for `<PollarProvider ui={{ ... }}>`). The same
+ * `network` / `modules` / `picker` opts power both, so the picker shows the
+ * exact wallets that signing will actually work with.
+ *
+ * @example
+ * ```tsx
+ * import { createStellarWalletsKitBundle } from '@pollar/stellar-wallets-kit-adapter/picker';
+ * import { Networks } from '@creit.tech/stellar-wallets-kit';
+ *
+ * const bundle = createStellarWalletsKitBundle({
+ *   network: Networks.PUBLIC,
+ *   picker: { wallets: ['xbull', 'lobstr', 'freighter'] },
+ * });
+ *
+ * <PollarProvider
+ *   client={{ apiKey: '…', walletAdapter: bundle.walletAdapter }}
+ *   ui={{ renderWallets: bundle.renderWallets }}
+ * />
+ * ```
+ */
+export function createStellarWalletsKitBundle(
+  options: StellarWalletsKitAdapterOptions = {},
+): StellarWalletsKitBundle {
+  const walletAdapter = stellarWalletsKit(options);
+  const renderWallets: RenderWalletsSlot = (slot) => (
+    <KitWalletPicker
+      onConnect={slot.onConnect}
+      authState={slot.authState}
+      {...(options.network !== undefined && { network: options.network })}
+      {...(options.modules !== undefined && { modules: options.modules })}
+      {...(options.picker !== undefined && { picker: options.picker })}
+    />
+  );
+  return { walletAdapter, renderWallets };
+}

--- a/packages/stellar-wallets-kit-adapter/src/picker/bundle.tsx
+++ b/packages/stellar-wallets-kit-adapter/src/picker/bundle.tsx
@@ -35,9 +35,7 @@ export interface StellarWalletsKitBundle {
  * />
  * ```
  */
-export function createStellarWalletsKitBundle(
-  options: StellarWalletsKitAdapterOptions,
-): StellarWalletsKitBundle {
+export function createStellarWalletsKitBundle(options: StellarWalletsKitAdapterOptions): StellarWalletsKitBundle {
   const walletAdapter = stellarWalletsKit(options);
   const renderWallets: RenderWalletsSlot = (slot) => (
     <KitWalletPicker

--- a/packages/stellar-wallets-kit-adapter/src/picker/bundle.tsx
+++ b/packages/stellar-wallets-kit-adapter/src/picker/bundle.tsx
@@ -36,14 +36,14 @@ export interface StellarWalletsKitBundle {
  * ```
  */
 export function createStellarWalletsKitBundle(
-  options: StellarWalletsKitAdapterOptions = {},
+  options: StellarWalletsKitAdapterOptions,
 ): StellarWalletsKitBundle {
   const walletAdapter = stellarWalletsKit(options);
   const renderWallets: RenderWalletsSlot = (slot) => (
     <KitWalletPicker
       onConnect={slot.onConnect}
       authState={slot.authState}
-      {...(options.network !== undefined && { network: options.network })}
+      network={options.network}
       {...(options.modules !== undefined && { modules: options.modules })}
       {...(options.picker !== undefined && { picker: options.picker })}
     />

--- a/packages/stellar-wallets-kit-adapter/src/picker/index.ts
+++ b/packages/stellar-wallets-kit-adapter/src/picker/index.ts
@@ -1,0 +1,4 @@
+export { KitWalletPicker } from './KitWalletPicker';
+export type { KitWalletPickerProps } from './KitWalletPicker';
+export { createStellarWalletsKitBundle } from './bundle';
+export type { StellarWalletsKitBundle } from './bundle';

--- a/packages/stellar-wallets-kit-adapter/tsconfig.json
+++ b/packages/stellar-wallets-kit-adapter/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/packages/stellar-wallets-kit-adapter/tsup.config.ts
+++ b/packages/stellar-wallets-kit-adapter/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    picker: 'src/picker/index.ts',
+  },
   format: ['cjs', 'esm'],
   dts: true,
   splitting: false,
@@ -9,5 +12,8 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   target: 'es2020',
-  external: ['@pollar/core', '@creit.tech/stellar-wallets-kit'],
+  external: ['@pollar/core', '@creit.tech/stellar-wallets-kit', 'react', 'react-dom', '@pollar/react'],
+  esbuildOptions(opts) {
+    opts.jsx = 'automatic';
+  },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig.json", "tsup.config.ts", "package.json"],
       "outputs": ["dist/**"]
     },
     "dev": {
@@ -10,6 +11,7 @@
       "persistent": true
     },
     "lint": {
+      "inputs": ["src/**", "tsconfig.json", "eslint.config.js", "eslint.config.mjs", "package.json"],
       "outputs": []
     },
     "clean": {


### PR DESCRIPTION
## Summary

Release of `@pollar/*` at `0.8.0`. Three breaking changes, one new public surface, and a batch of reliability fixes across all four packages.

- **`<PollarProvider>` reshaped** — `config` → `client`, `styles` moves under `appConfig.styles`, new `appConfig` opt-out for the remote `/applications/config` fetch, new `ui.renderWallets` slot for a pluggable wallet picker.
- **New `/picker` subpath on `@pollar/stellar-wallets-kit-adapter`** — `<KitWalletPicker>` and `createStellarWalletsKitBundle` render the kit's full wallet list (xBull, Lobstr, Rabet, Hana, OneKey, …) inside Pollar's `LoginModal`. React is now an optional peer dep on this package; the headless `stellarWalletsKit({ network })` consumer stays React-free.
- **`@pollar/core` unifies tx submission through `/tx/submit`** for both custodial and external wallets so the developer dashboard sees every transaction and `submissionToken` idempotency works end-to-end. External-wallet `submitTx` may now resolve to `pending` (previously only `success` / `error`).

Full notes in [CHANGELOG.md](./CHANGELOG.md). Migration matrix in [UPGRADE.md](./UPGRADE.md).

## Breaking changes

| Package | Change |
| --- | --- |
| `@pollar/react` | `<PollarProvider>` props: `config` → `client`; `styles` → `appConfig.styles`; remote `/applications/config` fetch is now opt-out via `appConfig` presence. Fetch errors are logged instead of silently swallowed. |
| `@pollar/stellar-wallets-kit-adapter` | `network` is now **required** on `StellarWalletsKitAdapterOptions` (no more `Networks.TESTNET` default). Per-call `networkPassphrase` overrides are rejected if they don't match init. |
| `@pollar/core` | External-wallet `submitTx` no longer hits Horizon directly — all submissions route through sdk-api `/tx/submit`. New `pending` outcome possible. ~50–150 ms latency cost vs. the legacy direct-Horizon path. |

## What's new

- `@pollar/react` — `ui.renderWallets` slot, `RenderWalletsProps` / `RenderWalletsSlot` exports.
- `@pollar/stellar-wallets-kit-adapter` — `/picker` subpath (`<KitWalletPicker>`, `createStellarWalletsKitBundle`), `KitPickerOptions` (wallet subset / order / layout / theme / labels), optional React peer dep.
- `@pollar/core` — proactive token refresh with a visibility-aware scheduler, `onStorageDegrade` telemetry hook, wallet-adapter-resolver timeout.

## What's fixed

- `@pollar/core` — auto-retry after a post-refresh 401 is now restricted to idempotent verbs (no more accidental double-POST). Login abort signal threaded through the wallet resolver.
- `@pollar/react` — provider props read directly instead of via a stale ref; timers cleared on unmount; explicit session equality.
- `@pollar/stellar-wallets-kit-adapter` — second-init network mismatch now logged; `isAvailable()` uses the kit's own flag instead of re-probing per render.
- `@pollar/privy-adapter` — self-heal wallet cache on stale entries, per-`userId` mutex on `POST /wallets/create`, coalesced concurrent `PrivyClient` construction, raw error messages dropped from HTTP responses, `@privy-io/node` pinned to `~0.18.0`.

## Test plan

- [x] `npm run build` succeeds across all four packages
- [x] `npm run lint` and `npm run typecheck` pass
- [x] `@pollar/react` consumer (sample app) starts and renders `LoginModal` with the default Freighter+Albedo picker (no `ui.renderWallets`)
- [x] Same consumer with `ui.renderWallets={bundle.renderWallets}` renders the kit's full wallet list and signs on `Networks.TESTNET`
- [ ] `appConfig={{}}` skips the remote `/applications/config` fetch (verify in Network panel)
- [ ] External-wallet `submitTx` now goes through `/tx/submit` and surfaces in `/apps/:id/monitor/transactions`
- [ ] Custodial-wallet flow unchanged end-to-end (build → sign → submit)
- [ ] `stellarWalletsKit({ /* no network */ })` throws a clear init error
- [ ] `privy-adapter` rejects raw error message leaks from Privy 4xx responses