### PR TITLE
Release 0.11.2: Stellar ownership proofs (SEP-53 / SEP-10) and a multichain history modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,98 @@
 # Changelog
 
+## 0.11.2
+
+> Stable release. Published under the default `latest` dist-tag
+> (`npm i @pollar/core`). Headline: **Stellar ownership proofs** — the new
+> `client.stellar` namespace signs SEP-53 messages and SEP-10 challenges across
+> custodial and external wallets — and the **Transaction History modal goes
+> multichain**. Additive, non-breaking on top of 0.11.1.
+
+### Highlights (since 0.11.1)
+
+- **`client.stellar` — SEP ownership proofs.** `sep53.signMessage(message)` and
+  `sep10.sign({ challengeXdr, ... })` prove wallet ownership to a verifier. Each
+  dispatches by wallet type: external wallets sign client-side via their
+  adapter, custodial wallets sign server-side through sdk-api, and smart
+  (passkey) wallets are rejected with a clear error (no classic ed25519 key).
+  Both paths return the same `sep53` scheme (base64 signature + signer address),
+  so external and custodial proofs are interchangeable for a verifier.
+- **Multichain Transaction History modal.** The History modal gains the network
+  picker and address chip the Balance / Send modals already have, per-chain
+  explorer links, and the unified `{ amount, unit }` fee.
+- **`@stellar/freighter-api` 6.0.0.** The Freighter adapter migrated to the v6
+  API, which unblocks native SEP-53 message signing.
+
+### `@pollar/core`
+
+- New `client.stellar` namespace (`StellarSepApi`), Stellar-specific standards
+  namespaced so the multichain client stays clean:
+  - `sep53.signMessage(message)` — SEP-53 message ownership proof. External
+    wallets sign through the new **optional `signStellarMessage`** on the
+    `WalletAdapter` interface (Freighter implements it via the v6 native
+    `signMessage`; Albedo throws — its `sign_message` intent cannot produce a
+    SEP-53 signature). Custodial wallets post to `/v2/stellar/sep53/sign`. The
+    signature is base64 ed25519 over the SEP-53 digest
+    (`SHA-256("Stellar Signed Message:\n" + message)`) on every path.
+  - `sep10.sign({ challengeXdr, homeDomains?, webAuthDomain? })` — SEP-10
+    challenge ownership proof. External wallets reuse the adapter's existing
+    `signTransaction`; custodial wallets post to `/v2/stellar/sep10/sign`,
+    which reuses the audited sign-sep10-challenge path (validates the challenge
+    is un-submittable). Passing the verifier domains enables full SEP-10
+    validation on the custodial path.
+- New exported types: `StellarSepApi`, `StellarMessageProof`, `Sep10SignParams`,
+  `Sep10Proof`, `SignMessageOptions`, `SignMessageResponse`.
+- `@stellar/freighter-api` bumped `2.0.0` → `6.0.0` and `FreighterAdapter`
+  migrated (v6 returns `{ ...data, error? }` instead of throwing, and
+  `getUserInfo` is replaced by `getAddress` / `requestAccess`). No change to the
+  adapter's own throw-on-failure contract, and it dedupes the second
+  freighter-api copy that `@pollar/stellar-wallets-kit-adapter` already pinned.
+- `schema.d.ts` regenerated from sdk-api: the two `/v2/stellar/sep*/sign` paths,
+  and the v2 history record now carries `chain` and `fee` (query accepts
+  `chain`).
+
+### `@pollar/react`
+
+- The Transaction History modal gains the network picker and address chip the
+  Balance / Send modals already have. Selecting a network refetches history
+  filtered to that chain (the filter is a server query param, since pagination
+  is server-side) and resets the pager to page 1 — page 3 of Stellar is not
+  page 3 of Solana. Each row links to its own chain's explorer
+  (explorer.solana.com for Solana, stellar.expert for Stellar) and shows the
+  unified `{ amount, unit }` fee, so a Solana row reads "5000 lamports" rather
+  than being mislabelled XLM. The picker hides itself on a single-chain app,
+  like the other modals.
+- **The swap sell list is Stellar-only again.** The filter now tests `chain`
+  (the same guard the buy list already used) instead of `type`: a SOL row
+  passed the `type === 'native'` arm and became a Stellar native sell asset,
+  and an SPL/ERC-20 row passed the trustline arm (`trustlineRemoved` is
+  Stellar-only, so it is `undefined` off Stellar) and was narrowed to a
+  credit_alphanum.
+- **A locally-passed `appConfig` is re-applied after mount.** A consumer that
+  added or swapped `<PollarProvider appConfig>` after the first render got
+  `configStatus: 'ready'` while the context kept serving the value from the
+  initial state (stale login settings and chain order). The effect keys on the
+  serialized config, so an inline `appConfig={{ ... }}` object literal does not
+  re-trigger it on every render.
+- **A Solana token send requires the row's mint and `decimals`.** Both are
+  optional on `WalletBalanceRecord` and both silent defaults were wrong for a
+  token: `mint: null` is dropped from the payload, turning a USDC transfer
+  into a native SOL one, and `decimals ?? 9` is SOL's precision, so a
+  6-decimal token would be multiplied by 1000. A non-native asset missing
+  either now fails the send; the `9` fallback remains only for native SOL.
+  sdk-api always populates both fields today, so this is a guard against
+  malformed data rather than a live path.
+
+### `@pollar/stellar-wallets-kit-adapter`
+
+- Implements `signStellarMessage` via `kit.signMessage`, so every kit wallet
+  that supports message signing can back a `client.stellar.sep53` proof.
+
+### Docs
+
+- The `@pollar/core` README's API reference now covers the full `PollarClient`
+  surface.
+
 ## 0.11.1
 
 > Stable release. Published under the default `latest` dist-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@
   stays `null` instead of being coerced to `'0'`, so the UI can tell
   "unavailable" from "zero". `WalletBalanceRecord.balance` is therefore
   `string | null`.
-- **Send on any chain the user holds.** `sendPayment()` is one entry point across
+- **Send on Stellar and Solana.** `sendPayment()` is one entry point across
   chains; Solana custodial sends land through the multichain atomic endpoint, and
-  the Send / Receive modals carry the network picker.
+  the Send / Receive modals carry the network picker. Polygon is browse-only: it
+  has no transfer path yet, so the Send modal blocks it and `sendPayment()`
+  returns an error for it.
 - **Network picker across every wallet modal.** New `ChainSelect` component and
   `useChains()` hook in `@pollar/react`; the balance, assets, send and receive
   modals filter to the selected chain, and the chain order plus primary address
@@ -62,13 +64,15 @@
 - `WalletBalanceRecord.balance` and `.available` are now `string | null`
   (`null` = the chain could not be read). Callers that parse the balance need a
   null check.
-- New `sendPayment(params)` — one entry point for sending on any chain the user
-  holds a wallet on. Stellar routes through `buildAndSignAndSubmitTx`, so
-  external adapters and passkey wallets keep the split build → sign → submit
-  flow; chains whose signature expires (a Solana blockhash lapses in ~60s) do
-  the whole thing in one server-side call and are **custodial-only** for now.
-  An `idempotencyKey` is minted per call, because a Solana submit is a single
-  non-idempotent shot and a transport retry would otherwise transfer twice.
+- New `sendPayment(params)` — one entry point for sending, on Stellar and on
+  Solana. Stellar routes through `buildAndSignAndSubmitTx`, so external adapters
+  and passkey wallets keep the split build → sign → submit flow; chains whose
+  signature expires (a Solana blockhash lapses in ~60s) do the whole thing in
+  one server-side call and are **custodial-only** for now. An `idempotencyKey`
+  is minted per call, because a Solana submit is a single non-idempotent shot
+  and a transport retry would otherwise transfer twice. `SendPaymentParams`
+  carries a `POLYGON` member for the shape, but there is no transfer path for it
+  yet and the call returns an error.
 - New `toBaseUnits(amount, decimals)` / `fromBaseUnits(base, decimals)`.
   Balances are reported formatted (`"1.5"`) while base-unit chains take integer
   amounts (`1500000000` lamports), so anything sending to those chains must

--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ This repository is managed with [Turborepo](https://turbo.build/repo) and contai
 
 ## Packages
 
-> **0.11.1 is a breaking change.** `WalletBalanceRecord.balance` and `.available` are now
+> **0.11.2 is additive (no breaking changes).** New `client.stellar` namespace: sign **SEP-53
+> message** and **SEP-10 challenge** ownership proofs across custodial and external wallets,
+> both returning the same `sep53` scheme so a verifier treats them alike. The Transaction
+> History modal goes **multichain** (network picker, per-chain explorer links, unified
+> `{ amount, unit }` fees), and the Freighter adapter runs on `@stellar/freighter-api` 6.0.0.
+>
+> Latest break — **0.11.1**: `WalletBalanceRecord.balance` and `.available` are
 > `string | null` — `null` means the chain could not be read and must render as unavailable,
-> never as `0`. Every chain now reports its native coin plus each token the app enabled
-> (0.11.0 reported only the native token off Stellar). `@pollar/react` gains a network picker
+> never as `0`. Every chain reports its native coin plus each token the app enabled
+> (0.11.0 reported only the native token off Stellar). `@pollar/react` gained a network picker
 > (`<ChainSelect>`) that scopes the wallet-balance, enabled-assets, send and receive modals to
 > one chain instead of tagging every row.
 >
@@ -26,7 +32,7 @@ This repository is managed with [Turborepo](https://turbo.build/repo) and contai
 
 ### [`@pollar/core`](./packages/core)
 
-**Version:** `0.11.1` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/core)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/core)
 
 Framework-agnostic TypeScript SDK. Provides the `PollarClient` class and all lower-level utilities needed to integrate
 Pollar authentication and multichain (Stellar + Solana) transactions into any JavaScript environment.
@@ -61,6 +67,9 @@ Pollar authentication and multichain (Stellar + Solana) transactions into any Ja
 - **Sponsored trustlines** - `setTrustline` lets the app config decide who pays (server-side): custodial wallets hit
   the sponsored/self-pay trustline endpoint, external wallets co-sign whichever XDR the server returns. Pass
   `skipSponsorship` to force the user's own wallet to pay via `change_trust`
+- **Stellar ownership proofs (SEP-53 / SEP-10)** - `client.stellar.sep53.signMessage()` and
+  `client.stellar.sep10.sign()` prove wallet ownership to a verifier. External wallets sign client-side via their
+  adapter, custodial wallets sign server-side, and both return the same `sep53` scheme
 - **Network resilience** - per-request timeout (default 10s) and idempotent-request retry; typed `PollarNetworkError`
 - KYC verification flow - provider selection, session start, and status polling
 - Transaction history - paginated fetch with status tracking
@@ -102,7 +111,7 @@ const client = new PollarClient({ apiKey: 'pk_...', storage });
 
 ### [`@pollar/react`](./packages/react)
 
-**Version:** `0.11.1` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/react)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/react)
 
 React bindings built on top of `@pollar/core`. Provides a context provider, hook, and pre-built UI components for
 drop-in authentication in React applications.
@@ -124,7 +133,9 @@ drop-in authentication in React applications.
 - `<RampWidget>` - SEP-24 buy/sell flow wired to the core ramps endpoints (external wallets sign the pending XDR inline)
 - `<KycModal>` - identity verification flow with provider selection and status polling _(UI preview - backend coming
   soon)_
-- `<TxHistoryModal>` — paginated transaction history viewer with auto-fetch on open and explorer links (stellar.expert for Stellar, Solscan for Solana)
+- `<TxHistoryModal>` — paginated multichain transaction history viewer with auto-fetch on open, a network picker that
+  filters server-side, per-chain explorer links (stellar.expert for Stellar, explorer.solana.com for Solana), and the
+  unified `{ amount, unit }` fee per row
 - `<WalletBalanceModal>` — multichain wallet balances (Stellar, Polygon, Solana): a `<ChainSelect>` picks the network and the rows are scoped to it; an unreadable chain shows a dash, never `0`
 - `<EnabledAssetsModal>` — the app's dashboard-enabled assets for the network picked in the header, with per-asset
   trustline state; establish/remove trustlines (Stellar only — other chains are informational)
