### PR TITLE
docs(skills): add the pollar-wallet-auth agent skill

### DIFF
--- a/skills/pollar-wallet-auth/SKILL.md
+++ b/skills/pollar-wallet-auth/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: pollar-wallet-auth
+description: Add email, social, or passkey login with an embedded Stellar wallet to a web or React Native app using @pollar/core and @pollar/react. Covers dashboard setup and API keys, sponsored (gasless) account activation and trustlines, payments, multi-venue swaps, SEP-24 ramps, and SEP-53 / SEP-10 ownership proofs. Use when app users need a Stellar wallet without a seed phrase or a browser extension.
+user-invocable: true
+argument-hint: '[pollar task]'
+---
+
+# Pollar: embedded Stellar wallets and login
+
+Pollar is wallet-as-a-service for Stellar. A user signs in with Google, GitHub, email OTP, or a device
+passkey and comes out the other side holding a Stellar account, funded and with trustlines already set,
+without ever seeing a secret key. The same client also connects external wallets (Freighter, Albedo,
+xBull) so both kinds of user go through one code path.
+
+The SDK is `@pollar/core` (framework agnostic) plus `@pollar/react` (provider, hooks, and prebuilt
+modals). Server-side signing, sponsorship, and key custody live behind the Pollar API, configured from
+[dashboard.pollar.xyz](https://dashboard.pollar.xyz).
+
+## When to use this skill
+
+- The app wants Stellar accounts for users who do not have a wallet and should not manage keys
+- Onboarding must be gasless: the app pays the base reserve, trustline reserves, and fees
+- One login flow has to cover both embedded (custodial) and external (Freighter / Albedo) wallets
+- The app needs passkey smart accounts (Soroban C-addresses) instead of classic G-addresses
+- The app needs payments, trustlines, swaps, SEP-24 fiat ramps, or SEP-10 / SEP-53 ownership proofs
+  on top of that wallet
+
+## When NOT to use this skill
+
+- Writing or auditing a Soroban contract: use the Stellar smart-contracts skill
+- Talking to Horizon or Stellar RPC directly, or signing with a raw keypair held by the app: use the
+  Stellar dapp and data skills
+- Issuing an asset from your own issuer account: use the Stellar assets skill
+
+## Read the file that matches the task
+
+| Task                                                             | File                                                  |
+| ---------------------------------------------------------------- | ----------------------------------------------------- |
+| Keys, dashboard config, funding modes, origin allowlist          | [Setup](#setup) (below)                               |
+| Login flows, auth state machine, sessions, logout                | [Authentication](#authentication) (below)             |
+| Which wallet a user got, addresses, balances                     | [Wallets and balances](#wallets-and-balances) (below) |
+| React and Next.js wiring, `usePollar`, prebuilt modals, branding | [react.md](react.md)                                  |
+| React Native and Expo, polyfills, secure storage, deep links     | [react-native.md](react-native.md)                    |
+| Payments, sponsorship, trustlines, swaps, ramps, earn, proofs    | [transactions.md](transactions.md)                    |
+| Things that silently break an integration                        | [Gotchas](#gotchas) (below)                           |
+
+## Install
+
+```bash
+npm install @pollar/react @pollar/core   # React and React Native
+npm install @pollar/core                 # anything else (Vue, Angular, Svelte, plain TS, Node)
+```
+
+Requires Node 20+ in the toolchain and React 18+ for `@pollar/react`.
+
+---
+
+## Mental model
+
+Every authenticated session carries a wallet with one of three custody types. Almost every branch in an
+integration comes down to which one the user has, so read it once and keep it:
+
+| `custody`  | What it is                                                                       | Address | Signing                                   |
+| ---------- | -------------------------------------------------------------------------------- | ------- | ----------------------------------------- |
+| `internal` | Custodial wallet Pollar creates at login. The default for social and email users | `G...`  | Server-side, sponsored per the app config |
+| `smart`    | Soroban smart account deployed for a device passkey                              | `C...`  | WebAuthn ceremony on the device           |
+| `external` | A wallet the user already had, connected through an adapter                      | `G...`  | The user's own extension or signer        |
+
+```ts
+const wallet = client.getWallet(); // WalletInfo | null
+if (wallet?.custody === 'internal') {
+  /* server signs */
+}
+```
+
+There is no `isAuthenticated()` on the core client. A session exists when `getAuthState().step` is
+`'authenticated'`, or equivalently when `getWallet()` is non-null. `@pollar/react` exposes the boolean
+as `isAuthenticated`.
+
+---
+
+## Setup
+
+### 1. Create the app and take the keys
+
+Sign in at [dashboard.pollar.xyz](https://dashboard.pollar.xyz), create an application, then
+**Build > API Keys > Generate**. Keys are per network and come in two flavours:
+
+| Prefix                          | Where it belongs                     |
+| ------------------------------- | ------------------------------------ |
+| `pub_testnet_` / `pub_mainnet_` | Frontend. Safe to ship in the bundle |
+| `sec_testnet_` / `sec_mainnet_` | Backend only. Never in client code   |
+
+The key decides the network: a `pub_testnet_` key can only talk to testnet. Keep `stellarNetwork` in
+the client config in sync with the key prefix rather than treating it as an independent switch.
+
+```bash
+# .env.local (Next.js)
+NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY=pub_testnet_xxxxxxxxxxxxxxxxxxxx
+POLLAR_SECRET_KEY=sec_testnet_xxxxxxxxxxxxxxxxxxxx
+```
+
+Testnet keys are capped at 1,000 requests per day, which is enough for development.
+
+### 2. Allowlist the origin
+
+Publishable keys are bound to origins. Register every origin the app runs on (including
+`http://localhost:3000`) under **Build > Domains**, or requests get rejected before any auth happens.
+
+React Native and Expo send no `Origin` header at all. Those keys need the native-clients flag enabled
+on the key itself, otherwise every request from the app fails the origin check. See
+[react-native.md](react-native.md).
+
+### 3. Instantiate the client once
+
+```ts
+import { PollarClient } from '@pollar/core';
+
+// Module scope, a DI container, or React context. Never inside a render function.
+export const client = new PollarClient({
+  apiKey: process.env.NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY!,
+  stellarNetwork: 'testnet', // default: 'testnet'
+  logLevel: 'warn', // 'silent' | 'error' | 'warn' | 'info' | 'debug'
+});
+
+await client.ready(); // keypair initialised and any persisted session restored
+```
+
+On the web, storage (`localStorage` with an in-memory fallback) and the DPoP key manager
+(non-extractable WebCrypto P-256) are autodetected. React Native has to inject both.
+
+### 4. Decide the funding mode
+
+Every Stellar account needs reserves. **Dashboard > Treasury > Funding Mode** picks who triggers the
+spend, and no code changes when you switch:
+
+| Mode        | Reserve is locked                              | Use for                                   |
+| ----------- | ---------------------------------------------- | ----------------------------------------- |
+| `IMMEDIATE` | At registration, automatically at login        | Consumer apps with no compliance gate     |
+| `DEFERRED`  | Only when your backend calls the fund endpoint | KYC-gated products, remittances, neobanks |
+
+The reserve is sponsored (CAP-33), not transferred: `1 XLM + 0.5 XLM per configured asset` stays locked
+in the app's funding wallet while it sponsors the user account. In `DEFERRED` mode the wallet exists as
+a `G...` address with no on-chain account until funded, so read `wallet.existsOnStellar` before offering
+any operation that needs a live account.
+
+---
+
+## Authentication
+
+`client.login()` is fire and forget. It returns `void` and reports progress through the auth state
+subscription, so never `await` it and never derive UI state from its return value.
+
+```ts
+import { PollarClient, WalletType } from '@pollar/core';
+
+client.login({ provider: 'google' });
+client.login({ provider: 'github' });
+client.login({ provider: 'email', email: 'user@example.com' });
+client.login({ provider: WalletType.FREIGHTER }); // an adapter's `type` IS the provider
+client.login({ provider: 'xbull' }); // adapters registered via `walletAdapters`
+
+client.verifyEmailCode('123456'); // second step of the email flow
+client.cancelLogin(); // abort whatever is in flight, back to `idle`
+```
+
+There is no `'wallet'` provider. External wallets are selected by the adapter id.
+
+Passkey smart accounts are their own pair of calls, and both need the `passkey` ceremony injected in
+the config (`@pollar/react` supplies it with `@simplewebauthn/browser`):
+
+```ts
+client.loginSmartWallet(); // returning user, WebAuthn get
+client.createSmartWallet(); // new user, WebAuthn create plus sponsored deploy
+```
+
+### Drive the UI from the state machine
+
+```ts
+const unsubscribe = client.onAuthStateChange((state) => {
+  // state.step: 'idle' | 'authenticating' | ... | 'authenticated' | 'error'
+  render(state.step, state.errorCode);
+});
+```
+
+In React use `useSyncExternalStore` over `onAuthStateChange` plus `getAuthState`, or just use
+`usePollar()` from `@pollar/react`. See [react.md](react.md).
+
+### PII is memory only
+
+The session persisted to storage holds ids, tokens, and wallet addresses. Email, name, avatar, and the
+linked providers are never written to disk:
+
+```ts
+const profile = client.getUserProfile();
+// { mail, first_name, last_name, avatar, providers } | null, until /auth/login completes
+```
+
+### Sessions and logout
+
+```ts
+const sessions = await client.listSessions(); // one row per refresh-token family
+await client.revokeSession(familyId);
+await client.logout(); // this device
+await client.logout({ everywhere: true }); // every session for this user
+```
+
+Every authenticated request is signed with a DPoP proof (RFC 9449) bound to a per-session keypair, so a
+stolen access token is useless on its own. `client.refresh()` is race safe: concurrent 401s coalesce
+into a single refresh.
+
+---
+
+## Wallets and balances
+
+```ts
+const wallet = client.getWallet(); // primary Stellar wallet, or null
+const all = client.getWallets(); // one per chain, [] on pre-multichain sessions
+
+await client.refreshBalance(); // pushes into WalletBalanceState
+const state = client.getWalletBalanceState();
+```
+
+The wallet exposes `address` only. There is no `publicKey` field, and `address` can be `null` when the
+wallet has no address yet.
+
+Balance records are multichain and tagged by `chain`, each carrying `decimals`, `limit`, and
+`sponsored`. `balance` and `available` are `string | null`, and **`null` means the chain could not be
+read**. Render it as unavailable, never as `0`, or the UI will tell a user their money is gone during a
+transient RPC outage.
+
+For anything that moves value (payments, trustlines, swaps, ramps, earn, ownership proofs) read
+[transactions.md](transactions.md).
+
+---
+
+## Gotchas
+
+These are the failures that look like SDK bugs and are not:
+
+1. **Recreating the client on every render.** `PollarClient` owns the keypair, storage listeners, and
+   the refresh scheduler. Instantiate it once. In `@pollar/react` the `client` prop is locked at first
+   render and swapping it later is ignored.
+2. **Awaiting `login()`.** It returns `void`. Subscribe to the auth state instead.
+3. **Origin not allowlisted.** The first symptom is a rejected request before any login UI appears. Add
+   the origin under Build > Domains, `localhost` included.
+4. **React Native without the entry-file polyfills.** DPoP proof construction needs
+   `crypto.getRandomValues`, `TextEncoder` / `TextDecoder`, and a spec-compliant `URL`. Missing any of
+   them means no authenticated request works at all. See [react-native.md](react-native.md).
+5. **Treating a `null` balance as zero.** See above.
+6. **Reading PII off the persisted session.** It is not there. Call `getUserProfile()`.
+7. **Assuming the account exists on-chain.** In `DEFERRED` funding mode, and for freshly connected
+   external wallets, check `wallet.existsOnStellar` first and call `createAccount()` for external ones.
+8. **Deciding sponsorship client-side.** Who pays is server-side app config. The client can only opt
+   out with `skipSponsorship: true`.
+9. **Expecting smart wallets to do everything.** Passkey C-address sessions have no classic trustlines,
+   do not use `signTx` (they go through `signAndSubmitTx`), and are not supported yet by swaps, earn, or
+   SEP-53 / SEP-10 proofs, which need a classic ed25519 key.
+10. **Mixing a mainnet key with `stellarNetwork: 'testnet'`.** The key wins. Keep them in sync.
+
+## Version note
+
+This skill tracks `@pollar/core` and `@pollar/react` `0.11.x`, which moved every request to the `/v2`
+API and added Solana alongside Stellar. Two earlier breaks matter if an existing integration is being
+upgraded: `0.11.1` made balances nullable, and `0.10.0` replaced the singular `walletAdapter` resolver
+and `loginWallet(id)` with a `walletAdapters: WalletAdapter[]` array. Check
+[UPGRADE.md](https://github.com/pollar-xyz/pollar/blob/main/UPGRADE.md) before bumping versions.
+
+## Sources
+
+Verify anything version-sensitive against the upstream docs rather than assuming this file is current:
+
+- [docs.pollar.xyz](https://docs.pollar.xyz) - guides, core concepts, and SDK reference
+- [github.com/pollar-xyz/pollar](https://github.com/pollar-xyz/pollar) - the SDK monorepo, CHANGELOG, and UPGRADE guide
+- [dashboard.pollar.xyz](https://dashboard.pollar.xyz) - app config, API keys, treasury, and domains

--- a/skills/pollar-wallet-auth/react-native.md
+++ b/skills/pollar-wallet-auth/react-native.md
@@ -1,0 +1,123 @@
+# React Native and Expo
+
+React Native is the environment where a Pollar integration most often fails for reasons that are not
+the SDK's fault. Three things have to be right: runtime polyfills, a storage adapter, and an API key
+that accepts origin-less requests.
+
+## 1. Entry-file polyfills (do this first)
+
+The SDK builds a DPoP proof (RFC 9449) for **every** authenticated request. That path uses three Web
+primitives Hermes does not all ship. Register them at the very top of the entry file, **before any
+`@pollar/core` import**. If one is missing, proof construction fails and no authenticated request
+works at all.
+
+```ts
+// index.js / App entry, before importing @pollar/core
+import 'react-native-get-random-values'; // crypto.getRandomValues
+import 'react-native-polyfill-globals/auto'; // TextEncoder / TextDecoder + URL
+```
+
+| Primitive                     | Used by                                  | Polyfill                         |
+| ----------------------------- | ---------------------------------------- | -------------------------------- |
+| `crypto.getRandomValues`      | keypair generation, DPoP `jti`           | `react-native-get-random-values` |
+| `TextEncoder` / `TextDecoder` | DPoP encoding, base64url, JWK thumbprint | `react-native-polyfill-globals`  |
+| `URL` (spec compliant)        | DPoP `htu` normalisation on every proof  | `react-native-polyfill-globals`  |
+
+SHA-256 runs on `@noble/hashes`, so `react-native-quick-crypto` is **not** required and the SDK works
+in Expo Go. Installing it is a security upgrade only: with `crypto.subtle` present the SDK uses
+`WebCryptoKeyManager`, whose private key is non-extractable. Without it, `NobleKeyManager` holds the
+private scalar in JS and persists it through the storage adapter. Both produce valid proofs, but the
+native module means an Expo dev build rather than Expo Go.
+
+Auth does not need a fetch-streaming polyfill: on React Native the SDK polls the non-streaming session
+status endpoint instead.
+
+## 2. Storage adapter
+
+Web autodetects `localStorage`. React Native must inject one, and both adapters are async because the
+underlying module is loaded through a dynamic import.
+
+**Expo (works in Expo Go):**
+
+```bash
+npx expo install expo-secure-store react-native-get-random-values
+npm i react-native-polyfill-globals
+```
+
+```ts
+import { PollarClient } from '@pollar/core';
+import { createSecureStoreAdapter } from '@pollar/core/adapters/expo';
+
+const storage = await createSecureStoreAdapter();
+// default keychain accessibility: WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+// which keeps iCloud Keychain from carrying the key to another device
+const client = new PollarClient({ apiKey: 'pub_testnet_...', storage });
+```
+
+**Bare React Native:**
+
+```bash
+npm i react-native-keychain react-native-get-random-values react-native-polyfill-globals
+```
+
+```ts
+import { createKeychainAdapter } from '@pollar/core/adapters/react-native-keychain';
+
+const storage = await createKeychainAdapter();
+const client = new PollarClient({ apiKey: 'pub_testnet_...', storage });
+```
+
+The key manager autodetects: `NobleKeyManager` on RN, `WebCryptoKeyManager` when `crypto.subtle` exists.
+
+## 3. Native clients on the API key
+
+Publishable keys are validated against an origin allowlist. React Native and Expo send no `Origin`
+header, so those requests fail the check no matter which domains are registered. The key used by a
+mobile app has to have native clients enabled on it from the dashboard. Symptom when it is not: every
+request is rejected before any login UI can appear, on a build that works fine in a browser.
+
+## 4. Injected browser-only strategies
+
+The built-in popup and extension paths are web only. On RN, OAuth and external-wallet logins need
+these injected:
+
+| Config               | Why                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `openAuthUrl`        | Web defaults to a popup. RN must open the hosted OAuth URL itself, typically via `expo-web-browser`                                   |
+| `oauthRedirectUri`   | Web defaults to `window.location.origin`. RN must pass its deep link                                                                  |
+| `visibilityProvider` | Drives the silent-refresh scheduler. Ships as `createAppStateVisibilityProvider()` from `@pollar/core/adapters/react-native-appstate` |
+| `walletAdapters`     | Freighter and Albedo are browser extensions and do not apply                                                                          |
+
+```ts
+import * as WebBrowser from 'expo-web-browser';
+import { createAppStateVisibilityProvider } from '@pollar/core/adapters/react-native-appstate';
+
+const client = new PollarClient({
+  apiKey: 'pub_testnet_...',
+  storage,
+  visibilityProvider: await createAppStateVisibilityProvider(),
+  oauthRedirectUri: 'myapp://auth',
+  openAuthUrl: async (url) => {
+    await WebBrowser.openAuthSessionAsync(url, 'myapp://auth');
+  },
+});
+```
+
+Email OTP needs none of this, which makes it the simplest first flow to get working on mobile.
+
+## 5. React binding
+
+Identical to web: `useSyncExternalStore` over `onAuthStateChange` plus `getAuthState`, or `usePollar()`
+from `@pollar/react`. See [react.md](react.md). Keep the client a singleton, and note that the storage
+adapter is created with `await`, so build the client in an async bootstrap and render a splash until
+`client.ready()` resolves.
+
+## Checklist when nothing authenticates
+
+Work down this list in order, because each step masks the ones after it:
+
+1. Are the polyfills imported before `@pollar/core`, in the entry file, not in a screen?
+2. Is a storage adapter passed to the constructor?
+3. Does the API key have native clients enabled?
+4. For OAuth: are `openAuthUrl` and `oauthRedirectUri` both set, and does the deep link scheme match
+   the one registered in the app config?

--- a/skills/pollar-wallet-auth/react.md
+++ b/skills/pollar-wallet-auth/react.md
@@ -1,0 +1,150 @@
+# React and Next.js
+
+`@pollar/react` wraps `@pollar/core` with a context provider, one hook, and a set of prebuilt modals
+that are already wired to the client. Reach for the modals first; drop to `@pollar/core` only when the
+UI has to be custom.
+
+## Provider
+
+```tsx
+import { PollarProvider } from '@pollar/react';
+import '@pollar/react/styles.css';
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return <PollarProvider client={{ apiKey: process.env.NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY! }}>{children}</PollarProvider>;
+}
+```
+
+| Prop        | Type                                 | Notes                                                                                                                                                                                 |
+| ----------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`    | `PollarClient \| PollarClientConfig` | Required. **Locked at first render**, swapping it after mount is ignored                                                                                                              |
+| `appConfig` | `PollarConfig`                       | Local override of the remote `/applications/config` fetch. Its **presence** is the opt-out switch: pass it, even as `{}`, and the remote fetch is skipped. Can be swapped after mount |
+| `adapters`  | `PollarAdapters`                     | Named set of `PollarAdapter` objects for app-specific flows (escrow, and so on)                                                                                                       |
+
+`PollarProvider` already carries `'use client'`. Components calling `usePollar()` need their own
+`'use client'` because they use hooks, which is a React rule and not a Pollar one. Server-side the SDK
+degrades to a no-op and warns, so never instantiate a client in a Server Component.
+
+The login modal is gated on the remote app-config fetch. Read `configStatus`
+(`'loading' | 'ready' | 'error'`) and call `retryConfig()` if you drive the login UI yourself.
+
+## The hook
+
+```tsx
+'use client';
+import { usePollar } from '@pollar/react';
+
+export function Profile() {
+  const { isAuthenticated, wallet, login, logout, getClient } = usePollar();
+
+  if (!isAuthenticated) return <button onClick={() => login({ provider: 'google' })}>Sign in</button>;
+
+  const profile = getClient().getUserProfile(); // PII lives in memory only
+
+  return (
+    <div>
+      <p>{wallet?.address}</p>
+      <p>{profile?.mail}</p>
+      <button onClick={logout}>Sign out</button>
+    </div>
+  );
+}
+```
+
+What `usePollar()` returns, grouped:
+
+- **Session**: `isAuthenticated`, `wallet`, `wallets`, `verified`, `getClient`
+- **App config**: `appConfig`, `styles`, `configStatus`, `retryConfig`
+- **Auth**: `login`, `logout`, `openLoginModal`, `sessions`, `openSessionsModal`
+- **Transactions**: `tx`, `buildTx`, `signTx`, `signAndSubmitTx`, `submitTx`,
+  `buildAndSignAndSubmitTx` (alias `runTx`), `sendPayment`, `openTxModal`
+- **History and balances**: `txHistory`, `openTxHistoryModal`, `walletBalance`,
+  `refreshWalletBalance`, `openWalletBalanceModal`
+- **Assets**: `enabledAssets`, `refreshAssets`, `setTrustline`, `openEnabledAssetsModal`
+- **Swap**: `getSwapQuote`, `swap`, `getSwapConfig`, `getSwapTokens`, `openSwapModal`
+- **Earn**: `getEarnProviders`, `getEarnOpportunities`, `getEarnPosition`, `earnDeposit`,
+  `earnWithdraw`, `openEarnModal`
+- **Other openers**: `openSendModal`, `openReceiveModal`, `openRampModal`, `openKycModal`,
+  `openDistributionRulesModal`
+- **Network**: `network`, `setNetwork`
+
+Custody is derived from the wallet, not a separate field:
+
+```ts
+const provider = wallet?.custody === 'external' ? wallet.provider : null;
+```
+
+`logout` here is fire and forget. Use `await getClient().logout()` when you need the promise.
+
+## Prebuilt UI
+
+Every modal mounts itself when its `openXModal()` action fires. Do not render them manually; they are
+already wired inside the provider. The fastest complete integration is one component:
+
+```tsx
+import { WalletButton } from '@pollar/react';
+
+export function Header() {
+  return <WalletButton />;
+}
+```
+
+`<WalletButton>` opens the login modal when signed out. Signed in, it shows the address with a dropdown
+for send, receive, copy, balance, history, ramp, KYC, distribution rules, sessions, sign out, plus a
+"Create account" action when an external wallet has no on-chain account yet.
+
+The rest: `<SendModal>`, `<ReceiveModal>`, `<SwapModal>`, `<EarnModal>`, `<TxHistoryModal>`,
+`<WalletBalanceModal>`, `<EnabledAssetsModal>`, `<SessionsModal>`, `<DistributionRulesModal>`,
+`<KycModal>`, `<RampWidget>`.
+
+To keep the data wiring but replace the chrome, use the `Template` companion of any modal
+(`<SendModalTemplate>`, `<LoginModalTemplate>`, and so on). `<TxHistoryModal>` and `<TransactionModal>`
+are not exported as wrappers, only as templates. The wallet-balance, enabled-assets, send, and receive
+templates each need `chains`, `selectedChain`, and `onSelectChain`.
+
+## Multichain UI
+
+Use `useChains()` rather than deriving chains from `wallets` yourself. It is the only source that knows
+the app's configured chain order, which comes from `/applications/config` and not from the session:
+
+```ts
+const { chains, primaryChain, primaryAddress, ready } = useChains();
+```
+
+`chains` is `[]` and `ready` is `false` while the config loads or fails, so gate any chain UI on
+`ready`. A chain the app switched off stops appearing on the next page load even if a stored session
+still carries it. `addressForChain(wallets, selectedChain)` resolves the address for a picked chain.
+
+## Bridging core into another framework
+
+`PollarClient` is a plain class and `on*StateChange` are callback subscriptions, so any framework works.
+Keep the client a singleton.
+
+**React without `@pollar/react`:**
+
+```tsx
+const client = new PollarClient({ apiKey: 'pub_testnet_...' }); // module scope
+
+export function useAuthState(): AuthState {
+  return useSyncExternalStore(
+    (cb) => client.onAuthStateChange(cb), // returns the unsubscribe fn
+    () => client.getAuthState(),
+    () => client.getAuthState(), // server snapshot
+  );
+}
+```
+
+**Angular:** the callbacks fire outside Angular's zone, so wrap state updates in `NgZone.run()` or use
+signals, otherwise the view never updates.
+
+**Vue 3:** assign the payload into a `ref` or `shallowRef` inside `onMounted` and unsubscribe in
+`onUnmounted`.
+
+## Logging
+
+```ts
+const client = new PollarClient({ apiKey, logLevel: 'debug', logger: mySink });
+```
+
+Levels run `silent` < `error` < `warn` < `info` < `debug`, default `info`. State-transition chatter and
+retry warnings sit at `debug`. `@pollar/react` reads the client's logger, so one setting covers both.

--- a/skills/pollar-wallet-auth/transactions.md
+++ b/skills/pollar-wallet-auth/transactions.md
@@ -1,0 +1,185 @@
+# Moving value: payments, trustlines, swaps, ramps, proofs
+
+Everything here runs against the wallet in the current session. Which path executes depends on the
+wallet's `custody` (`internal`, `smart`, `external`), and the SDK hides most of that behind one call.
+
+## The transaction pipeline
+
+```ts
+client.buildTx(operation, params, options?); // unsigned XDR from the Pollar API
+client.signTx(unsignedXdr, options?); // custodial: server signs; external: adapter signs
+client.submitTx(signedXdr); // broadcast
+```
+
+Composed shortcuts, in increasing order of convenience:
+
+```ts
+client.signAndSubmitTx(unsignedXdr?); // XDR optional, defaults to the tx in TransactionState
+client.buildAndSignAndSubmitTx(operation, params, options?); // alias: client.runTx(...)
+client.sendPayment(params); // one entry point for a payment
+```
+
+```ts
+// Stellar payment
+await client.sendPayment({ destination: 'G...', amount: '1.5', asset: { type: 'native' } });
+
+// Solana payment: amount in base units (lamports), custodial only for now
+await client.sendPayment({ chain: 'SOLANA', destination: '...', amount: '1500000000' });
+```
+
+Subscribe to `client.onTransactionStateChange` for progress. External and passkey wallets keep the
+granular `building`, `built`, `signing`, `submitting`, `success` transitions. Custodial wallets take a
+single round trip and emit one compound `building-signing-submitting` step, so if the UI needs separate
+"Building" / "Signing" / "Submitting" indicators on a custodial flow, call `buildTx`, `signTx`, and
+`submitTx` yourself.
+
+Poll the result with `client.getTxStatus(hash)`, which returns
+`'PENDING' | 'SUCCESS' | 'FAILED'`.
+
+Smart (passkey) wallets do not use `signTx`. They go through `signAndSubmitTx`, which runs the WebAuthn
+ceremony, and they need `passkeySign` injected in the client config.
+
+## Sponsorship (gasless)
+
+Who pays the fee is decided **server-side** from the app's dashboard config, not by the caller. On a
+custodial session the backend signs and returns a fee-bumped envelope with the app paying. The client's
+only lever is opting out:
+
+```ts
+await client.signTx(unsignedXdr); // sponsored per app config
+await client.signTx(unsignedXdr, { skipSponsorship: true }); // force the user to pay their own fee
+```
+
+## Activating an external account
+
+An external wallet that has never been used on Stellar has no on-chain account. `createAccount()`
+builds a sponsored `createAccount` server-side (the app's sponsor wallet pays base reserve and fee),
+signs the sponsor, then has the user's own wallet add the new-account signature and broadcasts.
+
+```ts
+const wallet = client.getWallet();
+if (wallet?.custody === 'external' && wallet.existsOnStellar === false) {
+  await client.createAccount();
+}
+```
+
+Not applicable to custodial wallets, which are created server-side at login, nor to smart wallets.
+Trustlines remain a separate step.
+
+## Trustlines
+
+```ts
+await client.setTrustline({ code: 'USDC', issuer: 'GA5Z...' }); // establish
+await client.setTrustline({ code: 'USDC', issuer: 'GA5Z...' }, { limit: '0' }); // remove
+await client.setTrustline(asset, { skipSponsorship: true }); // force self-pay change_trust
+```
+
+Routing is by sponsorship flag, not by wallet type: custodial wallets hit the trustline endpoint where
+the server sponsors or self-pays and submits; external wallets co-sign whichever XDR the build endpoint
+returns. Smart wallets do not use classic trustlines at all.
+
+To render the app's assets against the wallet's on-chain trustline state:
+
+```ts
+await client.refreshAssets();
+const assets = client.getEnabledAssetsState();
+```
+
+## Swaps
+
+`getSwapQuote` returns one priced route per venue (SDEX, Soroswap, Aquarius), each carrying a ready to
+run build payload. `swap` establishes any missing trustline on the buy asset unless
+`autoTrustline: false`, then executes.
+
+```ts
+const quotes = await client.getSwapQuote({
+  sellAsset: 'XLM',
+  buyAsset: 'USDC:GA5Z...',
+  amount: '25',
+  provider: 'auto',
+  slippageBps: 50,
+});
+
+const outcome = await client.swap(quotes[0]);
+```
+
+Which venues an app offers comes from its own `GET /swap/config`, so quote first and let the user pick
+rather than hardcoding a venue. A prebuilt XDR quote (Soroswap) is signed and submitted directly; an
+operation plus params quote (Aquarius, SDEX) runs through the `runTx` pipeline. Either way
+`onTransactionStateChange` fires. Slippage is enforced on-chain through `minReceived`. Smart wallets
+are not supported yet.
+
+## Earn (yield vaults and lending)
+
+DeFindex vaults and Blend pools sit behind one provider-selected API. An empty provider list means Earn
+is switched off for the app, so hide the UI entirely.
+
+```ts
+const providers = await client.getEarnProviders(); // [] means Earn is disabled
+const opportunities = await client.getEarnOpportunities('blend'); // each carries a live APY
+const position = await client.getEarnPosition({ provider: 'blend', opportunity: opportunities[0].id });
+
+await client.earnDeposit({ provider: 'blend', opportunity: opportunities[0].id, amount: '100' });
+await client.earnWithdraw({ provider: 'blend', opportunity: opportunities[0].id, amount: position.withdrawable });
+```
+
+Units differ per side: the deposit `amount` is the underlying asset amount, while the withdraw `amount`
+is in the position's `withdrawUnit` (asset amount for Blend, share count for DeFindex). Smart wallets
+are not supported yet.
+
+## Fiat ramps (SEP-24)
+
+```ts
+const quote = await client.getRampsQuote(query);
+const onramp = await client.createOnRamp(body);
+const status = await client.pollRampTransaction(onramp.txId);
+```
+
+Custodial wallets get a `kycUrl` to open. External wallets get a `pendingSignature` to sign and resume
+through `submitRampSignature(txId, body)`. Off-ramps additionally need `completeWithdraw(txId)`. The
+rest of the surface: `getRampCountries`, `createOffRamp`, `getRampTransaction`.
+
+KYC has its own methods: `getKycProviders(country)`, `startKyc(body)`, `getKycStatus(providerId?)`,
+`pollKycStatus(providerId)`, `resolveKyc(providerId, level?)`.
+
+## Ownership proofs (SEP-53 and SEP-10)
+
+`client.stellar` namespaces the Stellar-specific proof standards. Each method dispatches by wallet
+type: external wallets sign client-side through their adapter, custodial wallets sign server-side, and
+smart wallets return an error outcome because a C-address has no classic ed25519 key to prove.
+
+```ts
+// SEP-53: prove ownership by signing an arbitrary message
+const proof = await client.stellar.sep53.signMessage('verify me');
+// { status: 'signed', signature, signerAddress, scheme: 'sep53' } | { status: 'error', details?, code? }
+
+// SEP-10: sign a verifier-issued web-auth challenge
+const auth = await client.stellar.sep10.sign({
+  challengeXdr,
+  homeDomains: 'verifier.example.com', // optional, enables full SEP-10 validation on the custodial path
+  webAuthDomain: 'auth.verifier.example.com',
+});
+// { status: 'signed', signedXdr, signerAddress } | { status: 'error', details?, code? }
+```
+
+`signature` is base64 ed25519 over the SEP-53 digest
+(`SHA-256("Stellar Signed Message:\n" + message)`), produced identically on both paths, and `scheme` is
+always `sep53`. A verifier can treat custodial and external proofs interchangeably.
+
+Note that Freighter implements the client-side message signing; Albedo has no SEP-53 support.
+
+## Soroban auth entries
+
+```ts
+await client.signAuthEntry(entryXdr, { validUntilLedger });
+```
+
+Emits no transaction state, so a UI subscribed to `onTransactionStateChange` is not left stuck on
+`signing`.
+
+## Distribution rules
+
+```ts
+const rules = await client.listDistributionRules();
+await client.claimDistributionRule(body);
+```


### PR DESCRIPTION
## Summary

Adds `skills/pollar-wallet-auth/`, an agent skill that teaches an AI coding
assistant how to integrate Pollar (`@pollar/core` + `@pollar/react`) into a web
or React Native app. It is written for the `skills.stellar.org` ecosystem
listing and follows the layout that listing expects: a router `SKILL.md` with
frontmatter, plus progressive disclosure into three topic files that are only
read when the task calls for them.

Documentation only. No source, build config, or published package is touched.

## What is included

| File | Content |
| --- | --- |
| `SKILL.md` | Frontmatter and routing table, when to use / when not to use, the custody mental model (internal, smart, external), dashboard setup (keys, origin allowlist, single client instance, funding mode), the auth state machine, sessions and PII, wallets and balances, gotchas, version note, sources |
| `react.md` | Provider wiring for React and Next.js, `usePollar`, prebuilt and multichain modals, branding, bridging core into another framework, logging |
| `react-native.md` | Entry-file polyfills, storage adapter, native clients on the API key, injected browser-only strategies, React binding, a checklist for when nothing authenticates |
| `transactions.md` | Transaction pipeline, sponsorship, activating an external account, trustlines, swaps, earn, SEP-24 ramps, SEP-53 / SEP-10 ownership proofs, Soroban auth entries, distribution rules |

## Why

The public docs explain the API surface but not the failure modes that make an
integration break silently. The skill front-loads those so an agent avoids them
on the first attempt rather than after a debugging round trip:

- recreating `PollarClient` on every render, which resets the keypair, storage
  listeners, and the refresh scheduler
- awaiting `login()`, which returns `void`, instead of subscribing to the auth
  state
- an origin missing from the Build > Domains allowlist, which rejects requests
  before any login UI appears
- React Native without the entry-file polyfills, where DPoP proof construction
  has no `crypto.getRandomValues`, `TextEncoder` / `TextDecoder`, or a
  spec-compliant `URL`
- rendering a `null` balance as zero, when `null` means "not loaded" and not
  "empty"
- assuming smart wallet (passkey C-address) sessions support classic
  trustlines, `signTx`, swaps, earn, or SEP-53 / SEP-10 proofs

## Scope and accuracy

Content tracks `@pollar/core` and `@pollar/react` `0.11.x`: `/v2` API,
nullable balances since `0.11.1`, and the `walletAdapters: WalletAdapter[]`
array that replaced the singular `walletAdapter` resolver and `loginWallet(id)`
in `0.10.0`. Unsupported combinations are stated explicitly rather than left
implied, and every file points back to `docs.pollar.xyz`, this repo's
`CHANGELOG` / `UPGRADE.md`, and the dashboard so version-sensitive claims can
be re-verified instead of trusted.

## Review notes

- 4 files, 733 insertions, 0 deletions, all under `skills/`
- No change to package versions, exports, or CI
- Worth a second pair of eyes on the version note and on the smart wallet
  limitations, since those are the claims most likely to age


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for integrating embedded Stellar wallet authentication.
  * Documented React, Next.js, React Native, and Expo setup, including configuration, storage, deep links, and authentication flows.
  * Added transaction guidance covering signing, submission, sponsorship, swaps, fiat ramps, KYC, trustlines, and wallet-specific behavior.
  * Included troubleshooting advice, status handling, compatibility notes, and reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->