@@ -148,7 +159,7 @@ npm install @pollar/react @pollar/core
 
 ### [`@pollar/privy-adapter`](./packages/privy-adapter)
 
-**Version:** `0.11.1` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/privy-adapter)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/privy-adapter)
 
 Client-side **Privy** wallet adapter for `@pollar/core`. It drives the whole Privy flow itself - email / Google / GitHub
 login, creating the user's Privy embedded wallet (Stellar or Solana), and raw-hash signing - then hands the signature to Pollar for
@@ -173,7 +184,7 @@ npm install @pollar/privy-adapter @pollar/core @stellar/stellar-sdk @privy-io/re
 
 ### [`@pollar/privy-server-adapter`](./packages/privy-server-adapter)
 
-**Version:** `0.11.1` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/privy-server-adapter)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/privy-server-adapter)
 
 Server-side Privy adapter. A stateless HTTP proxy that lets Pollar sign Stellar or Solana transactions through your **Privy**
 server-wallet account without your `PRIVY_APP_SECRET` ever leaving your infrastructure. You run it in your own backend
@@ -202,7 +213,7 @@ npm install @pollar/privy-server-adapter
 
 ### [`@pollar/accesly-adapter`](./packages/accesly-adapter)
 
-**Version:** `0.11.1` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/accesly-adapter)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/accesly-adapter)
 
 Client-side **Accesly** smart-account wallet adapter for `@pollar/core`. Signs Stellar transactions with a user's
 Accesly C-address (passkey + MPC) smart wallet, client-side.
@@ -220,7 +231,7 @@ npm install @pollar/accesly-adapter @pollar/core @accesly/react @accesly/core
 
 ### [`@pollar/stellar-wallets-kit-adapter`](./packages/stellar-wallets-kit-adapter)
 
-**Version:** `0.11.1` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/stellar-wallets-kit-adapter)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/stellar-wallets-kit-adapter)
 
 Plugs [Stellar Wallets Kit](https://stellarwalletskit.dev) into Pollar as a set of wallet adapters, without
 `@pollar/core` having to depend on the kit. One install gives Pollar access to **every wallet module the kit
@@ -236,7 +247,7 @@ plus Ledger / Trezor / WalletConnect via opt-in.
   trim the bundle
 - SSR-safe: `stellarWalletsKitAdapters()` returns `[]` when there is no `window` (Next.js / Remix) and builds the real
   list when it re-runs on the client
-- Peer deps: `@creit.tech/stellar-wallets-kit@^2.0.0` and `@pollar/core@^0.11.1` (the kit is **not** bundled)
+- Peer deps: `@creit.tech/stellar-wallets-kit@^2.0.0` and `@pollar/core@^0.11.2` (the kit is **not** bundled)
 
 ```bash
 npm install @pollar/stellar-wallets-kit-adapter @pollar/core @creit.tech/stellar-wallets-kit
@@ -246,7 +257,7 @@ npm install @pollar/stellar-wallets-kit-adapter @pollar/core @creit.tech/stellar
 
 ### [`@pollar/solana-wallet-standard-adapter`](./packages/solana-wallet-standard-adapter)
 
-**Version:** `0.11.1` (first published release) &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/solana-wallet-standard-adapter)
+**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/solana-wallet-standard-adapter)
 
 The Solana counterpart to `@pollar/stellar-wallets-kit-adapter`. Connects user-controlled Solana wallets (Phantom,
 Solflare, Backpack, ...) to `@pollar/core` through the [Wallet Standard](https://github.com/wallet-standard/wallet-standard),
@@ -258,7 +269,7 @@ without bundling any wallet SDK into `@pollar/core`. Login uses **SIWS (Sign In 
 - `solanaWalletStandardAdapters(options?)` - discovers every installed Solana wallet and returns one `WalletAdapter`
   each to pass to `PollarClientConfig.walletAdapters`; SSR-safe (returns `[]` when there is no `window`)
 - `SolanaWalletStandardAdapter` - direct `WalletAdapter` implementation for use outside `PollarClient`
-- Peer dep: `@pollar/core@^0.11.1` only. The `@wallet-standard/*` packages and `@solana/wallet-standard-features` are
+- Peer dep: `@pollar/core@^0.11.2` only. The `@wallet-standard/*` packages and `@solana/wallet-standard-features` are
   bundled as regular dependencies, so consumers don't install them; no wallet SDK is bundled
 
 ```bash

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -46,13 +46,25 @@ and `ReceiveModalTemplate` now take `chains`, `selectedChain` and
 exported helpers:
 
 ```tsx
+import type { WalletChain } from '@pollar/core';
+import { useEffect, useState } from 'react';
 import { ChainSelect, addressForChain, useChains, usePollar } from '@pollar/react';
 
 const { wallets } = usePollar();
 // useChains() applies the app's configured chain order from /config; prefer it
 // over chainsOf(wallets) alone, which cannot know that order.
-const { chains, primaryChain } = useChains();
-const [selectedChain, setSelectedChain] = useState(primaryChain);
+const { chains } = useChains();
+
+// Start at null and settle on the first configured chain in an effect - the
+// same thing the built-in modals do. Seeding with useState(primaryChain) would
+// pin the picker to null forever: /config is still in flight on the first
+// render, primaryChain is null until it resolves, and useState only reads its
+// argument once.
+const [selectedChain, setSelectedChain] = useState<WalletChain | null>(null);
+useEffect(() => {
+  if (selectedChain === null && chains.length > 0) setSelectedChain(chains[0]!);
+}, [chains, selectedChain]);
+
 const walletAddress = addressForChain(wallets, selectedChain);
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrade guide
 
+## 0.11.1 -> 0.11.2
+
+No breaking changes and no migration steps. 0.11.2 is additive: the
+`client.stellar` namespace (SEP-53 message + SEP-10 challenge ownership
+proofs), a multichain Transaction History modal in `@pollar/react`, and the
+Freighter adapter migrated to `@stellar/freighter-api` 6.0.0. Existing call
+sites compile and behave unchanged. See the [CHANGELOG](./CHANGELOG.md) for
+the details.
+
 ## 0.11.0 -> 0.11.1
 
 0.11.1 reworks the multichain wallet responses. The wire format moved to a

--- a/examples/solana-web/src/App.tsx
+++ b/examples/solana-web/src/App.tsx
@@ -40,9 +40,7 @@ function Home() {
       <h1>Pollar x Solana</h1>
       <p>Click log in, choose your Solana wallet, and approve the Sign In With Solana request.</p>
       {solanaAdapters.length === 0 && (
-        <p style={{ color: '#b45309' }}>
-          No Solana wallet detected. Install Phantom, Solflare, or Backpack, then reload.
-        </p>
+        <p style={{ color: '#b45309' }}>No Solana wallet detected. Install Phantom, Solflare, or Backpack, then reload.</p>
       )}
       {isAuthenticated && wallet ? (
         <>
@@ -69,8 +67,8 @@ function Setup() {
     <main style={box}>
       <h1>Pollar x Solana — setup needed</h1>
       <p>
-        Copy <code>.env.example</code> to <code>.env.local</code> and set{' '}
-        <code>VITE_POLLAR_API_KEY</code> (an app with SOLANA enabled). Then restart <code>npm run dev</code>.
+        Copy <code>.env.example</code> to <code>.env.local</code> and set <code>VITE_POLLAR_API_KEY</code> (an app with SOLANA
+        enabled). Then restart <code>npm run dev</code>.
       </p>
     </main>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "polar-auth-monorepo",
       "version": "0.11.1",
+      "license": "MIT",
       "workspaces": [
         "packages/*",
         "examples/*"
@@ -2343,17 +2344,6 @@
         "preact": "^10.29.0"
       }
     },
-    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/freighter-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.0.tgz",
-      "integrity": "sha512-8CTQcKQmTq/wL715ZUzn1x1POpR0eYhYPKEiaeA7AT0WYBOauOGTxfWPFtSidX3ohAlJZP5HFXy1kG29cVjqxw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "6.0.3",
-        "semver": "7.7.1"
-      }
-    },
     "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@trezor/connect-plugin-stellar": {
       "version": "10.0.0-alpha.1",
       "resolved": "https://registry.npmjs.org/@trezor/connect-plugin-stellar/-/connect-plugin-stellar-10.0.0-alpha.1.tgz",
@@ -2484,19 +2474,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@creit.tech/xbull-wallet-connect": {
@@ -5987,10 +5964,26 @@
       "license": "MIT"
     },
     "node_modules/@stellar/freighter-api": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-2.0.0.tgz",
-      "integrity": "sha512-j/R7MLPL8S3QhwOEdAxSl7MgWBTXWlOXQKQyXR8mPk1JMKKR4tF8e4U+Fs9TPQH0HZoYqfVDvLOOUrTMMY058Q==",
-      "license": "Apache-2.0"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.0.tgz",
+      "integrity": "sha512-8CTQcKQmTq/wL715ZUzn1x1POpR0eYhYPKEiaeA7AT0WYBOauOGTxfWPFtSidX3ohAlJZP5HFXy1kG29cVjqxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
@@ -17643,6 +17636,7 @@
     "packages/accesly-adapter": {
       "name": "@pollar/accesly-adapter",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@pollar/core": "^0.11.1"
       },
@@ -17663,10 +17657,11 @@
     "packages/core": {
       "name": "@pollar/core",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.9.7",
         "@noble/hashes": "~1.8.0",
-        "@stellar/freighter-api": "^2.0.0",
+        "@stellar/freighter-api": "6.0.0",
         "openapi-fetch": "^0.17.0"
       },
       "devDependencies": {
@@ -17695,6 +17690,7 @@
     "packages/privy-adapter": {
       "name": "@pollar/privy-adapter",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@pollar/core": "^0.11.1"
       },
@@ -18280,6 +18276,7 @@
     "packages/privy-server-adapter": {
       "name": "@pollar/privy-server-adapter",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "@privy-io/node": "~0.18.0",
@@ -18303,6 +18300,7 @@
     "packages/react": {
       "name": "@pollar/react",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@pollar/core": "^0.11.1",
         "@simplewebauthn/browser": "^13.3.0",
@@ -18357,6 +18355,7 @@
     "packages/solana-wallet-standard-adapter": {
       "name": "@pollar/solana-wallet-standard-adapter",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@pollar/core": "^0.11.1",
         "@solana/wallet-standard-features": "^1.4.0",
@@ -18381,6 +18380,7 @@
     "packages/stellar-wallets-kit-adapter": {
       "name": "@pollar/stellar-wallets-kit-adapter",
       "version": "0.11.1",
+      "license": "MIT",
       "dependencies": {
         "@pollar/core": "^0.11.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polar-auth-monorepo",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "polar-auth-monorepo",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -17635,10 +17635,10 @@
     },
     "packages/accesly-adapter": {
       "name": "@pollar/accesly-adapter",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.1"
+        "@pollar/core": "^0.11.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -17651,12 +17651,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@pollar/core": "^0.11.1"
+        "@pollar/core": "^0.11.2"
       }
     },
     "packages/core": {
       "name": "@pollar/core",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.9.7",
@@ -17689,10 +17689,10 @@
     },
     "packages/privy-adapter": {
       "name": "@pollar/privy-adapter",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.1"
+        "@pollar/core": "^0.11.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -17708,7 +17708,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@pollar/core": "^0.11.1",
+        "@pollar/core": "^0.11.2",
         "@privy-io/expo": ">=0.69 <1",
         "@privy-io/react-auth": "^3",
         "@stellar/stellar-sdk": "^15.1.0",
@@ -18275,7 +18275,7 @@
     },
     "packages/privy-server-adapter": {
       "name": "@pollar/privy-server-adapter",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -18299,10 +18299,10 @@
     },
     "packages/react": {
       "name": "@pollar/react",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.1",
+        "@pollar/core": "^0.11.2",
         "@simplewebauthn/browser": "^13.3.0",
         "qr.js": "^0.0.0"
       },
@@ -18322,7 +18322,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@pollar/core": "^0.11.1",
+        "@pollar/core": "^0.11.2",
         "react": ">=18",
         "react-dom": ">=18"
       }
@@ -18354,10 +18354,10 @@
     },
     "packages/solana-wallet-standard-adapter": {
       "name": "@pollar/solana-wallet-standard-adapter",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.1",
+        "@pollar/core": "^0.11.2",
         "@solana/wallet-standard-features": "^1.4.0",
         "@wallet-standard/app": "^1.1.1",
         "@wallet-standard/base": "^1.1.1",
@@ -18374,15 +18374,15 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@pollar/core": "^0.11.1"
+        "@pollar/core": "^0.11.2"
       }
     },
     "packages/stellar-wallets-kit-adapter": {
       "name": "@pollar/stellar-wallets-kit-adapter",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.1"
+        "@pollar/core": "^0.11.2"
       },
       "devDependencies": {
         "@creit.tech/stellar-wallets-kit": "^2.3.0",
@@ -18397,7 +18397,7 @@
       },
       "peerDependencies": {
         "@creit.tech/stellar-wallets-kit": "^2.0.0",
-        "@pollar/core": "^0.11.1"
+        "@pollar/core": "^0.11.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polar-auth-monorepo",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "scripts": {
     "build": "turbo build",

--- a/packages/accesly-adapter/package.json
+++ b/packages/accesly-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/accesly-adapter",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@pollar/core": "^0.11.1"
+    "@pollar/core": "^0.11.2"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.1"
+    "@pollar/core": "^0.11.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -514,10 +514,12 @@ submitting → success` transitions (each composed call emits its own); custodia
 
 #### `client.sendPayment(params): Promise<SubmitOutcome>`
 
-One entry point for a payment on any chain the user holds a wallet on. A Stellar payment routes through
-`buildAndSignAndSubmitTx` (so external adapters and passkey wallets keep the split flow); a Solana payment is a single
-server-side call and is **custodial-only** for now. `SendPaymentParams` is a per-chain union - a Stellar member with a
-decimal `amount` and an `asset`, a Solana member with an integer base-unit `amount` and an optional `mint`.
+One entry point for a payment on Stellar or Solana. A Stellar payment routes through `buildAndSignAndSubmitTx` (so
+external adapters and passkey wallets keep the split flow); a Solana payment is a single server-side call and is
+**custodial-only** for now. `SendPaymentParams` is a per-chain union - a Stellar member with a decimal `amount` and an
+`asset`, a Solana member with an integer base-unit `amount` and an optional `mint`. The union also carries a `POLYGON`
+member for the shape, but there is no transfer path for it yet: the call returns
+`{ status: 'error', details: 'Sending on POLYGON is not supported yet.' }`.
 
 ```ts
 // Stellar
@@ -913,6 +915,7 @@ import type {
   WalletAssetsContent,
   EnabledAssetRecord,
   EnabledAssetsState,
+  SendPaymentParams,
 
   // Solana wallet adapters (SIWS)
   SolanaSignInInput,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,14 +2,20 @@
 
 Core SDK for [Pollar](https://pollar.xyz) — authentication and transaction utilities for Stellar and Solana applications.
 
-> **0.11.1** reworks the multichain wallet responses. **Breaking:** `WalletBalanceRecord.balance`
-> and `.available` are now `string | null` - `null` means the chain could not be read, and must
-> render as unavailable rather than as `0`. Every chain now reports its native coin plus each
-> token the app enabled (0.11.0 reported only the native token off Stellar), and balances gained
-> `decimals`, `limit` and `sponsored`. `signTx` accepts `skipSponsorship`. New exported types:
-> `WalletAssetsContent`, `EnabledAssetRecord`, `PollarPersistedWallet`.
+> **0.11.2** adds `client.stellar` — **SEP-53 message** and **SEP-10 challenge** ownership
+> proofs. External wallets sign client-side through their adapter (new optional
+> `signStellarMessage` on `WalletAdapter`; Freighter implements it, Albedo has no SEP-53
+> support), custodial wallets sign server-side, and both return the same `sep53` scheme so a
+> verifier treats them alike. Also: `@stellar/freighter-api` bumped to 6.0.0. Non-breaking.
+> New exported types: `StellarSepApi`, `StellarMessageProof`, `Sep10SignParams`, `Sep10Proof`,
+> `SignMessageOptions`, `SignMessageResponse`.
 >
-> Earlier: **0.11.0** went multichain (Solana joins Stellar) and moved every request to the
+> Earlier: **0.11.1** reworked the multichain wallet responses. **Breaking:**
+> `WalletBalanceRecord.balance` and `.available` are `string | null` - `null` means the chain
+> could not be read, and must render as unavailable rather than as `0`. Every chain reports its
+> native coin plus each token the app enabled (0.11.0 reported only the native token off
+> Stellar), and balances gained `decimals`, `limit` and `sponsored`. `signTx` accepts
+> `skipSponsorship`. **0.11.0** went multichain (Solana joins Stellar) and moved every request to the
 > **`/v2`** API. **0.10.0** unified external wallets into `walletAdapters: WalletAdapter[]` and
 > removed the singular `walletAdapter` resolver and `client.loginWallet()`.
 >
@@ -705,6 +711,37 @@ Log into (or create) a Soroban smart-account C-address backed by a device passke
 client.loginSmartWallet(): void; // returning user (WebAuthn get)
 client.createSmartWallet(): void; // new user (WebAuthn create + sponsored deploy)
 ```
+
+---
+
+### Stellar ownership proofs (SEP-53 / SEP-10)
+
+`client.stellar` namespaces the Stellar-specific proof standards so the multichain client stays clean. Each method
+dispatches by wallet type: external wallets sign client-side through their adapter, custodial wallets sign server-side
+through the API, and smart (passkey) wallets yield an error outcome — a C-address has no classic ed25519 key to prove.
+
+```ts
+// SEP-53: prove ownership by signing an arbitrary message
+const proof = await client.stellar.sep53.signMessage('verify me');
+// { status: 'signed', signature, signerAddress, scheme: 'sep53' } | { status: 'error', details?, code? }
+
+// SEP-10: sign a verifier-issued web-auth challenge transaction
+const auth = await client.stellar.sep10.sign({
+  challengeXdr,
+  homeDomains: 'verifier.example.com', // optional; enables full SEP-10 validation on the custodial path
+  webAuthDomain: 'auth.verifier.example.com', // optional
+});
+// { status: 'signed', signedXdr, signerAddress } | { status: 'error', details?, code? }
+```
+
+`signature` is base64 ed25519 over the SEP-53 digest (`SHA-256("Stellar Signed Message:\n" + message)`), produced
+identically by external wallets and the custodial signer — `scheme` is always `sep53`, so the two proof paths are
+interchangeable for a verifier.
+
+For external wallets, SEP-53 needs an adapter that implements the optional `signStellarMessage` method: the built-in
+`FreighterAdapter` does (native v6 `signMessage`), and `@pollar/stellar-wallets-kit-adapter` does via
+`kit.signMessage`. Albedo does not support SEP-53 message signing and yields an error outcome — use a SEP-10 challenge
+instead. SEP-10 reuses the adapter's existing `signTransaction`, so every Stellar adapter supports it.
 
 ---
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@noble/curves": "~1.9.7",
     "@noble/hashes": "~1.8.0",
-    "@stellar/freighter-api": "^2.0.0",
+    "@stellar/freighter-api": "6.0.0",
     "openapi-fetch": "^0.17.0"
   },
   "peerDependencies": {

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -92,40 +92,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/stellar/sep53/sign": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Sign a message (SEP-53 ownership proof, custodial) */
-        post: operations["postStellarSep53Sign"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/stellar/sep10/sign": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Sign a SEP-10 web-auth challenge (ownership proof, custodial) */
-        post: operations["postStellarSep10Sign"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/tx/submit": {
         parameters: {
             query?: never;
@@ -790,6 +756,46 @@ export interface paths {
         post?: never;
         /** Revoke a specific session (refresh-token family) */
         delete: operations["deleteAuthSessionsByFamilyId"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/stellar/sep53/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sign a message (SEP-53 ownership proof, custodial)
+         * @description Signs a plaintext message with the user's custodial wallet using the SEP-53 "Stellar Signed Message" framing. Returns the base64 signature and signer address. External wallets sign client-side in the SDK.
+         */
+        post: operations["postStellarSep53Sign"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/stellar/sep10/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sign a SEP-10 web-auth challenge (ownership proof, custodial)
+         * @description Signs a verifier-issued SEP-10 challenge transaction with the user's custodial wallet. wallet-service validates the challenge is a harmless, un-submittable SEP-10 tx before signing. External wallets sign client-side in the SDK.
+         */
+        post: operations["postStellarSep10Sign"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -1817,202 +1823,6 @@ export interface operations {
                         success: true;
                         content: {
                             signedAuthEntry: string;
-                        };
-                    };
-                };
-            };
-            /** @description Validation error */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-            /** @description Policy denial */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-            /** @description Signing error */
-            502: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-        };
-    };
-    postStellarSep53Sign: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    address: string;
-                    message: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Signed message */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        code: "SDK_STELLAR_MESSAGE_SIGNED";
-                        /** @constant */
-                        success: true;
-                        content: {
-                            signature: string;
-                            signerAddress: string;
-                            /** @constant */
-                            scheme: "sep53";
-                        };
-                    };
-                };
-            };
-            /** @description Validation error */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-            /** @description Policy denial */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-            /** @description Signing error */
-            502: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        success: false;
-                        code: string;
-                        message?: string;
-                        resultCode?: string;
-                    };
-                };
-            };
-        };
-    };
-    postStellarSep10Sign: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    address: string;
-                    challengeXdr: string;
-                    homeDomains?: string | string[];
-                    webAuthDomain?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Signed challenge */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        code: "SDK_STELLAR_SEP10_SIGNED";
-                        /** @constant */
-                        success: true;
-                        content: {
-                            signedXdr: string;
-                            signerAddress: string;
                         };
                     };
                 };
@@ -5303,6 +5113,202 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    postStellarSep53Sign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    address: string;
+                    message: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed message */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_STELLAR_MESSAGE_SIGNED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            signature: string;
+                            signerAddress: string;
+                            /** @constant */
+                            scheme: "sep53";
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Signing error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    postStellarSep10Sign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    address: string;
+                    challengeXdr: string;
+                    homeDomains?: string | string[];
+                    webAuthDomain?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed challenge */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_STELLAR_SEP10_SIGNED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            signedXdr: string;
+                            signerAddress: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Signing error */
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -92,6 +92,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/stellar/sep53/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sign a message (SEP-53 ownership proof, custodial) */
+        post: operations["postStellarSep53Sign"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/stellar/sep10/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sign a SEP-10 web-auth challenge (ownership proof, custodial) */
+        post: operations["postStellarSep10Sign"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tx/submit": {
         parameters: {
             query?: never;
@@ -1783,6 +1817,202 @@ export interface operations {
                         success: true;
                         content: {
                             signedAuthEntry: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Policy denial */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Signing error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    postStellarSep53Sign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    address: string;
+                    message: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed message */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_STELLAR_MESSAGE_SIGNED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            signature: string;
+                            signerAddress: string;
+                            /** @constant */
+                            scheme: "sep53";
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Policy denial */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Signing error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    postStellarSep10Sign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    address: string;
+                    challengeXdr: string;
+                    homeDomains?: string | string[];
+                    webAuthDomain?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed challenge */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_STELLAR_SEP10_SIGNED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            signedXdr: string;
+                            signerAddress: string;
                         };
                     };
                 };

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -156,7 +156,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get transaction history */
+        /**
+         * Get transaction history (multichain)
+         * @description Every chain by default; pass `?chain=` to narrow. Each row is tagged with its `chain` and a `{ amount, unit }` fee.
+         */
         get: operations["getTxHistory"];
         put?: never;
         post?: never;
@@ -238,7 +241,7 @@ export interface paths {
         put?: never;
         /**
          * Enable or remove a trustline for an enabled asset
-         * @description Establishes (no limit) or removes (limit '0') a trustline on the authenticated user's custodial wallet for an asset configured in the application, sponsored by the app (the reserve and fee are paid by the app wallets). Returns the refreshed enabled-asset list. Only valid for the sponsored custodial path — custom assets, adapter-managed wallets, and apps with trustline sponsoring disabled must sign a change_trust transaction client-side instead and will get a 400 here. The wallet and network are derived from the session.
+         * @description Establishes (no limit) or removes (limit '0') a trustline on the authenticated user's custodial wallet. When the asset is app-configured and sponsoring is on, the app wallets pay the reserve + fee; otherwise the server self-pays with the user's own wallet. Either way it submits server-side and returns the refreshed enabled-asset list. The wallet and network are derived from the session.
          */
         post: operations["postWalletAssetsTrustline"];
         delete?: never;
@@ -258,7 +261,7 @@ export interface paths {
         put?: never;
         /**
          * Build a sponsored trustline for an external wallet to co-sign
-         * @description Builds a sponsored changeTrust for an app-configured asset and signs ONLY the app's sponsor wallet (which covers the 0.5 XLM reserve and the fee), returning the partially-signed XDR. Use this for EXTERNAL / adapter-managed wallets whose key the platform does not hold: the caller adds the trustor signature with its own wallet and broadcasts via POST /tx/submit. Custodial wallets should use POST /wallet/assets/trustline instead. Only valid for the sponsored path — custom assets and apps with trustline sponsoring disabled get a 400 and must sign a plain change_trust client-side. The wallet and network are derived from the session.
+         * @description Builds a changeTrust for an EXTERNAL / adapter-managed wallet whose key the platform does not hold, and returns it for the caller to co-sign with its own wallet and broadcast via POST /tx/submit. When the app covers it, the response is `sponsorSignedXdr` (sponsor already signed, app pays the 0.5 XLM reserve + fee); otherwise it's `unsignedXdr`, a plain self-pay change_trust the trustor signs and pays for. The `sponsored` flag says which. Custodial wallets should use POST /wallet/assets/trustline instead. The wallet and network are derived from the session.
          */
         post: operations["postWalletAssetsTrustlineBuild"];
         delete?: never;
@@ -2338,6 +2341,7 @@ export interface operations {
             query?: {
                 limit?: number;
                 offset?: number;
+                chain?: "STELLAR" | "POLYGON" | "SOLANA";
             };
             header?: never;
             path?: never;
@@ -2359,13 +2363,18 @@ export interface operations {
                         content: {
                             records: {
                                 id: string;
+                                /** @enum {string} */
+                                chain: "STELLAR" | "POLYGON" | "SOLANA";
                                 hash: string;
                                 /** @enum {string} */
                                 network: "testnet" | "mainnet";
                                 /** @enum {string} */
                                 status: "PENDING" | "SUCCESS" | "FAILED";
                                 operation: string;
-                                feeXlm?: string;
+                                fee?: {
+                                    amount: string;
+                                    unit: string;
+                                };
                                 resultCode?: string;
                                 details: {
                                     [key: string]: unknown;

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -74,8 +74,12 @@ import {
   RampTxStatus,
   SessionInfo,
   SessionsState,
+  Sep10Proof,
+  Sep10SignParams,
   SignAuthEntryOutcome,
   SignOutcome,
+  StellarMessageProof,
+  StellarSepApi,
   SendPaymentParams,
   SubmitOutcome,
   TransactionState,
@@ -265,6 +269,11 @@ export class PollarClient {
   private readonly _walletAdapters = new Map<WalletId, WalletAdapter>();
   private readonly _passkey: PasskeyCeremony | null;
   private readonly _passkeySign: PasskeySigner | null;
+  /**
+   * Stellar SEP ownership-proof surface (`client.stellar.sep53`, `.sep10`). Set
+   * in the constructor so it exists on both client and server runtimes.
+   */
+  readonly stellar: StellarSepApi;
   private _loginController: AbortController | null = null;
   /** Aborts an in-flight `/auth/session/resume` on destroy() or re-trigger. */
   private _resumeController: AbortController | null = null;
@@ -363,6 +372,13 @@ export class PollarClient {
       resignRetry: (request) => this._resignForRetry(request),
     });
     this._wireMiddlewares();
+
+    // Stellar SEP ownership-proof namespace. Thin object over the private
+    // dispatchers so the public surface reads `client.stellar.sep53.signMessage(...)`.
+    this.stellar = {
+      sep53: { signMessage: (message: string) => this._sep53SignMessage(message) },
+      sep10: { sign: (params: Sep10SignParams) => this._sep10Sign(params) },
+    };
 
     this._networkState = { step: 'connected', network: config.stellarNetwork ?? 'testnet' };
 
@@ -1808,8 +1824,7 @@ export class PollarClient {
           return { status: 'success' };
         }
         const details =
-          (error as { details?: string; code?: string } | undefined)?.details ??
-          (error as { code?: string } | undefined)?.code;
+          (error as { details?: string; code?: string } | undefined)?.details ?? (error as { code?: string } | undefined)?.code;
         return { status: 'error', ...(details && { details }) };
       } catch (err) {
         const details = err instanceof Error ? err.message : undefined;
@@ -1829,8 +1844,7 @@ export class PollarClient {
       const xdr = data?.content?.sponsorSignedXdr ?? data?.content?.unsignedXdr;
       if (error || !data?.success || !xdr) {
         const details =
-          (error as { details?: string; code?: string } | undefined)?.details ??
-          (error as { code?: string } | undefined)?.code;
+          (error as { details?: string; code?: string } | undefined)?.details ?? (error as { code?: string } | undefined)?.code;
         return { status: 'error', ...(details && { details }) };
       }
       const signed = await this.signTx(xdr);
@@ -2216,6 +2230,120 @@ export class PollarClient {
       });
       if (!error && data?.success && data.content?.signedAuthEntry) {
         return { status: 'signed', signedAuthEntry: data.content.signedAuthEntry };
+      }
+      const details = (error as { details?: string } | undefined)?.details;
+      return { status: 'error', ...(details && { details }) };
+    } catch (err) {
+      const details = err instanceof Error ? err.message : undefined;
+      return { status: 'error', ...(details && { details }) };
+    }
+  }
+
+  // ─── Stellar SEP ownership proofs (client.stellar.*) ──────────────────────────
+
+  /**
+   * SEP-53 message signing (`client.stellar.sep53.signMessage`). Returns a base64
+   * signature + signer address a verifier checks under the `sep53` scheme.
+   *
+   * - External wallets sign client-side via the adapter's `signStellarMessage`
+   *   (Freighter/SWK produce the SEP-53 framing natively; Albedo has none).
+   * - Custodial wallets sign server-side via `/stellar/sep53/sign`, where the
+   *   backend applies the mandatory SEP-53 prefix.
+   * - Smart (passkey) wallets cannot: a C-address has no classic ed25519 key.
+   */
+  private async _sep53SignMessage(message: string): Promise<StellarMessageProof> {
+    const noSigner = this._externalSignerMissing();
+    if (noSigner) return noSigner;
+    if (this._session?.wallet?.type === 'smart') {
+      return { status: 'error', details: 'SEP-53 message signing is not supported for smart (passkey) wallets.' };
+    }
+    const address = this._session?.wallet?.address ?? '';
+
+    // External adapter signs directly (smart already returned above).
+    if (this._walletAdapter) {
+      if (!this._walletAdapter.signStellarMessage) {
+        return { status: 'error', details: `Wallet "${this._walletAdapter.type}" does not support message signing (SEP-53).` };
+      }
+      try {
+        const { signature, signerAddress } = await this._walletAdapter.signStellarMessage(message, {
+          networkPassphrase: this._networkPassphrase(),
+          ...(address ? { accountToSign: address } : {}),
+        });
+        return { status: 'signed', signature, signerAddress: signerAddress ?? address, scheme: 'sep53' };
+      } catch (err) {
+        const details = err instanceof Error ? err.message : undefined;
+        return { status: 'error', ...(details && { details }) };
+      }
+    }
+
+    // Custodial: backend signs with the user's key (SEP-53 prefix enforced there).
+    try {
+      const { data, error } = await this._api.POST('/stellar/sep53/sign', { body: { address, message } });
+      if (!error && data?.success && data.content?.signature) {
+        return {
+          status: 'signed',
+          signature: data.content.signature,
+          signerAddress: data.content.signerAddress,
+          scheme: 'sep53',
+        };
+      }
+      const details = (error as { details?: string } | undefined)?.details;
+      return { status: 'error', ...(details && { details }) };
+    } catch (err) {
+      const details = err instanceof Error ? err.message : undefined;
+      return { status: 'error', ...(details && { details }) };
+    }
+  }
+
+  /**
+   * SEP-10 challenge signing (`client.stellar.sep10.sign`). The verifier builds
+   * the challenge; this signs it and returns the signed XDR for the verifier to
+   * check with `WebAuth.readChallengeTx`.
+   *
+   * - External wallets sign the challenge transaction via the adapter.
+   * - Custodial wallets sign via `/stellar/sep10/sign`, which reuses the audited
+   *   sign-sep10-challenge endpoint (validates the challenge is un-submittable).
+   * - Smart (passkey) wallets cannot: SEP-10 is for classic accounts.
+   */
+  private async _sep10Sign(params: Sep10SignParams): Promise<Sep10Proof> {
+    const noSigner = this._externalSignerMissing();
+    if (noSigner) return noSigner;
+    if (this._session?.wallet?.type === 'smart') {
+      return {
+        status: 'error',
+        details: 'SEP-10 is for classic accounts; smart (passkey) wallets cannot sign a SEP-10 challenge.',
+      };
+    }
+    const address = this._session?.wallet?.address ?? '';
+
+    if (this._walletAdapter) {
+      if (!this._walletAdapter.signTransaction) {
+        return { status: 'error', details: `Wallet "${this._walletAdapter.type}" cannot sign a SEP-10 challenge.` };
+      }
+      try {
+        const { signedTxXdr } = await this._walletAdapter.signTransaction(params.challengeXdr, {
+          networkPassphrase: this._networkPassphrase(),
+          ...(address ? { accountToSign: address } : {}),
+        });
+        return { status: 'signed', signedXdr: signedTxXdr, signerAddress: address };
+      } catch (err) {
+        const details = err instanceof Error ? err.message : undefined;
+        return { status: 'error', ...(details && { details }) };
+      }
+    }
+
+    // Custodial path.
+    try {
+      const { data, error } = await this._api.POST('/stellar/sep10/sign', {
+        body: {
+          address,
+          challengeXdr: params.challengeXdr,
+          ...(params.homeDomains !== undefined ? { homeDomains: params.homeDomains } : {}),
+          ...(params.webAuthDomain !== undefined ? { webAuthDomain: params.webAuthDomain } : {}),
+        },
+      });
+      if (!error && data?.success && data.content?.signedXdr) {
+        return { status: 'signed', signedXdr: data.content.signedXdr, signerAddress: data.content.signerAddress };
       }
       const details = (error as { details?: string } | undefined)?.details;
       return { status: 'error', ...(details && { details }) };

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -33,6 +33,8 @@ export type {
   SignTransactionResponse,
   SignAuthEntryOptions,
   SignAuthEntryResponse,
+  SignMessageOptions,
+  SignMessageResponse,
   SolanaSignInInput,
   SolanaSignInOutput,
   SolanaSignMessageResponse,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -543,6 +543,46 @@ export type SignOutcome =
  */
 export type SignAuthEntryOutcome = { status: 'signed'; signedAuthEntry: string } | { status: 'error'; details?: string };
 
+// ─── Stellar SEP ownership proofs (client.stellar.*) ────────────────────────────
+
+/**
+ * Result of {@link StellarSepApi.sep53}.signMessage — a SEP-53 message signature.
+ * `signature` is base64 ed25519 over SHA-256("Stellar Signed Message:\n" + message),
+ * the same digest external wallets (Freighter/SWK) and the custodial signer both
+ * produce, so `scheme` is always `sep53`.
+ */
+export type StellarMessageProof =
+  | { status: 'signed'; signature: string; signerAddress: string; scheme: 'sep53' }
+  | { status: 'error'; details?: string; code?: string };
+
+/** Input to {@link StellarSepApi.sep10}.sign — a verifier-issued SEP-10 challenge. */
+export interface Sep10SignParams {
+  /** The SEP-10 challenge transaction (unsigned XDR) built by the verifier. */
+  challengeXdr: string;
+  /** Verifier home domain(s); when present, the custodial signer runs full SEP-10 validation. */
+  homeDomains?: string | string[];
+  /** Verifier web-auth domain; enables full SEP-10 validation on the custodial path. */
+  webAuthDomain?: string;
+}
+
+/** Result of {@link StellarSepApi.sep10}.sign — the challenge with the user's signature. */
+export type Sep10Proof =
+  | { status: 'signed'; signedXdr: string; signerAddress: string }
+  | { status: 'error'; details?: string; code?: string };
+
+/**
+ * Stellar Ecosystem Proposal ownership-proof surface, exposed as `client.stellar`.
+ * These are Stellar-specific standards, namespaced so the multichain client stays
+ * clean. Each method dispatches by wallet type: external wallets sign client-side
+ * via their adapter, custodial wallets sign server-side through sdk-api.
+ */
+export interface StellarSepApi {
+  /** SEP-53: sign an arbitrary message (message ownership proof). */
+  sep53: { signMessage(message: string): Promise<StellarMessageProof> };
+  /** SEP-10: sign a web-auth challenge transaction (transaction ownership proof). */
+  sep10: { sign(params: Sep10SignParams): Promise<Sep10Proof> };
+}
+
 /**
  * A payment, addressed per chain.
  *

--- a/packages/core/src/wallets/AlbedoAdapter.ts
+++ b/packages/core/src/wallets/AlbedoAdapter.ts
@@ -5,6 +5,8 @@ import { WalletType } from './types';
 import type {
   WalletAdapter,
   ConnectWalletResponse,
+  SignMessageOptions,
+  SignMessageResponse,
   SignTransactionOptions,
   SignTransactionResponse,
   SignAuthEntryOptions,
@@ -152,5 +154,12 @@ export class AlbedoAdapter implements WalletAdapter {
 
     if (!result.signed_xdr) throw new Error('Albedo auth entry signing rejected');
     return { signedAuthEntry: result.signed_xdr };
+  }
+
+  async signStellarMessage(_message: string, _options?: SignMessageOptions): Promise<SignMessageResponse> {
+    // Albedo's `sign_message` intent does not produce a SEP-53 signature, so it
+    // cannot back a SEP-53 ownership proof. Fail loudly rather than return a
+    // signature a verifier cannot check under the sep53 scheme.
+    throw new Error('Albedo does not support SEP-53 message signing; use a SEP-10 challenge instead');
   }
 }

--- a/packages/core/src/wallets/FreighterAdapter.ts
+++ b/packages/core/src/wallets/FreighterAdapter.ts
@@ -8,13 +8,17 @@ import {
   isConnected,
   requestAccess,
   signAuthEntry,
+  signMessage,
   signTransaction,
 } from '@stellar/freighter-api';
 
+import { base64urlEncode } from '../lib/base64url';
 import type {
   ConnectWalletResponse,
   SignAuthEntryOptions,
   SignAuthEntryResponse,
+  SignMessageOptions,
+  SignMessageResponse,
   SignTransactionOptions,
   SignTransactionResponse,
   WalletAdapter,
@@ -106,11 +110,34 @@ export class FreighterAdapter implements WalletAdapter {
     }
     return { signedAuthEntry };
   }
+
+  async signStellarMessage(message: string, options?: SignMessageOptions): Promise<SignMessageResponse> {
+    // Freighter v6 applies the SEP-53 framing itself and returns the signature as
+    // `signedMessage` (raw bytes, or a base64 string on some platforms).
+    const { signedMessage, signerAddress } = unwrap(await signMessage(message, freighterOpts(options)), 'signMessage');
+    if (!signedMessage) {
+      throw new Error('Invalid response from Freighter');
+    }
+    const signature = typeof signedMessage === 'string' ? signedMessage : bytesToBase64(new Uint8Array(signedMessage));
+    return { signature, signerAddress };
+  }
+}
+
+/** Standard base64 (padded) via the pure-JS base64url encoder — no `Buffer`, no
+ *  `btoa`, so it works in browser and RN alike. Matches the custodial path's
+ *  `signature.toString('base64')` so both proof paths return one format. */
+function bytesToBase64(bytes: Uint8Array): string {
+  const b64 = base64urlEncode(bytes).replace(/-/g, '+').replace(/_/g, '/');
+  const remainder = b64.length % 4;
+  return remainder === 0 ? b64 : b64 + '='.repeat(4 - remainder);
 }
 
 /** Map our `{ networkPassphrase, accountToSign }` options onto freighter-api v6's
  *  `{ networkPassphrase?, address? }`, omitting undefined keys. */
-function freighterOpts(options?: SignTransactionOptions | SignAuthEntryOptions): { networkPassphrase?: string; address?: string } {
+function freighterOpts(options?: SignTransactionOptions | SignAuthEntryOptions | SignMessageOptions): {
+  networkPassphrase?: string;
+  address?: string;
+} {
   const opts: { networkPassphrase?: string; address?: string } = {};
   if (options?.networkPassphrase) opts.networkPassphrase = options.networkPassphrase;
   if (options?.accountToSign) opts.address = options.accountToSign;

--- a/packages/core/src/wallets/FreighterAdapter.ts
+++ b/packages/core/src/wallets/FreighterAdapter.ts
@@ -2,11 +2,11 @@
 // https://github.com/tusharpamnani/stellar-wallet-kit
 
 import {
+  getAddress,
   getNetwork,
-  getUserInfo,
   isAllowed,
   isConnected,
-  setAllowed,
+  requestAccess,
   signAuthEntry,
   signTransaction,
 } from '@stellar/freighter-api';
@@ -21,6 +21,19 @@ import type {
 } from './types';
 import { WalletType } from './types';
 
+/**
+ * freighter-api v6 returns `{ ...data, error? }` on every call instead of the
+ * bare values / thrown errors of v2. This helper turns that error envelope into
+ * a thrown `Error` so the adapter keeps the same throw-on-failure contract the
+ * rest of `@pollar/core` expects.
+ */
+function unwrap<T extends { error?: { message: string } }>(result: T, context: string): Omit<T, 'error'> {
+  if (result.error) {
+    throw new Error(`Freighter ${context} failed: ${result.error.message}`);
+  }
+  return result;
+}
+
 export class FreighterAdapter implements WalletAdapter {
   readonly type = WalletType.FREIGHTER;
   readonly meta = { label: 'Freighter', group: 'Wallet' };
@@ -28,29 +41,28 @@ export class FreighterAdapter implements WalletAdapter {
 
   async isAvailable(): Promise<boolean> {
     try {
-      return await isConnected();
+      const { isConnected: connected } = await isConnected();
+      return connected;
     } catch {
       return false;
     }
   }
 
   async connect(): Promise<ConnectWalletResponse> {
-    const connected = await isConnected();
+    const { isConnected: connected } = await isConnected();
     if (!connected) {
       throw new Error('Freighter wallet is not installed');
     }
 
-    const allowed = await isAllowed();
-    if (!allowed) {
-      await setAllowed();
+    // `requestAccess` prompts the user (if not already granted) and returns the
+    // active address — it replaces the v2 `isAllowed`/`setAllowed`/`getUserInfo`
+    // dance in a single call.
+    const { address } = unwrap(await requestAccess(), 'requestAccess');
+    if (!address) {
+      throw new Error('Failed to get address from Freighter');
     }
 
-    const userInfo = await getUserInfo();
-    if (!userInfo?.publicKey) {
-      throw new Error('Failed to get user information from Freighter');
-    }
-
-    return { address: userInfo.publicKey };
+    return { address };
   }
 
   async disconnect(): Promise<void> {
@@ -59,36 +71,48 @@ export class FreighterAdapter implements WalletAdapter {
 
   async getPublicKey(): Promise<string | null> {
     try {
-      const allowed = await isAllowed();
+      // Non-prompting: only report an address when access is already granted, so
+      // this stays side-effect-free (no Freighter popup) unlike `connect`.
+      const { isAllowed: allowed } = await isAllowed();
       if (!allowed) return null;
-      const userInfo = await getUserInfo();
-      return userInfo?.publicKey ?? null;
+      const { address, error } = await getAddress();
+      if (error || !address) return null;
+      return address;
     } catch {
       return null;
     }
   }
 
   async getNetwork(): Promise<string> {
-    return getNetwork();
+    const { network } = unwrap(await getNetwork(), 'getNetwork');
+    return network;
   }
 
   async signTransaction(xdr: string, options?: SignTransactionOptions): Promise<SignTransactionResponse> {
-    const result = await signTransaction(xdr, {
-      network: options?.network,
-      networkPassphrase: options?.networkPassphrase,
-      accountToSign: options?.accountToSign,
-    });
-    if (!result || typeof result !== 'string') {
+    // v6 dropped the `network` option; it derives the network from
+    // `networkPassphrase`. `accountToSign` is now `address`. Omit undefined keys
+    // rather than passing them (the build runs `exactOptionalPropertyTypes`).
+    const { signedTxXdr } = unwrap(await signTransaction(xdr, freighterOpts(options)), 'signTransaction');
+    if (!signedTxXdr) {
       throw new Error('Invalid response from Freighter');
     }
-    return { signedTxXdr: result };
+    return { signedTxXdr };
   }
 
   async signAuthEntry(entryXdr: string, options?: SignAuthEntryOptions): Promise<SignAuthEntryResponse> {
-    const result = await signAuthEntry(entryXdr, { accountToSign: options?.accountToSign });
-    if (!result || typeof result !== 'string') {
+    const { signedAuthEntry } = unwrap(await signAuthEntry(entryXdr, freighterOpts(options)), 'signAuthEntry');
+    if (!signedAuthEntry) {
       throw new Error('Invalid response from Freighter');
     }
-    return { signedAuthEntry: result };
+    return { signedAuthEntry };
   }
+}
+
+/** Map our `{ networkPassphrase, accountToSign }` options onto freighter-api v6's
+ *  `{ networkPassphrase?, address? }`, omitting undefined keys. */
+function freighterOpts(options?: SignTransactionOptions | SignAuthEntryOptions): { networkPassphrase?: string; address?: string } {
+  const opts: { networkPassphrase?: string; address?: string } = {};
+  if (options?.networkPassphrase) opts.networkPassphrase = options.networkPassphrase;
+  if (options?.accountToSign) opts.address = options.accountToSign;
+  return opts;
 }

--- a/packages/core/src/wallets/index.ts
+++ b/packages/core/src/wallets/index.ts
@@ -10,6 +10,8 @@ export type {
   SignTransactionResponse,
   SignAuthEntryOptions,
   SignAuthEntryResponse,
+  SignMessageOptions,
+  SignMessageResponse,
   SolanaSignInInput,
   SolanaSignInOutput,
   SolanaSignMessageResponse,

--- a/packages/core/src/wallets/types.ts
+++ b/packages/core/src/wallets/types.ts
@@ -52,6 +52,20 @@ export interface SignAuthEntryResponse {
   signedAuthEntry: string;
 }
 
+/** Options for {@link WalletAdapter.signStellarMessage} (SEP-53). */
+export interface SignMessageOptions {
+  networkPassphrase?: string;
+  accountToSign?: string;
+}
+
+/** Result of a SEP-53 message signature. */
+export interface SignMessageResponse {
+  /** base64 ed25519 signature over the SEP-53 digest. */
+  signature: string;
+  /** The signer's public key (`G...`). Absent if the wallet doesn't report it. */
+  signerAddress?: string;
+}
+
 // ─── Solana (SIWS) ────────────────────────────────────────────────────────────
 // Structural mirror of the Wallet Standard's `solana:signIn` IO, kept here so
 // `@pollar/core` types the Solana adapter contract WITHOUT depending on
@@ -134,6 +148,13 @@ export interface WalletAdapter {
   // flows assert their presence (a STELLAR adapter that omits them is a bug).
   signTransaction?(xdr: string, options?: SignTransactionOptions): Promise<SignTransactionResponse>;
   signAuthEntry?(entryXdr: string, options?: SignAuthEntryOptions): Promise<SignAuthEntryResponse>;
+  /**
+   * SEP-53: sign an arbitrary message and return the base64 signature + signer
+   * address. Stellar adapters only, and optional even among them — not every
+   * wallet exposes message signing (e.g. Albedo does not). Used by the
+   * `client.stellar.sep53` ownership-proof flow for external wallets.
+   */
+  signStellarMessage?(message: string, options?: SignMessageOptions): Promise<SignMessageResponse>;
   // ─── Solana signing (SIWS login + phase-2 transfers) ───────────────────────
   /** SIWS: sign the server-issued Sign In With Solana input. Solana adapters only. */
   signIn?(input: SolanaSignInInput): Promise<SolanaSignInOutput>;

--- a/packages/privy-adapter/package.json
+++ b/packages/privy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/privy-adapter",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -49,7 +49,7 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@pollar/core": "^0.11.1",
+    "@pollar/core": "^0.11.2",
     "@privy-io/expo": ">=0.69 <1",
     "@privy-io/react-auth": "^3",
     "@stellar/stellar-sdk": "^15.1.0",
@@ -72,7 +72,7 @@
     }
   },
   "dependencies": {
-    "@pollar/core": "^0.11.1"
+    "@pollar/core": "^0.11.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/privy-server-adapter/package.json
+++ b/packages/privy-server-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/privy-server-adapter",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,14 +3,20 @@
 React bindings for [Pollar](https://pollar.xyz) — drop-in authentication UI, transaction modals, and hooks for
 Stellar and Solana applications.
 
-> **0.11.1** requires `@pollar/core@^0.11.1`. Headline feature: a **network
-> picker** (`<ChainSelect>`) across the wallet-balance, enabled-assets, send and
-> receive modals - each scopes its rows to the selected chain instead of tagging
-> every row, and the filter is local (the backend returns every chain in one
-> payload, so switching networks costs no request). Balances now format against
-> each token's own `decimals`, and a `null` balance renders as a dash rather than
-> as `0`, because `null` means the chain could not be read. The login modal shows
-> loading / error state when the app config fails to load. See the
+> **0.11.2** requires `@pollar/core@^0.11.2`. The **Transaction History modal
+> goes multichain**: the same network picker and address chip as the Balance /
+> Send modals, a server-side chain filter (pagination is server-side, so
+> switching networks refetches and resets to page 1), per-chain explorer links
+> (stellar.expert for Stellar, explorer.solana.com for Solana), and the unified
+> `{ amount, unit }` fee, so a Solana row reads "5000 lamports". The picker
+> hides itself on a single-chain app. Non-breaking.
+>
+> Earlier: **0.11.1** added the network picker (`<ChainSelect>`) across the
+> wallet-balance, enabled-assets, send and receive modals - each scopes its rows
+> to the selected chain instead of tagging every row, with a local filter (the
+> backend returns every chain in one payload). Balances format against each
+> token's own `decimals`, and a `null` balance renders as a dash rather than as
+> `0`, because `null` means the chain could not be read. See the
 > [CHANGELOG](../../CHANGELOG.md) and [UPGRADE.md](../../UPGRADE.md) for the full
 > version history before upgrading.
 
@@ -97,11 +103,11 @@ Context provider that initialises the Pollar client and makes it available to ch
 </PollarProvider>
 ```
 
-| Prop        | Type                                 | Required | Description                                                                                                                                                                                     |
-| ----------- | ------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`    | `PollarClient \| PollarClientConfig` | Yes      | Either a pre-built `PollarClient` (testing, reuse outside React) or a `PollarClientConfig` the provider will construct one from. **Locked at first render** — swapping after mount is ignored   |
-| `appConfig` | `PollarConfig`                       | No       | Local override of `/applications/config`. **Presence is the opt-out switch**: pass it (even `{}`) and the remote fetch is skipped. Omit it to keep the existing remote-fetch-on-mount behaviour |
-| `adapters`  | `PollarAdapters`                     | No       | Named set of `PollarAdapter` objects (e.g. Trustless Work). See below                                                                                                                           |
+| Prop        | Type                                 | Required | Description                                                                                                                                                                                                                                                                                                                                   |
+| ----------- | ------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`    | `PollarClient \| PollarClientConfig` | Yes      | Either a pre-built `PollarClient` (testing, reuse outside React) or a `PollarClientConfig` the provider will construct one from. **Locked at first render** — swapping after mount is ignored                                                                                                                                                 |
+| `appConfig` | `PollarConfig`                       | No       | Local override of `/applications/config`. **Presence is the opt-out switch**: pass it (even `{}`) and the remote fetch is skipped. Omit it to keep the existing remote-fetch-on-mount behaviour. Unlike `client`, it can be added or swapped after mount — the context re-applies it (compared by value, so an inline object literal is fine) |
+| `adapters`  | `PollarAdapters`                     | No       | Named set of `PollarAdapter` objects (e.g. Trustless Work). See below                                                                                                                                                                                                                                                                         |
 
 ---
 
@@ -296,7 +302,7 @@ already wired inside `<PollarProvider>` — and most are exported in case you wa
 | `<SwapModal>`              | On-chain asset-to-asset swap: pick from/to assets and amount, quote across venues, execute (auto-trustline on the buy asset when needed); paste a custom buy token (code + issuer)                                                                                                                                                                                                       |
 | `<EarnModal>`              | Deposit/withdraw across DeFindex vaults and Blend pools: provider + opportunity selection with live APY, wallet balance, over-spend guards, and auto-trustline on deposit                                                                                                                                                                                                                |
 | `<ReceiveModal>`           | Wallet address as QR code with copy-to-clipboard (no external QR dependency required)                                                                                                                                                                                                                                                                                                    |
-| `<TxHistoryModal>`         | Paginated transaction history with auto-fetch on open and stellar.expert explorer links                                                                                                                                                                                                                                                                                                  |
+| `<TxHistoryModal>`         | Paginated multichain transaction history with auto-fetch on open. A `<ChainSelect>` in the header filters server-side (switching networks refetches and resets to page 1); rows link to their own chain's explorer (stellar.expert for Stellar, explorer.solana.com for Solana) and show the unified `{ amount, unit }` fee                                                              |
 | `<WalletBalanceModal>`     | Multichain wallet balances (Stellar, Polygon, Solana). A `<ChainSelect>` in the header picks the network and the rows are filtered to it; shows that chain's address plus a refresh button. An unreadable chain's balance renders as a dash, never as `0`. On Solana testnet each row offers a faucet hint — a devnet SOL faucet on the native row, Circle's USDC faucet on the USDC row |
 | `<EnabledAssetsModal>`     | The application's dashboard-enabled assets for the network picked in the header, with per-asset trustline state; establish/remove trustlines (Stellar only - other chains are informational)                                                                                                                                                                                             |
 | `<DistributionRulesModal>` | Manage the wallet's distribution rules                                                                                                                                                                                                                                                                                                                                                   |

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/react",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -40,12 +40,12 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@pollar/core": "^0.11.1",
+    "@pollar/core": "^0.11.2",
     "react": ">=18",
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.1",
+    "@pollar/core": "^0.11.2",
     "@simplewebauthn/browser": "^13.3.0",
     "qr.js": "^0.0.0"
   },

--- a/packages/react/src/components/earn-modal/EarnModal.tsx
+++ b/packages/react/src/components/earn-modal/EarnModal.tsx
@@ -162,9 +162,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
     if (!selectedOpportunity) return null;
     const balances = walletBalance.step === 'loaded' ? walletBalance.data.balances : [];
     const issuer = selectedOpportunity.asset.issuer;
-    const rec = balances.find((b) =>
-      issuer === null ? b.type === 'native' : b.code === assetCode && b.issuer === issuer,
-    );
+    const rec = balances.find((b) => (issuer === null ? b.type === 'native' : b.code === assetCode && b.issuer === issuer));
     return rec ? rec.available : null;
   })();
 
@@ -184,10 +182,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
     );
   })();
   const depositNeedsTrustline =
-    tab === 'deposit' &&
-    !smartUnsupported &&
-    !!selectedOpportunity?.asset.issuer &&
-    !depositAssetRecord?.trustlineEstablished;
+    tab === 'deposit' && !smartUnsupported && !!selectedOpportunity?.asset.issuer && !depositAssetRecord?.trustlineEstablished;
 
   const hash = transaction.step === 'success' ? transaction.hash : null;
   const buildData = 'buildData' in transaction ? transaction.buildData : null;
@@ -539,8 +534,8 @@ export function EarnModal({ onClose }: EarnModalProps) {
 
             {depositNeedsTrustline && selectedOpportunity && (
               <div className="pollar-swap-trustline-notice">
-                To deposit {assetCode} your wallet needs a trustline. This will create it first (~0.5 XLM reserve,
-                refundable if you later remove it), then deposit — two signatures.
+                To deposit {assetCode} your wallet needs a trustline. This will create it first (~0.5 XLM reserve, refundable if
+                you later remove it), then deposit — two signatures.
               </div>
             )}
 

--- a/packages/react/src/components/send-modal/SendModal.tsx
+++ b/packages/react/src/components/send-modal/SendModal.tsx
@@ -160,9 +160,23 @@ export function SendModal({ onClose }: SendModalProps) {
       return;
     }
 
+    // A non-native asset needs BOTH its mint (carried in `issuer`) and its own
+    // `decimals`, and neither has a safe default: without the mint the payload
+    // below drops to a native transfer, so a USDC send would move SOL instead,
+    // and the 9-decimal fallback would multiply a 6-decimal token by 1000. The
+    // backend always sends both, so this only fires on malformed data - but it
+    // fails the send rather than sending the wrong thing.
+    const isNativeAsset = selectedAsset.type === 'native';
+    if (isBaseUnitChain && !isNativeAsset && (!selectedAsset.issuer || selectedAsset.decimals === undefined)) {
+      setFormError('This token is missing its mint or decimals and cannot be sent.');
+      return;
+    }
+
     // Solana takes integer base units while the form (like the balance above it)
     // is in decimals, so convert before sending — with the asset's own decimals,
-    // and via strings so a 9-decimal amount is not rounded by a float.
+    // and via strings so a 9-decimal amount is not rounded by a float. The
+    // fallback is native SOL's 9, reached only on the native row (the guard above
+    // rejects any other asset that lacks `decimals`).
     let sendAmount = amount;
     if (isBaseUnitChain) {
       try {
@@ -180,8 +194,9 @@ export function SendModal({ onClose }: SendModalProps) {
         chain: 'SOLANA',
         destination: destination.trim(),
         amount: sendAmount,
-        // Native SOL carries no mint; an SPL token's mint rides in `issuer`.
-        ...(selectedAsset.type === 'native' ? {} : { mint: selectedAsset.issuer ?? null }),
+        // Native SOL carries no mint; an SPL token's mint rides in `issuer`,
+        // which the guard above proved is present.
+        ...(isNativeAsset ? {} : { mint: selectedAsset.issuer }),
       });
       return;
     }

--- a/packages/react/src/components/swap-modal/SwapModal.tsx
+++ b/packages/react/src/components/swap-modal/SwapModal.tsx
@@ -122,12 +122,16 @@ export function SwapModal({ onClose }: SwapModalProps) {
   // Sell: native XLM + every asset the wallet has a trustline for, even at a 0
   // balance — so the user always sees what they hold and knows when to fund
   // (the amount field guards against overselling). Buy: app-enabled assets.
-  // Swap is Stellar-only, so drop any non-Stellar balance (SOL/POL carry no
-  // `type`) — the guard both filters them and narrows `type` for toRef().
+  // Swap is Stellar-only, so the guard drops every non-Stellar balance and
+  // narrows `type` for toRef(). It has to test `chain`, not `type`: SOL/POL
+  // report `type: 'native'` exactly like XLM, and a Solana/Polygon token reports
+  // `type: 'token'` with no `trustlineRemoved`, so neither can be told apart
+  // from a Stellar row by `type` alone.
   const sellOptions: SwapAssetOption[] = balances
     .filter(
       (b): b is typeof b & { type: 'native' | 'credit_alphanum4' | 'credit_alphanum12' } =>
-        b.type != null && (b.type === 'native' || !b.trustlineRemoved),
+        (b.chain === undefined || b.chain === 'STELLAR') &&
+        (b.type === 'native' || ((b.type === 'credit_alphanum4' || b.type === 'credit_alphanum12') && !b.trustlineRemoved)),
     )
     // A null `available` (chain unreadable) maps to undefined — "unknown", which
     // the option already models — rather than to a 0 that would read as "empty".

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
@@ -16,7 +16,7 @@ interface TxHistoryModalProps {
 }
 
 export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
-  const { getClient, styles, txHistory, wallets, network } = usePollar();
+  const { getClient, styles, txHistory, wallets } = usePollar();
   const { theme = 'light', accentColor = '#005DB4' } = styles;
   const [offset, setOffset] = useState(0);
 
@@ -61,7 +61,6 @@ export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
         chains={chains}
         selectedChain={selectedChain}
         walletAddress={walletAddress}
-        network={network}
         onSelectChain={onSelectChain}
         onRefresh={() => paged(offset)}
         onPrev={() => paged(Math.max(0, offset - PAGE_SIZE))}

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
@@ -1,7 +1,10 @@
 'use client';
 
+import { WalletChain } from '@pollar/core';
 import { useCallback, useEffect, useState } from 'react';
 import { usePollar } from '../../context';
+import { useChains } from '../../useChains';
+import { addressForChain } from '../ChainSelect';
 import '../shared.css';
 import './TxHistoryModal.css';
 import { TxHistoryModalTemplate } from './TxHistoryModalTemplate';
@@ -13,21 +16,40 @@ interface TxHistoryModalProps {
 }
 
 export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
-  const { getClient, styles, txHistory } = usePollar();
+  const { getClient, styles, txHistory, wallets, network } = usePollar();
   const { theme = 'light', accentColor = '#005DB4' } = styles;
   const [offset, setOffset] = useState(0);
 
+  const { chains } = useChains();
+  const [selectedChain, setSelectedChain] = useState<WalletChain | null>(null);
+  // Default to the app's first configured network, like the other modals.
+  useEffect(() => {
+    if (selectedChain === null && chains.length > 0) setSelectedChain(chains[0]!);
+  }, [chains, selectedChain]);
+
+  const walletAddress = addressForChain(wallets, selectedChain);
+
+  // The chain filter is a server query param (pagination is server-side), so a
+  // fetch always carries the selected chain. Null while chains resolve — the
+  // effect below waits for it rather than fetching the whole unfiltered set.
   const load = useCallback(
-    (nextOffset: number) => {
+    (nextOffset: number, chain: WalletChain) => {
       setOffset(nextOffset);
-      void getClient().fetchTxHistory({ limit: PAGE_SIZE, offset: nextOffset });
+      void getClient().fetchTxHistory({ limit: PAGE_SIZE, offset: nextOffset, chain });
     },
     [getClient],
   );
 
+  // (Re)load from page 1 whenever the selected chain changes. Switching networks
+  // must reset the offset — page 3 of Stellar is not page 3 of Solana.
   useEffect(() => {
-    load(0);
-  }, [load]);
+    if (selectedChain) load(0, selectedChain);
+  }, [selectedChain, load]);
+
+  const onSelectChain = (chain: WalletChain) => setSelectedChain(chain);
+  const paged = (nextOffset: number) => {
+    if (selectedChain) load(nextOffset, selectedChain);
+  };
 
   return (
     <div className="pollar-overlay" onClick={onClose}>
@@ -36,9 +58,14 @@ export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
         accentColor={accentColor}
         txHistory={txHistory}
         offset={offset}
-        onRefresh={() => load(offset)}
-        onPrev={() => load(Math.max(0, offset - PAGE_SIZE))}
-        onNext={() => load(offset + PAGE_SIZE)}
+        chains={chains}
+        selectedChain={selectedChain}
+        walletAddress={walletAddress}
+        network={network}
+        onSelectChain={onSelectChain}
+        onRefresh={() => paged(offset)}
+        onPrev={() => paged(Math.max(0, offset - PAGE_SIZE))}
+        onNext={() => paged(offset + PAGE_SIZE)}
         onClose={onClose}
       />
     </div>

--- a/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
@@ -17,8 +17,6 @@ interface TxHistoryModalTemplateProps {
   selectedChain: WalletChain | null;
   /** Address of the wallet on {@link selectedChain}. */
   walletAddress: string;
-  /** testnet vs mainnet — picks the explorer's cluster. */
-  network: StellarNetwork;
   onSelectChain: (chain: WalletChain) => void;
   onRefresh: () => void;
   onPrev: () => void;
@@ -94,7 +92,6 @@ export function TxHistoryModalTemplate({
   chains,
   selectedChain,
   walletAddress,
-  network,
   onSelectChain,
   onRefresh,
   onPrev,

--- a/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { TxHistoryRecord, TxHistoryState } from '@pollar/core';
+import { StellarNetwork, TxHistoryRecord, TxHistoryState, WalletChain } from '@pollar/core';
 import { type CSSProperties, type ReactNode } from 'react';
-import { CopyButton, PollarModalFooter } from '../commons';
+import { ChainSelect } from '../ChainSelect';
+import { CopyButton, cropAddress, PollarModalFooter } from '../commons';
 
 const PAGE_SIZE = 10;
 
@@ -11,10 +12,26 @@ interface TxHistoryModalTemplateProps {
   accentColor: string;
   txHistory: TxHistoryState;
   offset: number;
+  /** Networks the user holds a wallet on; the first one is the default. */
+  chains: WalletChain[];
+  selectedChain: WalletChain | null;
+  /** Address of the wallet on {@link selectedChain}. */
+  walletAddress: string;
+  /** testnet vs mainnet — picks the explorer's cluster. */
+  network: StellarNetwork;
+  onSelectChain: (chain: WalletChain) => void;
   onRefresh: () => void;
   onPrev: () => void;
   onNext: () => void;
   onClose: () => void;
+}
+
+/** The explorer transaction URL for a row, by its chain. */
+function explorerUrlFor(chain: WalletChain, hash: string, network: StellarNetwork): string {
+  if (chain === 'SOLANA') {
+    return `https://explorer.solana.com/tx/${hash}${network === 'testnet' ? '?cluster=devnet' : ''}`;
+  }
+  return `https://stellar.expert/explorer/${network === 'testnet' ? 'testnet' : 'public'}/tx/${hash}`;
 }
 
 function StatusBadge({ status }: { status: TxHistoryRecord['status'] }) {
@@ -74,6 +91,11 @@ export function TxHistoryModalTemplate({
   accentColor,
   txHistory,
   offset,
+  chains,
+  selectedChain,
+  walletAddress,
+  network,
+  onSelectChain,
   onRefresh,
   onPrev,
   onNext,
@@ -149,6 +171,15 @@ export function TxHistoryModalTemplate({
         </div>
       </div>
 
+      <ChainSelect value={selectedChain} options={chains} onChange={onSelectChain} disabled={isLoading} />
+
+      {walletAddress && (
+        <div className="pollar-address-row">
+          <span className="pollar-address">{cropAddress(walletAddress)}</span>
+          <CopyButton value={walletAddress} label="Copy wallet address" />
+        </div>
+      )}
+
       <div className="pollar-hist-list">
         {txHistory.step === 'idle' && <div className="pollar-modal-empty">Click Refresh to load transactions.</div>}
         {isLoading && (
@@ -161,9 +192,9 @@ export function TxHistoryModalTemplate({
         {txHistory.step === 'loaded' && records.length === 0 && <div className="pollar-modal-empty">No transactions yet.</div>}
         {records.map((record) => {
           const hash = typeof record.hash === 'string' && record.hash.length > 0 ? record.hash : undefined;
-          const explorerUrl = hash
-            ? `https://stellar.expert/explorer/${record.network === 'testnet' ? 'testnet' : 'public'}/tx/${hash}`
-            : undefined;
+          // Each row carries its own chain (a filtered view is still per-chain),
+          // so the explorer link follows the row, not the picker.
+          const explorerUrl = hash ? explorerUrlFor(record.chain, hash, record.network) : undefined;
           const asset = typeof record.details?.asset === 'string' ? record.details.asset : undefined;
           // `change_trust` summaries embed the asset as `CODE:ISSUER` — split so
           // the issuer can be truncated and copied on its own.
@@ -212,7 +243,11 @@ export function TxHistoryModalTemplate({
                 {typeof record.details?.sponsored === 'boolean' && (
                   <span>· {record.details.sponsored ? 'Sponsored' : 'Self-paid'}</span>
                 )}
-                {record.feeXlm && <span>· {record.feeXlm} XLM</span>}
+                {record.fee && (
+                  <span>
+                    · {record.fee.amount} {record.fee.unit}
+                  </span>
+                )}
               </span>
 
               <div className="pollar-hist-item-footer">
@@ -227,7 +262,7 @@ export function TxHistoryModalTemplate({
                       href={explorerUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      aria-label="View on Stellar Explorer"
+                      aria-label="View on block explorer"
                     >
                       <svg width="12" height="12" viewBox="0 0 13 13" fill="none" aria-hidden>
                         <path

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -363,6 +363,17 @@ export function PollarProvider({
   const [configRetry, setConfigRetry] = useState(0);
   const retryConfig = useCallback(() => setConfigRetry((n) => n + 1), []);
 
+  // A locally-passed `appConfig` is tracked by CONTENT, not by identity. A
+  // consumer writing `appConfig={{ ... }}` inline hands us a new object on every
+  // render, so keying the config effect on the object itself would re-run it,
+  // set state with a fresh reference, re-render, and never settle. The
+  // serialized form only changes when the config really changes, and
+  // `PollarConfig` is a plain JSON response shape, so it serializes losslessly.
+  const appConfigKey = appConfigProp === undefined ? '' : JSON.stringify(appConfigProp);
+  // The effect reads the prop through this ref so it does not have to key on it.
+  const appConfigPropRef = useRef(appConfigProp);
+  appConfigPropRef.current = appConfigProp;
+
   useEffect(() => {
     return pollarClient.onTransactionStateChange(setTransaction);
   }, [pollarClient]);
@@ -451,12 +462,18 @@ export function PollarProvider({
     // PRESENCE of `appConfig` is the opt-out, not its contents: any value at all
     // means the consumer owns the config, so the remote fetch never runs and
     // what they passed is used as-is. It is 'ready' immediately because there is
-    // nothing to wait for.
+    // nothing to wait for. It is also re-applied here, not only seeded in the
+    // initial state, so a consumer that swaps the config after mount is not left
+    // with the value from the first render.
     //
     // Otherwise this runs on every mount, which is what keeps branding, login
     // methods and chains current: a change in the dashboard lands on the next
     // page load with no re-login.
-    if (appConfigProp !== undefined) {
+    const localConfig = appConfigPropRef.current;
+    if (localConfig !== undefined) {
+      // Same fallback as the initial state above, so a JS consumer passing an
+      // explicit null still lands on the default config instead of a null one.
+      setResolvedConfig(localConfig ?? DEFAULT_APP_CONFIG);
       setConfigStatus('ready');
       return;
     }
@@ -481,7 +498,7 @@ export function PollarProvider({
     return () => {
       cancelled = true;
     };
-  }, [pollarClient, appConfigProp, configRetry]);
+  }, [pollarClient, appConfigKey, configRetry]);
 
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [transactionModalOpen, setTransactionModalOpen] = useState(false);

--- a/packages/solana-wallet-standard-adapter/README.md
+++ b/packages/solana-wallet-standard-adapter/README.md
@@ -29,6 +29,31 @@ do not install them yourself.
 ```ts
 import { PollarClient } from '@pollar/core';
 import { solanaWalletStandardAdapters } from '@pollar/solana-wallet-standard-adapter';
+
+const client = new PollarClient({
+  apiKey: '...',
+  walletAdapters: [...solanaWalletStandardAdapters()],
+});
+```
+
+`solanaWalletStandardAdapters()` discovers every installed Solana wallet and returns one
+adapter each. It is SSR-safe (returns `[]` when `window` is undefined), so build
+the `PollarClient` on the client.
+
+### Alongside Stellar wallets
+
+`walletAdapters` is one flat list, so Stellar and Solana wallets coexist in it.
+That needs two packages the install command above does not cover -
+`@pollar/stellar-wallets-kit-adapter` and its own peer
+`@creit.tech/stellar-wallets-kit`:
+
+```bash
+npm install @pollar/stellar-wallets-kit-adapter @creit.tech/stellar-wallets-kit
+```
+
+```ts
+import { PollarClient } from '@pollar/core';
+import { solanaWalletStandardAdapters } from '@pollar/solana-wallet-standard-adapter';
 import { stellarWalletsKitAdapters } from '@pollar/stellar-wallets-kit-adapter';
 import { Networks } from '@creit.tech/stellar-wallets-kit';
 
@@ -37,10 +62,6 @@ const client = new PollarClient({
   walletAdapters: [...stellarWalletsKitAdapters({ network: Networks.PUBLIC }), ...solanaWalletStandardAdapters()],
 });
 ```
-
-`solanaWalletStandardAdapters()` discovers every installed Solana wallet and returns one
-adapter each. It is SSR-safe (returns `[]` when `window` is undefined), so build
-the `PollarClient` on the client.
 
 ### Options
 

--- a/packages/solana-wallet-standard-adapter/README.md
+++ b/packages/solana-wallet-standard-adapter/README.md
@@ -9,10 +9,13 @@ This is the Solana counterpart to `@pollar/stellar-wallets-kit-adapter`. Login u
 **SIWS (Sign In With Solana)** via the wallet's native `solana:signIn` feature -
 the Solana analogue of Stellar's SEP-10 challenge.
 
-> **0.11.1** is the first published release. The adapter declares
+> **0.11.2** requires `@pollar/core@^0.11.2` (peer range bump only; no adapter
+> changes).
+>
+> **0.11.1** was the first published release. The adapter declares
 > `chain: 'SOLANA'`, which is what routes `login({ provider })` through the SIWS
 > flow instead of Stellar's SEP-10 challenge - end to end, discovery through
-> login. Requires `@pollar/core@^0.11.1`.
+> login.
 
 ## Installation
 

--- a/packages/solana-wallet-standard-adapter/package.json
+++ b/packages/solana-wallet-standard-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/solana-wallet-standard-adapter",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@pollar/core": "^0.11.1"
+    "@pollar/core": "^0.11.2"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.1",
+    "@pollar/core": "^0.11.2",
     "@solana/wallet-standard-features": "^1.4.0",
     "@wallet-standard/app": "^1.1.1",
     "@wallet-standard/base": "^1.1.1",

--- a/packages/stellar-wallets-kit-adapter/README.md
+++ b/packages/stellar-wallets-kit-adapter/README.md
@@ -55,7 +55,10 @@ time (via `ensureInit()`), building one `StellarWalletsKitAdapter` per module up
 front. It is not lazy - a later `login({ provider })` just routes to the
 matching adapter that was already built.
 
-> **0.11.1** requires `@pollar/core@^0.11.1` / `@pollar/react@^0.11.1`.
+> **0.11.2** requires `@pollar/core@^0.11.2` / `@pollar/react@^0.11.2`. The
+> adapter now implements `signStellarMessage` (via `kit.signMessage`), so every
+> kit wallet that supports message signing can back a SEP-53 ownership proof
+> through `client.stellar.sep53`.
 >
 > **0.10.0** - switched to the `walletAdapters[]` array model: the factory is now
 > `stellarWalletsKitAdapters()` (was `stellarWalletsKit()`) and returns a

--- a/packages/stellar-wallets-kit-adapter/package.json
+++ b/packages/stellar-wallets-kit-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/stellar-wallets-kit-adapter",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -38,10 +38,10 @@
   },
   "peerDependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.0.0",
-    "@pollar/core": "^0.11.1"
+    "@pollar/core": "^0.11.2"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.1"
+    "@pollar/core": "^0.11.2"
   },
   "devDependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.3.0",

--- a/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
+++ b/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
@@ -3,6 +3,8 @@ import type {
   ConnectWalletResponse,
   SignAuthEntryOptions,
   SignAuthEntryResponse,
+  SignMessageOptions,
+  SignMessageResponse,
   SignTransactionOptions,
   SignTransactionResponse,
   WalletAdapter,
@@ -99,5 +101,24 @@ export class StellarWalletsKitAdapter implements WalletAdapter {
       ...(options?.accountToSign !== undefined && { address: options.accountToSign }),
     });
     return { signedAuthEntry: result.signedAuthEntry };
+  }
+
+  async signStellarMessage(message: string, options?: SignMessageOptions): Promise<SignMessageResponse> {
+    // Same singleton network guard as the other signing paths.
+    if (options?.networkPassphrase !== undefined && options.networkPassphrase !== getInitNetwork()) {
+      throw new Error(
+        `[StellarWalletsKit] networkPassphrase override "${options.networkPassphrase}" does not match the network configured at init ("${getInitNetwork()}"). The kit is a global singleton — configure one network at \`stellarWalletsKitAdapters({ network })\` and use that for every call.`,
+      );
+    }
+    StellarWalletsKit.setWallet(String(this.type));
+    // The kit produces the SEP-53 signature natively and returns it as a base64
+    // `signedMessage` plus the signer address.
+    const result = await StellarWalletsKit.signMessage(message, {
+      ...(options?.accountToSign !== undefined && { address: options.accountToSign }),
+    });
+    return {
+      signature: result.signedMessage,
+      ...(result.signerAddress !== undefined && { signerAddress: result.signerAddress }),
+    };
   }
 }


### PR DESCRIPTION
## Overview

Stable release of `@pollar/*` 0.11.2, published under the default `latest`
dist-tag. Two headline changes: the new **`client.stellar` namespace** signs
SEP-53 messages and SEP-10 challenges so a verifier can prove wallet ownership,
and the **Transaction History modal goes multichain**. Additive on top of
0.11.1 for every runtime path.

11 commits, 32 files (+1,003 / -195). All seven packages bump to 0.11.2.

## Highlights

### `@pollar/core`

- **`client.stellar` — SEP ownership proofs.** Stellar-specific standards
  namespaced so the multichain client stays clean.
  - `stellar.sep53.signMessage(message)` returns a base64 ed25519 signature over
    the SEP-53 digest (`SHA-256("Stellar Signed Message:\n" + message)`) plus the
    signer address. External wallets sign client-side through the new optional
    `signStellarMessage` on `WalletAdapter`; custodial wallets post to
    `/v2/stellar/sep53/sign`. Every path produces the same digest, so a verifier
    treats external and custodial proofs alike.
  - `stellar.sep10.sign({ challengeXdr, homeDomains?, webAuthDomain? })` signs a
    verifier-issued SEP-10 challenge. External wallets reuse the adapter's
    existing `signTransaction`; custodial wallets post to
    `/v2/stellar/sep10/sign`, which reuses the audited sign-sep10-challenge path
    (it validates that the challenge is un-submittable). Passing the verifier
    domains turns on full SEP-10 validation server-side.
  - Smart (passkey) wallets are rejected with an explicit error on both: a
    C-address has no classic ed25519 key to sign with.
- **`@stellar/freighter-api` 2.0.0 to 6.0.0**, with `FreighterAdapter` migrated
  (v6 returns `{ ...data, error? }` instead of throwing, and `getUserInfo` is
  replaced by `getAddress` / `requestAccess`). The adapter's own
  throw-on-failure contract is unchanged. The bump also dedupes the second
  freighter-api copy that `@pollar/stellar-wallets-kit-adapter` already pinned,
  and it is what unblocks native SEP-53 message signing.
- New exported types: `StellarSepApi`, `StellarMessageProof`, `Sep10SignParams`,
  `Sep10Proof`, `SignMessageOptions`, `SignMessageResponse`.
- `schema.d.ts` regenerated from sdk-api: the two `/v2/stellar/sep*/sign` paths,
  and a v2 history record that now carries `chain` and `fee` (the query accepts
  `chain`).

### `@pollar/react`

- **Multichain Transaction History modal.** It gains the network picker and
  address chip the Balance / Send modals already have. Selecting a network
  refetches filtered to that chain (the filter is a server query param, since
  pagination is server-side) and resets the pager to page 1, because page 3 of
  Stellar is not page 3 of Solana. Each row links to its own chain's explorer
  (stellar.expert, explorer.solana.com) and renders the unified
  `{ amount, unit }` fee, so a Solana row reads "5000 lamports" instead of being
  mislabelled XLM. The picker hides itself on a single-chain app, like the
  other modals.

### `@pollar/stellar-wallets-kit-adapter`

- Implements `signStellarMessage` via `kit.signMessage`, so every kit wallet
  that supports message signing can back a `client.stellar.sep53` proof.
  Albedo stays opted out: its `sign_message` intent cannot produce a SEP-53
  signature, so the adapter throws rather than returning a signature a verifier
  would reject.

## Review fixes carried over from #51

Four findings from the CodeRabbit review on #51, each verified against the code
and against sdk-api before being applied.

- **The swap sell list is Stellar-only again** (`SwapModal.tsx`). The filter
  tested `type` on the premise that non-Stellar rows carry none. They do: the v2
  wallet route emits `type: 'native'` for a chain's native coin and
  `type: 'token'` for its tokens. A SOL row therefore passed the
  `type === 'native'` arm and became a Stellar native sell asset, and an
  SPL/ERC-20 row passed the trustline arm (`trustlineRemoved` is Stellar-only,
  so it is `undefined` off Stellar) and was narrowed to a `credit_alphanum`. The
  filter now tests `chain`, the same guard the buy list already used.
- **A locally-passed `appConfig` is re-applied after mount** (`context.tsx`).
  `resolvedConfig` was only seeded in the initial state, so a consumer that
  added or swapped `<PollarProvider appConfig>` after the first render got
  `configStatus: 'ready'` while the context kept serving the first render's
  value. The effect now keys on the serialized config rather than the object
  reference, so an inline `appConfig={{ ... }}` literal does not re-trigger it
  on every render.
- **A Solana token send requires the row's mint and `decimals`**
  (`SendModal.tsx`). Both are optional on `WalletBalanceRecord` and both silent
  defaults were wrong for a token: `mint: null` is dropped from the payload,
  which turns a USDC transfer into a native SOL one, and `decimals ?? 9` is
  SOL's precision, so a 6-decimal token would be multiplied by 1000. A
  non-native asset missing either now fails the send; the `9` stays only as the
  native-SOL fallback. sdk-api always populates both fields today, so this is a
  guard against malformed data rather than a live path.
- **Documentation corrections.** `sendPayment` was described as sending on "any
  chain the user holds" in three places; it sends on Stellar and Solana, while
  Polygon sits in the params union for the shape and returns an error. The
  chain-picker migration snippet in `UPGRADE.md` seeded the picker with
  `useState(primaryChain)`, which pins it to `null` forever because `/config` is
  still in flight on the first render. The Solana adapter's usage example
  imported two packages its install command did not cover. `SendPaymentParams`
  was missing from the core README's exported-type list.

## Compatibility

No runtime behaviour changes for existing call sites, and nothing under `/v1` is
affected. Two type-level notes for direct consumers:

1. `TxHistoryModalTemplate` now requires `chains`, `selectedChain`,
   `walletAddress` and `onSelectChain` — the same shape the other modal
   templates took in 0.11.1. `<TxHistoryModal>` builds them for you; only code
   that mounts the template directly needs to change.
2. `WalletAdapter` gained an optional `signStellarMessage`. Existing adapters
   keep compiling; an adapter that omits it simply cannot back a SEP-53 proof.

## Validation

- `npm run build`: 7/7 packages.
- `npm run lint` (turbo, whole repo): 11/11, 0 errors. One pre-existing
  `react-hooks/exhaustive-deps` warning in `SendModal.tsx`.
- `npm run test:smoke`: 101 pass, 0 fail.
- `npx prettier --check` over the repo: clean.

Full details in [CHANGELOG.md](./CHANGELOG.md); migration notes, where any are
needed, in [UPGRADE.md](./UPGRADE.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stellar SEP-53 message signing and SEP-10 challenge signing.
  * Expanded Transaction History with multichain filtering, pagination reset, explorer links, and unified fee displays.
  * Added Stellar wallet message-signing support where available.

* **Bug Fixes**
  * Improved Solana token sending validation and swap asset filtering.
  * Fixed configuration updates after initialization.
  * Polygon payments now return a clear unsupported error.

* **Documentation**
  * Updated release notes, upgrade guidance, API references, and package versions for 0.11.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->