### PR TITLE
Release 0.11.3: session resilience, passkey fixes, peer-only core packaging

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,6 @@ c2c2f31c6934cd9b3748786bb9db336c20f3eef1
 
 # ASCII normalization of comments across all packages (no behavior change)
 3c35b3c3a010f1bb0e1a935be738a0ff5001c986
+
+# Prettier pass over the comment-ASCII guard (no behavior change)
+143171400435de199d37627d01420267b9f185f4

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,6 @@ f2517dd0c0bc2ff65528c3855ce61bafc44a7aed
 
 # Prettier formatting across core, adapters, tests, and docs (no behavior change)
 c2c2f31c6934cd9b3748786bb9db336c20f3eef1
+
+# Prettier pass over the changelog and the resume smoke test (no behavior change)
+344db1dbb67f2138182901988ffc99287630f708

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,3 +13,6 @@ c2c2f31c6934cd9b3748786bb9db336c20f3eef1
 
 # Prettier pass over the changelog and the resume smoke test (no behavior change)
 344db1dbb67f2138182901988ffc99287630f708
+
+# ASCII normalization of comments across all packages (no behavior change)
+3c35b3c3a010f1bb0e1a935be738a0ff5001c986

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # Release branches (0.11.3, 0.12.0, ...) get the same gate as main: work
+    # lands there first and only reaches main once it is already merged, so
+    # gating main alone means the checks run after the review, not before it.
+    branches: [main, '0.*']
   push:
-    branches: [main]
+    branches: [main, '0.*']
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.11.3 (unreleased)
+
+> Patch release. Headline: the **Smart Wallet passkey ceremony is now installed
+> however the client reaches `PollarProvider`**, so a consumer-built
+> `PollarClient` no longer silently loses passkey login. Additive, non-breaking
+> on top of 0.11.2.
+
+### `@pollar/core`
+
+- New `client.setPasskeyDefaults({ passkey?, passkeySign? })`. Fills in the
+  passkey ceremony and signer when they were not supplied at construction, and
+  never replaces ones that were, so React Native keeps injecting its native
+  provider through the constructor. Core still ships no WebAuthn implementation
+  of its own and stays platform-agnostic; the web implementation lives in
+  `@pollar/react`. `_passkey` / `_passkeySign` stop being `readonly` to allow
+  this. Both are read per login and per signature, never latched at
+  construction, so filling them in later takes effect immediately.
+
+### `@pollar/react`
+
+- **Fix: a pre-built `PollarClient` no longer loses passkey support.**
+  `PollarProvider` injected `browserPasskeyCeremony` only on the branch that
+  builds the client from a config object. A consumer passing a ready instance
+  (a module singleton shared with non-React code, say) got a client with no
+  ceremony, so `createSmartWallet()` / `loginSmartWallet()` failed at the first
+  step with `passkey ceremony not configured` and the "Passkey support is not
+  configured" error in the login modal. Smart-wallet `signAndSubmitTx` failed
+  the same way, since `passkeySign` was missing too. The provider now calls
+  `setPasskeyDefaults()` on an instance it receives.
+- **Fix: an explicit `passkey: undefined` no longer wipes the default.** The
+  config branch spread `...client` after the defaults, so a config carrying the
+  key with an undefined value (an optional ceremony that resolved to nothing)
+  overrode `browserPasskeyCeremony`. Defaults now apply with `??`: an
+  explicitly configured ceremony still wins, an absent one still falls back.
+- `browserPasskeyCeremony` and `browserPasskeySigner` are now exported, for
+  consumers who build their own `PollarClient` and want the ceremony wired at
+  construction, or who want to wrap it (logging, a custom `rpId`).
+
+### Before publishing this version
+
+- Bump `@pollar/react`'s `@pollar/core` dependency to `^0.11.3`.
+  `setPasskeyDefaults()` is new in core, and the current `^0.11.2` range lets a
+  resolver pair new react with old core, which throws
+  `client.setPasskeyDefaults is not a function` when the provider mounts.
+- Consumers that pin both packages to an exact version must bump them together.
+  Mixing versions installs a second copy of core, and `client instanceof
+  PollarClient` then compares against a different class object, so the provider
+  takes the config branch and spreads an instance into the constructor instead
+  of failing outright.
+
 ## 0.11.2
 
 > Stable release. Published under the default `latest` dist-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 > trigger behind "session cleared ~700ms after login" in development), and the
 > **Smart Wallet passkey ceremony is now installed however the client reaches
 > `PollarProvider`**, so a consumer-built `PollarClient` no longer silently
-> loses passkey login. Additive, non-breaking on top of 0.11.2.
+> loses passkey login. The release also carries the **ramp-widget work** that
+> landed before the cut: server-normalized deposit instructions, a KYC gate,
+> pre-submit amount limits, navigable flow steps, per-field placeholders and
+> hints, and Branding-configurable modal chrome. Additive on top of 0.11.2 for
+> typical integrations; the exceptions are two type-level changes for custom
+> templates, called out inline below (the normalized deposit-instructions
+> shape, and a dead wallet-button template prop).
 
 ### `@pollar/core`
 
@@ -198,6 +204,21 @@
   session restored fully functional on the next reload. Rows from sessions the
   instance never held (another document's or instance's newer login) are still
   protected: they are never in the history.
+- **New ramp client methods:** `getRampLiquidity(rail)`, `getRampKycStatus()`
+  and `decodePixQr(qrCode)`, plus an optional `kycRequired` on the ramp
+  response. Surfaced on the generic ramp API rather than as provider-specific
+  methods, so all five providers ride one flow and the widget does not fork
+  per provider. `schema.d.ts` regenerated from `openapi.v2.json`; v2 mounts
+  v1's ramp routes unchanged, so the new paths appear in both documents.
+- **New: `PollarApiError`.** The ten ramp endpoint helpers collapsed every
+  failure into `new Error(code)`, discarding the body the server answered
+  with. They now share one wrapper carrying the code, the server's `details`
+  and the whole body, so a ramp failure reaches the caller with its cause
+  intact. `message` is still the code, so anything rendering `err.message` is
+  unchanged.
+- **New exported types:** `RampDepositInstructions`, `RampScannable` and
+  `RampInstructionField`, so a payment screen can be rendered without
+  `@pollar/react` and without reaching into the generated schema.
 
 ### `@pollar/react`
 
@@ -274,6 +295,45 @@
   behavior in this package. A custom template that read `props.walletType` can
   reconstruct it from `usePollar()`:
   `const walletType = wallet?.custody === 'external' ? wallet.provider : null;`
+- **The ramp widget consumes the server's normalized deposit instructions.**
+  sdk-api now answers with one shape for every provider, so the widget stopped
+  translating: the internal `flattenInstructions` / `INSTRUCTION_LABELS` /
+  `InstructionKind` machinery is gone, and three blocks remain - the code to
+  scan, the payload as text when the server marks it worth pasting, and a map
+  over `fields` - none of which knows which provider served the route. Pollar's
+  own QR arrives as inline markup so `currentColor` keeps it legible in both
+  themes; a provider's bitmap (`inlineSafe: false`) renders through an `<img>`
+  instead. A custom ramp template must adopt the normalized shape - this is
+  the type-level change flagged in the headline.
+- **Ramp KYC gate.** When an off-ramp answers `kycRequired: true` and the
+  provider publishes no hosted KYC URL, the withdraw button is withheld with
+  the reason stated (nothing was sent, nothing was signed) and
+  `getRampKycStatus()` is polled until the provider clears the user.
+- **Amount limits are enforced and explained before submitting.** The widget
+  checks the amount against the chosen route's `minAmount` / `maxAmount` (the
+  limits already travelled on the quote and nothing read them) and renders the
+  warning in the route list, where another route can be picked without leaving
+  the flow; ramp API failures now surface the server's exact bound through
+  `PollarApiError` instead of a bare error code.
+- **The widget's flow is navigable and legible.** `select_route` gains Back
+  (returning to the amount step and carrying the reason with it, shown under
+  the field and cleared on typing), and picking a route shows a spinner and
+  "Starting..." on that row while the other rows dim and stop responding, so a
+  second click cannot race a competing request.
+- **`RampFieldSpec` grew `optional`, `placeholder` / `placeholderFrom` and
+  `hint`** - all optional, all driven by what the quote declares. A blank
+  optional field no longer blocks Continue; `placeholderFrom` names a sibling
+  select whose chosen option supplies the example, so one Pix field shows a
+  CPF mask, an email or a +55 number as the kind changes without the component
+  knowing what a Pix key is.
+- **The modal chrome is configurable from Branding.** New
+  `components/modal-theme.ts` (`buildModalCssVars()` + `modalChrome()`)
+  replaces an identical block copy-pasted into 14 templates: background, text,
+  secondary-button fill, both radii and the overlay z-index resolve from the
+  per-app Branding config, so a variable added there reaches every modal at
+  once. The primary button takes its label color from the accent's luminance
+  instead of a hardcoded white, so the Amber preset stops rendering white on
+  yellow.
 
 ### Tests and CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,15 @@
   ready-made `PollarClient` are unaffected - that path never constructed
   anything. No API change.
 
+- **Fix: a client from a second copy of `@pollar/core` is recognised as one.**
+  `PollarProvider` decided between "a ready client" and "a config" with
+  `client instanceof PollarClient`. With two copies of core in the tree that is
+  `false` for a real client, so the provider took the config branch and spread a
+  live instance into `new PollarClient({...})` - the spread carries `apiKey`, so
+  it quietly produced a SECOND client on the same API key rather than failing
+  outright, which is the same shared-session-row configuration everything else
+  in this release had to defend against. It now uses `isPollarClient()`, which
+  sees through the copy boundary.
 - **Fix: a pre-built `PollarClient` no longer loses passkey support.**
   `PollarProvider` injected `browserPasskeyCeremony` only on the branch that
   builds the client from a config object. A consumer passing a ready instance
@@ -247,6 +256,16 @@
 - `browserPasskeyCeremony` and `browserPasskeySigner` are now exported, for
   consumers who build their own `PollarClient` and want the ceremony wired at
   construction, or who want to wrap it (logging, a custom `rpId`).
+
+- **New: `isPollarClient(value)`.** A cross-copy type guard for `PollarClient`,
+  additive to the public surface. `instanceof` compares against one specific
+  class object, so it answers `false` for an instance built by a different copy
+  of `@pollar/core` - and a second copy is easy to end up with. Every instance
+  now carries a `Symbol.for('@pollar/core.PollarClient')` brand, which resolves
+  through the runtime-wide symbol registry, so any copy recognises the others'
+  instances. The guard tries `instanceof` first, so it also accepts instances
+  from builds that predate the brand. Use it instead of `instanceof` wherever a
+  client may have crossed a package boundary.
 
 ### Tests and CI
 
@@ -282,14 +301,22 @@
 
 ### Packaging
 
-- `@pollar/react` now requires `@pollar/core@^0.11.3` (`setPasskeyDefaults()` is
-  new in core; an older one throws
+- **`@pollar/core` is now a peer dependency only.** `@pollar/react` and the
+  wallet adapters listed it in `dependencies` AND `peerDependencies`. The
+  `dependencies` entry is what told npm to install a package-local copy, and a
+  second copy of core is what broke `instanceof`, split the module-level
+  live-client registry in two, and let two clients share one persisted session
+  row. It now appears only as a peer (plus a `devDependency` for building here),
+  so the application's single copy is the one everybody uses. npm 7+ installs
+  peers automatically; on npm 6, Yarn 1, or with `--legacy-peer-deps`, add
+  `@pollar/core` to your own dependencies.
+- Version ranges are unchanged and did not need bumping: `^0.11.2` already means
+  `>=0.11.2 <0.12.0`, so npm resolves the highest matching version and dedupes
+  to one copy. The duplicate only ever came from the `dependencies` entry above,
+  or from exact pins that disagree.
+- `@pollar/react` requires `@pollar/core@^0.11.3` (`setPasskeyDefaults()` is new
+  in core; an older one throws
   `client.setPasskeyDefaults is not a function` when the provider mounts).
-  Consumers that pin both packages to an
-  exact version must bump them together: mixing versions installs a second
-  copy of core, and `client instanceof PollarClient` then compares against a
-  different class object, so the provider takes the config branch and spreads
-  an instance into the constructor instead of failing outright.
 
 ## 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.3 (unreleased)
+## 0.11.3
 
 > Patch release. Headlines: **sessions no longer die on reload when the DPoP
 > keypair fails to persist** (thumbprint-mismatch logout loop), and the **Smart
@@ -217,17 +217,15 @@
   consumers who build their own `PollarClient` and want the ceremony wired at
   construction, or who want to wrap it (logging, a custom `rpId`).
 
-### Before publishing this version
+### Packaging
 
-- Bump `@pollar/react`'s `@pollar/core` dependency to `^0.11.3`.
-  `setPasskeyDefaults()` is new in core, and the current `^0.11.2` range lets a
-  resolver pair new react with old core, which throws
-  `client.setPasskeyDefaults is not a function` when the provider mounts.
-- Consumers that pin both packages to an exact version must bump them together.
-  Mixing versions installs a second copy of core, and `client instanceof
-PollarClient` then compares against a different class object, so the provider
-  takes the config branch and spreads an instance into the constructor instead
-  of failing outright.
+- `@pollar/react` now requires `@pollar/core@^0.11.3` (`setPasskeyDefaults()`
+  is new in core; an older core throws `client.setPasskeyDefaults is not a
+  function` when the provider mounts). Consumers that pin both packages to an
+  exact version must bump them together: mixing versions installs a second
+  copy of core, and `client instanceof PollarClient` then compares against a
+  different class object, so the provider takes the config branch and spreads
+  an instance into the constructor instead of failing outright.
 
 ## 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,68 @@
 
 ## 0.11.3 (unreleased)
 
-> Patch release. Headline: the **Smart Wallet passkey ceremony is now installed
-> however the client reaches `PollarProvider`**, so a consumer-built
-> `PollarClient` no longer silently loses passkey login. Additive, non-breaking
-> on top of 0.11.2.
+> Patch release. Headlines: **sessions no longer die on reload when the DPoP
+> keypair fails to persist** (thumbprint-mismatch logout loop), and the **Smart
+> Wallet passkey ceremony is now installed however the client reaches
+> `PollarProvider`**, so a consumer-built `PollarClient` no longer silently
+> loses passkey login. Additive, non-breaking on top of 0.11.2.
 
 ### `@pollar/core`
 
+- **Fix: a session no longer dies on the first reload when the DPoP keypair
+  fails to persist (`SDK_AUTH_DPOP_INVALID` / `thumbprint-mismatch`).** When
+  IndexedDB couldn't durably store the keypair (blocked, evicted, private
+  mode), the failure was swallowed: login worked against the in-memory key, but
+  the next page load generated a fresh keypair, every `/auth/session/resume`
+  401'd with `thumbprint-mismatch`, and `_clearSession()` then also destroyed
+  the (new, valid) keypair — logging the user out with no diagnostic. Four
+  changes, none touching the public API:
+  - The persisted session now records `dpopJkt` — the thumbprint of the key
+    its tokens are bound to (`cnf.jkt`). On restore, a mismatch against the
+    currently loaded keypair means every proof-bound call (resume, refresh,
+    signing) is guaranteed to fail, so the session is cleared **locally** with
+    an error log naming the real cause — no doomed resume round trip, no 401
+    burst, no phantom `authenticated` emission. Sessions persisted by older
+    SDKs have no `dpopJkt` and behave as before (the resume decides).
+  - `_clearSession()` no longer resets the DPoP keypair. The key is
+    device-scoped, not session-scoped, and the clear also runs on failure
+    paths (rejected resume, failed refresh, cross-tab clear, superseded login
+    race) where destroying it made every other session bound to the key —
+    persisted, or a token the consumer held elsewhere — permanently
+    unverifiable. The keypair is rotated only on explicit `logout()`. The
+    in-memory `DPoP-Nonce` also survives the clear (it is origin-scoped server
+    state); it is intentionally **not** persisted across page loads — server
+    nonces are short-lived, so the one cold-start `use_dpop_nonce` round trip
+    stays. To keep multiple tabs coherent now that the clear keeps the key,
+    the new optional `KeyManager.resync()` (drop the in-memory cache, keep
+    persistent storage) runs on every clear, and the `dpopJkt` check resyncs
+    and re-compares before concluding a mismatch — so after a cross-tab
+    logout → fresh login, a sibling tab adopts the rotated shared key instead
+    of signing with its stale cached copy (or clearing the session the other
+    tab just created).
+  - `_resume()` coalesces concurrent triggers (startup restore + visibility
+    flaps used to abort/restart each other into a burst of identical 401s)
+    and backs off exponentially (1s → 30s cap) after non-terminal failures
+    (network, 429, 5xx). Terminal 401/403/410 still clears the session
+    immediately, exactly as before.
+  - Key managers persist durably and loudly: IndexedDB writes now await the
+    transaction's `complete` event (a put request's `onsuccess` fires before
+    the commit, so commit-time failures were silent), and the new optional
+    `KeyManager.ensurePersisted()` (implemented by both `WebCryptoKeyManager`
+    and `NobleKeyManager`) is called at login just before the key is bound:
+    it re-writes and read-back-verifies the key, and the client warns
+    `"the session will NOT survive a reload"` when persistence is
+    unavailable — at login time, not as a mystery logout later. The re-write
+    also heals a key deleted by another tab's `reset()`.
+  - New smoke suite `tests/smoke-resume.cjs` covers all of it against a mock
+    server that actually verifies the DPoP binding (nonce challenge + proof
+    thumbprint vs `cnf.jkt`) and an IndexedDB shim that survives across
+    client instances.
+  - Recovery note: sessions persisted by ≤0.11.2 whose keypair DID persist
+    resume normally after upgrading. Sessions whose keypair was already lost
+    or reset cannot be recovered (the private key is gone — that is DPoP's
+    security property); those users must log in once more, now with a clean
+    single log line instead of a 401 loop.
 - New `client.setPasskeyDefaults({ passkey?, passkeySign? })`. Fills in the
   passkey ceremony and signer when they were not supplied at construction, and
   never replaces ones that were, so React Native keeps injecting its native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@
 
 ### `@pollar/core`
 
+- **Fix: `logout()` no longer destroys a session created while it runs.**
+  `logout()` awaits a network call and an adapter disconnect, and consumers
+  routinely do not await it (`@pollar/react` fires it from the login modal and
+  the wallet button, then offers the login UI). A complete new login could land
+  inside that window - the abort below only cancels a login already running -
+  and the teardown then ran against whatever state existed when the awaits
+  resolved: it wiped the new session and rotated away the key that session had
+  just been bound to. The whole teardown is now guarded on the session
+  generation snapshotted at the top of `logout()`.
+- **Fix: `logout()` rotates the DPoP keypair only when it still owns the
+  session row.** The keypair record (`pollar-keys/<apiKeyHash>`) is shared by
+  every document on the origin and is MORE shared than the session row, which
+  was already ownership-gated. A client whose session had been superseded still
+  destroyed the key the current row's session was bound to, leaving that session
+  in storage pointing at a `cnf.jkt` that no longer existed locally - cleared on
+  its next restore with its refresh token still valid.
+- **Fix: a logout propagates to sibling clients in the SAME document.** Browsers
+  deliver `storage` events only to OTHER documents, so two instances side by
+  side were the blind spot: after one logged out, the other kept its session and
+  re-persisted the row on its next write. The live-client registry now carries
+  the instances (not just a count) and the clear is announced in-process,
+  mirroring what the cross-document handler does.
+- **Change: the last server-issued `DPoP-Nonce` is persisted**
+  (`pollar:<apiKeyHash>:dpopNonce`) and restored at startup. The server requires
+  a nonce on every proof, so without it the first authenticated request of every
+  page load was a guaranteed 401 `use_dpop_nonce` challenge plus a retry. sdk-api
+  nonces verify for days (24h active + a 3-day rotation overlap), carry no user
+  identity and grant nothing on their own, so the value survives page loads and
+  session teardowns; a stale one costs exactly what having none costs.
 - **Fix: `logout()` cancels a login still in flight.** It never aborted
   `_loginController` (only `cancelLogin()` and `destroy()` did), so a
   `/auth/login` response landing after the logout re-ran the session store and
@@ -21,8 +50,7 @@
   It was computed with `getThumbprint()` at store time; if the key rotated
   between the login's bind and its store (e.g. the logout race above, or a
   cross-tab rotation mid-login), the field vouched for a key the server never
-  saw and the restore-time binding check waved through a session guaranteed to
-  401. `authenticate()` now computes the thumbprint of the exact `dpopJwk` it
+  saw and the restore-time binding check waved through a session guaranteed to 401. `authenticate()` now computes the thumbprint of the exact `dpopJwk` it
   sent to `/auth/login` and threads it into `storeSession` (internal
   `FlowDeps` signature only); the store-time read remains as fallback for the
   refresh path.
@@ -167,7 +195,7 @@
   `client.setPasskeyDefaults is not a function` when the provider mounts.
 - Consumers that pin both packages to an exact version must bump them together.
   Mixing versions installs a second copy of core, and `client instanceof
-  PollarClient` then compares against a different class object, so the provider
+PollarClient` then compares against a different class object, so the provider
   takes the config branch and spreads an instance into the constructor instead
   of failing outright.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,9 +219,10 @@
 
 ### Packaging
 
-- `@pollar/react` now requires `@pollar/core@^0.11.3` (`setPasskeyDefaults()`
-  is new in core; an older core throws `client.setPasskeyDefaults is not a
-  function` when the provider mounts). Consumers that pin both packages to an
+- `@pollar/react` now requires `@pollar/core@^0.11.3` (`setPasskeyDefaults()` is
+  new in core; an older one throws
+  `client.setPasskeyDefaults is not a function` when the provider mounts).
+  Consumers that pin both packages to an
   exact version must bump them together: mixing versions installs a second
   copy of core, and `client instanceof PollarClient` then compares against a
   different class object, so the provider takes the config branch and spreads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,9 @@
     the commit, so commit-time failures were silent), and the new optional
     `KeyManager.ensurePersisted()` (implemented by both `WebCryptoKeyManager`
     and `NobleKeyManager`) is called at login just before the key is bound:
-    it re-writes and read-back-verifies the key, and the client warns
+    it re-writes the key and verifies that what storage hands back is that
+    same key (by thumbprint, so another tab writing its own pair between the
+    two is caught rather than accepted), and the client warns
     `"the session will NOT survive a reload"` when persistence is
     unavailable — at login time, not as a mystery logout later. The re-write
     also heals a key deleted by another tab's `reset()`.
@@ -302,13 +304,18 @@
   scan, the payload as text when the server marks it worth pasting, and a map
   over `fields` - none of which knows which provider served the route. Pollar's
   own QR arrives as inline markup so `currentColor` keeps it legible in both
-  themes; a provider's bitmap (`inlineSafe: false`) renders through an `<img>`
-  instead. A custom ramp template must adopt the normalized shape - this is
-  the type-level change flagged in the headline.
+  themes; anything not inline-safe renders through an `<img>` whose data URL
+  follows the declared `encoding`, so a provider's `utf8` SVG is escaped rather
+  than base64-wrapped into a URL no browser can decode. A custom ramp template
+  must adopt the normalized shape - this is the type-level change flagged in
+  the headline.
 - **Ramp KYC gate.** When an off-ramp answers `kycRequired: true` and the
   provider publishes no hosted KYC URL, the withdraw button is withheld with
   the reason stated (nothing was sent, nothing was signed) and
-  `getRampKycStatus()` is polled until the provider clears the user.
+  `getRampKycStatus()` is polled until the provider clears the user. Approval
+  unblocks the next quote, not that one: the provider consumed its quote when
+  it asked for KYC, so the transaction stays blocked for good and the approved
+  state offers a "Request a new quote" button instead of the withdraw.
 - **Amount limits are enforced and explained before submitting.** The widget
   checks the amount against the chosen route's `minAmount` / `maxAmount` (the
   limits already travelled on the quote and nothing read them) and renders the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,14 @@
   instances. The guard tries `instanceof` first, so it also accepts instances
   from builds that predate the brand. Use it instead of `instanceof` wherever a
   client may have crossed a package boundary.
+- **Removed: the `walletType` prop on `WalletButtonTemplateProps`.**
+  `WalletButton` derived it (`wallet.provider` for an `external`-custody wallet,
+  else `null`) and passed it down, but the default template never rendered it;
+  the wallet-logo mapping lives in the transaction modal's `TxStatusView`,
+  which derives the same value itself. Type-level only - the value carried no
+  behavior in this package. A custom template that read `props.walletType` can
+  reconstruct it from `usePollar()`:
+  `const walletType = wallet?.custody === 'external' ? wallet.provider : null;`
 
 ### Tests and CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 0.11.3
 
 > Patch release. Headlines: **sessions no longer die on reload when the DPoP
-> keypair fails to persist** (thumbprint-mismatch logout loop), and the **Smart
-> Wallet passkey ceremony is now installed however the client reaches
+> keypair fails to persist** (thumbprint-mismatch logout loop), **`PollarProvider`
+> no longer leaves a second `PollarClient` running under React StrictMode** (the
+> trigger behind "session cleared ~700ms after login" in development), and the
+> **Smart Wallet passkey ceremony is now installed however the client reaches
 > `PollarProvider`**, so a consumer-built `PollarClient` no longer silently
 > loses passkey login. Additive, non-breaking on top of 0.11.2.
 
@@ -199,6 +201,35 @@
 
 ### `@pollar/react`
 
+- **Fix: StrictMode no longer leaves an orphaned `PollarClient` running.**
+  The provider builds the client in a `useState` initializer, and React
+  StrictMode double-invokes that initializer in development while discarding the
+  first pass's hook state entirely - the instance the component keeps comes from
+  the second pass, and `useRef` carries nothing between the two, so nothing in
+  the component could see the first construction. That first client was never
+  torn down: it outlived the provider's own unmount, holding a cross-tab
+  `storage` listener, a proactive-refresh loop and a live-client registry entry
+  for the life of the page.
+
+  This is a real behavior change, not just tidier teardown. Two live clients on
+  one API key share the persisted session row and the DPoP keypair while running
+  independent refresh loops, so the orphan would restore the previous session,
+  revalidate it, and on the 401/403 clear the row the fresh login had just
+  written - surfacing as a session dropped about one round trip (~700ms) after a
+  successful login, with no `logout()` call, no visible 401 and no `storage`
+  event, because both clients live in the same document. Every cross-document
+  hardening elsewhere in this release exists to survive that configuration;
+  this stops it from happening in the first place. Development only (StrictMode
+  is a dev behavior), but that is where it was being hit.
+
+  Both render passes receive the same props object, so the provider now keys
+  clients it builds on that config object and the second pass reuses the first
+  pass's instance instead of constructing another. The entry is dropped as soon
+  as the mount effect claims the client, so a later provider rendered with the
+  same retained config object still builds its own. Consumers who pass a
+  ready-made `PollarClient` are unaffected - that path never constructed
+  anything. No API change.
+
 - **Fix: a pre-built `PollarClient` no longer loses passkey support.**
   `PollarProvider` injected `browserPasskeyCeremony` only on the branch that
   builds the client from a config object. A consumer passing a ready instance
@@ -216,6 +247,23 @@
 - `browserPasskeyCeremony` and `browserPasskeySigner` are now exported, for
   consumers who build their own `PollarClient` and want the ceremony wired at
   construction, or who want to wrap it (logging, a custom `rpId`).
+
+### Tests and CI
+
+- Three new smoke suites, wired into `npm run test:smoke` (which CI already
+  runs). `smoke-lifecycle.cjs` asserts that a destroyed client leaves nothing
+  behind - no registry entry, no `storage` listener, no reachability - since the
+  live-client registry holds instances. `smoke-invariants.cjs` drives seeded
+  random sequences of login / logout / un-awaited logout racing a login /
+  refresh / revalidate / reload / second instance / cross-tab clear / revocation
+  and checks fixed properties after every step, so it looks for the next
+  state-disagreement race rather than the last one; a failing seed replays with
+  `node tests/smoke-invariants.cjs <seed>`. `smoke-react.cjs` covers
+  `PollarProvider`'s client lifecycle and is what caught the StrictMode orphan
+  above. Each suite ships a positive control, and each was verified to fail
+  against the code that predates its fix.
+- CI runs on release branches (`main` and `0.*`), not `main` alone, so a release
+  branch is no longer unverified until its pull request opens.
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,40 @@
   `@pollar/react`. `_passkey` / `_passkeySign` stop being `readonly` to allow
   this. Both are read per login and per signature, never latched at
   construction, so filling them in later takes effect immediately.
+- **Fix: a logout sticks, and a login can no longer be undone by a write
+  already in flight.** Every mutation of the shared
+  `pollar:<apiKeyHash>:session` row now goes through one serialized writer that
+  re-checks the session generation immediately before it writes, instead of
+  after. Previously a persist that started before a logout landed after it and
+  re-created the row: the client went `idle` but the session came back on the
+  next reload, and in a browser that write's own `storage` event could log
+  other documents back in. Overlapping writes also landed in adapter-resolution
+  order, so an older session could win over a newer one.
+- **Fix: a client only removes the shared session row it owns.** The row is
+  shared by every document — and every client instance — on the origin, so a
+  teardown now removes it only when it still holds the session being cleared. A
+  second instance sitting on a stale session (e.g. React StrictMode
+  double-invoking the `useState` initializer that builds the client) used to
+  delete the row a fresh login had just written, about one round trip after
+  "Session stored", with no `logout()` and no 401 in the affected document.
+  `refresh()` called with no session no longer touches storage at all.
+- **Fix: the cross-tab `storage` handler no longer acts on events that are not
+  about this session.** It ignores `key === null` (a `clear()` of a whole
+  area, which any code on the origin can fire — an unrelated app on
+  `localhost`, a demo, an injected script), ignores events whose `storageArea`
+  is not `localStorage` (a same-origin iframe's `sessionStorage.clear()` used
+  to log the user out), and guards on holding a session rather than on the auth
+  step, so a cross-tab logout can no longer flap a login in progress. A client
+  destroyed before `_initialize()` finished no longer leaves a live listener
+  behind.
+- **Fix: a session row this build cannot read is no longer deleted.**
+  `readStorage()` used to remove the row on any validation or parse failure; in
+  a browser that removal emits a `storage` event, so one document hitting the
+  failure logged every other one out. It is now left alone and simply ignored.
+  `wallets[]` entries whose `type`/`chain` this build does not know are pruned
+  instead of failing the whole session (a newer server adding a chain no longer
+  logs older tabs out), and the access/refresh token bounds went from 4096 to
+  8192 chars so a larger JWT cannot silently invalidate a valid session.
 
 ### `@pollar/react`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,21 @@
   `PollarProvider`'s client lifecycle and is what caught the StrictMode orphan
   above. Each suite ships a positive control, and each was verified to fail
   against the code that predates its fix.
+- A fourth new suite, `smoke-cross-document.cjs`, ports the scratchpad
+  harnesses that found the cross-document teardown bugs. It adds the two mock
+  capabilities the rest of the suite lacks — real `storage`-event semantics
+  (delivered to every same-origin document EXCEPT the writer, one "document"
+  per client) and a storage adapter whose session writes can be held so the
+  `_persistSession` queue takes real depth. Covers: adoption of a sibling
+  document's login; a stale document's teardown not removing a fresh login's
+  row or keypair; foreign `clear()` / other-storage-area events ignored; the
+  triple race (held write + queued login-over-login + logout) resolved by
+  ownership-by-session-history with the key rotation; `destroy()` discarding a
+  queued refresh mutation; logout with the login's persist still queued; and
+  it pins the documented limitation that an external PHYSICAL deletion of the
+  row a client holds still reads as a logout (what the explicit logout-signal
+  design, in backlog, would fix). Negative-controlled against the pre-fix
+  bundle: the ownership, handler-filter and triple-race blocks fail there.
 - CI runs on release branches (`main` and `0.*`), not `main` alone, so a release
   branch is no longer unverified until its pull request opens.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@
 
 ### `@pollar/core`
 
+- **Fix: a superseded `logout()` no longer disconnects the wallet adapter.**
+  The adapter disconnect ran before the logout's generation guard, and
+  registered adapters are per-type singletons — so when a new external-wallet
+  login landed while the logout awaited the server, the "old" adapter
+  reference could be the very instance the new session was now using, and
+  disconnecting it cut that session's provider connection (external signing
+  broken until reconnect). The disconnect now sits behind the guard, with a
+  second generation re-check after its own await. Accepted residual: a
+  disconnect already in flight cannot be cancelled; if a login completes
+  during that exact await the provider connection can still be cut, though
+  the session and its keypair survive.
+- The same-document sibling registry now registers only on client runtimes
+  (browser / RN), matching the deregistration in `destroy()`. The old
+  unconditional registration leaked one entry (plus its notify closure) per
+  server-side client — those never deregister — and fired the "multiple live
+  clients" warning on servers, where one client per request is the normal
+  pattern and nothing is actually shared.
+- `tests/smoke-resume.cjs` grows to 44 checks (block 14): a superseded logout
+  leaves the adapter connected (0 disconnect calls) while an owned external
+  logout disconnects exactly once.
 - **Fix: `logout()` no longer destroys a session created while it runs.**
   `logout()` awaits a network call and an adapter disconnect, and consumers
   routinely do not await it (`@pollar/react` fires it from the login modal and
@@ -166,6 +186,16 @@
   instead of failing the whole session (a newer server adding a chain no longer
   logs older tabs out), and the access/refresh token bounds went from 4096 to
   8192 chars so a larger JWT cannot silently invalidate a valid session.
+- **Fix: a logout racing a login-over-login no longer leaves the previous
+  session's row behind.** Ownership for removing the shared session row is now
+  membership in the instance's own session history (`_ownedSessionIds`, stored
+  or restored, capped), not equality with the session being cleared. Without
+  this, a logout whose replacement write was still queued could find the row
+  holding this client's PREVIOUS session, refuse to remove it as "not ours",
+  and skip the key rotation gated on that removal — so the old, never-revoked
+  session restored fully functional on the next reload. Rows from sessions the
+  instance never held (another document's or instance's newer login) are still
+  protected: they are never in the history.
 
 ### `@pollar/react`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@
 
 ### `@pollar/core`
 
+- **Fix: `logout()` cancels a login still in flight.** It never aborted
+  `_loginController` (only `cancelLogin()` and `destroy()` did), so a
+  `/auth/login` response landing after the logout re-ran the session store and
+  resurrected the session — the user pressed logout and ended up logged in,
+  and (because logout rotates the keypair) that resurrected session was bound
+  to a destroyed key, guaranteed to 401 on first use. The flow deps already
+  no-op on an aborted signal, so aborting at the top of `logout()` closes it.
+- **Fix: the persisted `dpopJkt` records the key the server actually bound.**
+  It was computed with `getThumbprint()` at store time; if the key rotated
+  between the login's bind and its store (e.g. the logout race above, or a
+  cross-tab rotation mid-login), the field vouched for a key the server never
+  saw and the restore-time binding check waved through a session guaranteed to
+  401. `authenticate()` now computes the thumbprint of the exact `dpopJwk` it
+  sent to `/auth/login` and threads it into `storeSession` (internal
+  `FlowDeps` signature only); the store-time read remains as fallback for the
+  refresh path.
+- **Fix: `init()` no longer early-returns into a half-built key manager.**
+  `_doInit` assigns the keypair and only then awaits the JWK export +
+  thumbprint; a caller landing in that window returned immediately and
+  `getThumbprint()` threw "initialization failed" while init was mid-flight —
+  silently omitting `dpopJkt` and disabling the binding check. Both managers
+  now require all three fields (`keyPair`/`privateKey`, `publicJwk`,
+  `thumbprint`) before the fast path, so such callers join the in-flight init.
+- Corrected the `_clearSession` nonce comment: sdk-api DPoP nonces verify for
+  days (24h active + 3-day rotation overlap), not "short-lived" — not
+  persisting the nonce across page loads is a simplicity trade-off, and
+  persisting it is a possible future latency win (would skip the cold-start
+  `use_dpop_nonce` challenge).
+- `tests/smoke-resume.cjs` grew to 27 checks: logout-cancels-login (no
+  resurrection), `dpopJkt === cnf.jkt` even when the store-time key lies
+  (simulated mid-login rotation), and `getThumbprint()` during the init
+  window resolving instead of throwing.
 - **Fix: a session no longer dies on the first reload when the DPoP keypair
   fails to persist (`SDK_AUTH_DPOP_INVALID` / `thumbprint-mismatch`).** When
   IndexedDB couldn't durably store the keypair (blocked, evicted, private

--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ This repository is managed with [Turborepo](https://turbo.build/repo) and contai
 
 ## Packages
 
-> **0.11.2 is additive (no breaking changes).** New `client.stellar` namespace: sign **SEP-53
+> **0.11.3 is a patch (no breaking changes).** Session resilience in `@pollar/core`: a session
+> **survives reloads when the DPoP keypair fails to persist** (no more thumbprint-mismatch
+> logout loop), `logout()` no longer races an in-flight or newer login (no resurrected or
+> leaked sessions), and cross-tab / multi-client session-row writes are serialized and
+> ownership-gated. In `@pollar/react`, a consumer-built `PollarClient` passed to
+> `PollarProvider` **keeps passkey login**. `@pollar/react@0.11.3` requires
+> `@pollar/core@^0.11.3`; if you pin exact versions, bump both together.
+>
+> Earlier: **0.11.2** (additive) added the `client.stellar` namespace: sign **SEP-53
 > message** and **SEP-10 challenge** ownership proofs across custodial and external wallets,
 > both returning the same `sep53` scheme so a verifier treats them alike. The Transaction
 > History modal goes **multichain** (network picker, per-chain explorer links, unified
@@ -32,7 +40,7 @@ This repository is managed with [Turborepo](https://turbo.build/repo) and contai
 
 ### [`@pollar/core`](./packages/core)
 
-**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/core)
+**Version:** `0.11.3` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/core)
 
 Framework-agnostic TypeScript SDK. Provides the `PollarClient` class and all lower-level utilities needed to integrate
 Pollar authentication and multichain (Stellar + Solana) transactions into any JavaScript environment.
@@ -111,7 +119,7 @@ const client = new PollarClient({ apiKey: 'pk_...', storage });
 
 ### [`@pollar/react`](./packages/react)
 
-**Version:** `0.11.2` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/react)
+**Version:** `0.11.3` &nbsp;|&nbsp; **Registry:** [npm](https://www.npmjs.com/package/@pollar/react)
 
 React bindings built on top of `@pollar/core`. Provides a context provider, hook, and pre-built UI components for
 drop-in authentication in React applications.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ This repository is managed with [Turborepo](https://turbo.build/repo) and contai
 > logout loop), `logout()` no longer races an in-flight or newer login (no resurrected or
 > leaked sessions), and cross-tab / multi-client session-row writes are serialized and
 > ownership-gated. In `@pollar/react`, a consumer-built `PollarClient` passed to
-> `PollarProvider` **keeps passkey login**. `@pollar/react@0.11.3` requires
-> `@pollar/core@^0.11.3`; if you pin exact versions, bump both together.
+> `PollarProvider` **keeps passkey login**, and StrictMode no longer leaves an orphaned
+> client running (dev only). Packaging: **`@pollar/core` is now a peer dependency only** of
+> `@pollar/react`, so the application's single copy of core is the one every package uses
+> (npm 7+ installs peers automatically; npm 6, Yarn 1 and `--legacy-peer-deps` users must
+> add core to their own dependencies), and the new `isPollarClient()` guard recognizes a
+> client even across duplicate copies. `@pollar/react@0.11.3` requires
+> `@pollar/core@^0.11.3`; if you pin exact versions, keep both on the same version.
 >
 > Earlier: **0.11.2** (additive) added the `client.stellar` namespace: sign **SEP-53
 > message** and **SEP-10 challenge** ownership proofs across custodial and external wallets,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,14 +2,19 @@
 
 ## 0.11.2 -> 0.11.3
 
-No breaking changes and no migration steps. 0.11.3 is a patch: sessions survive
-reloads when the DPoP keypair fails to persist, `logout()` no longer races an
-in-flight or newer login, cross-tab session writes are serialized and
-ownership-gated, and a consumer-built `PollarClient` passed to `PollarProvider`
-keeps passkey login. One packaging note: `@pollar/react@0.11.3` requires
-`@pollar/core@^0.11.3`; if you pin both packages to exact versions, bump them
-together (mixing versions installs a second copy of core and the provider's
-`client instanceof PollarClient` check fails). See the
+No breaking changes. 0.11.3 is a patch: sessions survive reloads when the DPoP
+keypair fails to persist, `logout()` no longer races an in-flight or newer
+login, cross-tab session writes are serialized and ownership-gated, and a
+consumer-built `PollarClient` passed to `PollarProvider` keeps passkey login.
+
+One packaging change: `@pollar/core` moved from `dependencies` to
+`peerDependencies` in `@pollar/react`. The old `dependencies` entry could
+install a second, package-local copy of core, which broke `instanceof`, split
+the live-client registry, and let two clients share one persisted session row.
+On npm 7+ there is nothing to do - peer dependencies install automatically. On
+npm 6, Yarn 1, or with `--legacy-peer-deps`, add `@pollar/core` to your own
+dependencies. `@pollar/react@0.11.3` requires `@pollar/core@^0.11.3`; if you
+pin both packages to exact versions, keep them on the same version. See the
 [CHANGELOG](./CHANGELOG.md) for the details.
 
 ## 0.11.1 -> 0.11.2

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,8 +14,20 @@ the live-client registry, and let two clients share one persisted session row.
 On npm 7+ there is nothing to do - peer dependencies install automatically. On
 npm 6, Yarn 1, or with `--legacy-peer-deps`, add `@pollar/core` to your own
 dependencies. `@pollar/react@0.11.3` requires `@pollar/core@^0.11.3`; if you
-pin both packages to exact versions, keep them on the same version. See the
-[CHANGELOG](./CHANGELOG.md) for the details.
+pin both packages to exact versions, keep them on the same version.
+
+One type-level removal in `@pollar/react`: `WalletButtonTemplateProps` no
+longer carries `walletType`. The default template never rendered it (the
+wallet-logo mapping lives in the transaction modal, which derives its own
+value). If a custom wallet-button template of yours read `props.walletType`,
+reconstruct it from the wallet exposed by `usePollar()`:
+
+```tsx
+const { wallet } = usePollar();
+const walletType = wallet?.custody === 'external' ? wallet.provider : null;
+```
+
+See the [CHANGELOG](./CHANGELOG.md) for the details.
 
 ## 0.11.1 -> 0.11.2
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade guide
 
+## 0.11.2 -> 0.11.3
+
+No breaking changes and no migration steps. 0.11.3 is a patch: sessions survive
+reloads when the DPoP keypair fails to persist, `logout()` no longer races an
+in-flight or newer login, cross-tab session writes are serialized and
+ownership-gated, and a consumer-built `PollarClient` passed to `PollarProvider`
+keeps passkey login. One packaging note: `@pollar/react@0.11.3` requires
+`@pollar/core@^0.11.3`; if you pin both packages to exact versions, bump them
+together (mixing versions installs a second copy of core and the provider's
+`client instanceof PollarClient` check fails). See the
+[CHANGELOG](./CHANGELOG.md) for the details.
+
 ## 0.11.1 -> 0.11.2
 
 No breaking changes and no migration steps. 0.11.2 is additive: the

--- a/package-lock.json
+++ b/package-lock.json
@@ -17656,7 +17656,7 @@
     },
     "packages/core": {
       "name": "@pollar/core",
-      "version": "0.11.2",
+      "version": "0.11.3-rc.1",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.9.7",
@@ -18299,10 +18299,10 @@
     },
     "packages/react": {
       "name": "@pollar/react",
-      "version": "0.11.2",
+      "version": "0.11.3-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.2",
+        "@pollar/core": "^0.11.3-rc.1",
         "@simplewebauthn/browser": "^13.3.0",
         "qr.js": "^0.0.0"
       },
@@ -18322,7 +18322,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@pollar/core": "^0.11.2",
+        "@pollar/core": "^0.11.3-rc.1",
         "react": ">=18",
         "react-dom": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18187,11 +18187,9 @@
       "name": "@pollar/accesly-adapter",
       "version": "0.11.2",
       "license": "MIT",
-      "dependencies": {
-        "@pollar/core": "^0.11.2"
-      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@pollar/core": "^0.11.2",
         "eslint": "^10.5.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
@@ -18241,11 +18239,9 @@
       "name": "@pollar/privy-adapter",
       "version": "0.11.2",
       "license": "MIT",
-      "dependencies": {
-        "@pollar/core": "^0.11.2"
-      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@pollar/core": "^0.11.2",
         "@privy-io/expo": "^0.69.4",
         "@privy-io/react-auth": "^3.32.2",
         "@stellar/stellar-sdk": "^15.1.0",
@@ -18852,12 +18848,12 @@
       "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.3",
         "@simplewebauthn/browser": "^13.3.0",
         "qr.js": "^0.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@pollar/core": "^0.11.3",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "eslint": "^10.5.0",
@@ -18908,7 +18904,6 @@
       "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.2",
         "@solana/wallet-standard-features": "^1.4.0",
         "@wallet-standard/app": "^1.1.1",
         "@wallet-standard/base": "^1.1.1",
@@ -18916,6 +18911,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@pollar/core": "^0.11.2",
         "eslint": "^10.5.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
@@ -18932,12 +18928,10 @@
       "name": "@pollar/stellar-wallets-kit-adapter",
       "version": "0.11.2",
       "license": "MIT",
-      "dependencies": {
-        "@pollar/core": "^0.11.2"
-      },
       "devDependencies": {
         "@creit.tech/stellar-wallets-kit": "^2.3.0",
         "@eslint/js": "^10.0.1",
+        "@pollar/core": "^0.11.2",
         "eslint": "^10.5.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -989,6 +989,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -1305,6 +1356,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -2490,6 +2554,146 @@
         "node": ">=16"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
@@ -3121,6 +3325,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -11341,6 +11563,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
@@ -11846,11 +12078,77 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -11908,6 +12206,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -12131,6 +12436,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -13189,6 +13507,19 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -13344,6 +13675,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -13539,6 +13877,85 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -14080,6 +14497,13 @@
         "is-buffer": "~1.1.6"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/micro-ftch": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
@@ -14491,6 +14915,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -15101,6 +15538,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -15295,6 +15742,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -15668,6 +16128,13 @@
         "standardwebhooks": "1.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
@@ -15742,6 +16209,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -15761,6 +16248,19 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -15991,6 +16491,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.26.0",
@@ -16323,6 +16833,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wagmi": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
@@ -16368,6 +16891,16 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -17452,6 +17985,23 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
@@ -17656,7 +18206,7 @@
     },
     "packages/core": {
       "name": "@pollar/core",
-      "version": "0.11.3-rc.1",
+      "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.9.7",
@@ -18299,10 +18849,10 @@
     },
     "packages/react": {
       "name": "@pollar/react",
-      "version": "0.11.3-rc.1",
+      "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
-        "@pollar/core": "^0.11.3-rc.1",
+        "@pollar/core": "^0.11.3",
         "@simplewebauthn/browser": "^13.3.0",
         "qr.js": "^0.0.0"
       },
@@ -18312,6 +18862,7 @@
         "@types/react-dom": "^18.0.0",
         "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
+        "jsdom": "^29.1.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "tsup": "^8.5.1",
@@ -18322,7 +18873,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@pollar/core": "^0.11.3-rc.1",
+        "@pollar/core": "^0.11.3",
         "react": ">=18",
         "react-dom": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stellar-wallets-kit-adapter:publish": "cd packages/stellar-wallets-kit-adapter && npm publish --access public",
     "solana-wallet-standard-adapter:publish": "cd packages/solana-wallet-standard-adapter && npm publish --access public",
     "core:update-openapi": "curl -k https://sdk.api.local.pollar.xyz/openapi.v2.json -o /tmp/openapi.json && npx openapi-typescript /tmp/openapi.json -o ./packages/core/src/api/schema.d.ts",
-    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs"
+    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs && node tests/check-comment-ascii.cjs"
   },
   "devDependencies": {
     "prettier": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stellar-wallets-kit-adapter:publish": "cd packages/stellar-wallets-kit-adapter && npm publish --access public",
     "solana-wallet-standard-adapter:publish": "cd packages/solana-wallet-standard-adapter && npm publish --access public",
     "core:update-openapi": "curl -k https://sdk.api.local.pollar.xyz/openapi.v2.json -o /tmp/openapi.json && npx openapi-typescript /tmp/openapi.json -o ./packages/core/src/api/schema.d.ts",
-    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs"
+    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs"
   },
   "devDependencies": {
     "prettier": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stellar-wallets-kit-adapter:publish": "cd packages/stellar-wallets-kit-adapter && npm publish --access public",
     "solana-wallet-standard-adapter:publish": "cd packages/solana-wallet-standard-adapter && npm publish --access public",
     "core:update-openapi": "curl -k https://sdk.api.local.pollar.xyz/openapi.v2.json -o /tmp/openapi.json && npx openapi-typescript /tmp/openapi.json -o ./packages/core/src/api/schema.d.ts",
-    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs"
+    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-react.cjs"
   },
   "devDependencies": {
     "prettier": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "polar-auth-monorepo",
+  "private": true,
   "version": "0.11.2",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stellar-wallets-kit-adapter:publish": "cd packages/stellar-wallets-kit-adapter && npm publish --access public",
     "solana-wallet-standard-adapter:publish": "cd packages/solana-wallet-standard-adapter && npm publish --access public",
     "core:update-openapi": "curl -k https://sdk.api.local.pollar.xyz/openapi.v2.json -o /tmp/openapi.json && npx openapi-typescript /tmp/openapi.json -o ./packages/core/src/api/schema.d.ts",
-    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-react.cjs"
+    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs"
   },
   "devDependencies": {
     "prettier": "^3.8.4",

--- a/packages/accesly-adapter/package.json
+++ b/packages/accesly-adapter/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/pollar-xyz/pollar.git",
     "directory": "packages/accesly-adapter"
   },
-  "description": "Accesly Smart Account wallet adapter for @pollar/core — sign Stellar transactions with a user's Accesly C-address (passkey + MPC) smart wallet, client-side.",
+  "description": "Accesly Smart Account wallet adapter for @pollar/core - sign Stellar transactions with a user's Accesly C-address (passkey + MPC) smart wallet, client-side.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/accesly-adapter/package.json
+++ b/packages/accesly-adapter/package.json
@@ -39,11 +39,9 @@
   "peerDependencies": {
     "@pollar/core": "^0.11.2"
   },
-  "dependencies": {
-    "@pollar/core": "^0.11.2"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@pollar/core": "^0.11.2",
     "eslint": "^10.5.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/accesly-adapter/src/index.ts
+++ b/packages/accesly-adapter/src/index.ts
@@ -9,7 +9,7 @@ import type {
 /**
  * Signs a full Stellar transaction XDR for the user's Accesly Smart Account and
  * returns the signed XDR. The consumer wires this from `@accesly/react`'s
- * `useAccesly().tx` — typically `wallet.unlockForSigning` (passkey → Shamir →
+ * `useAccesly().tx` - typically `wallet.unlockForSigning` (passkey -> Shamir ->
  * ed25519 seed) followed by `tx.signRawXdr({ transactionXdr, ed25519Seed, expectedPublicKey })`.
  */
 export type AcceslySignXdr = (xdr: string) => Promise<string>;
@@ -30,7 +30,7 @@ const ACCESLY_ID = 'accesly';
  *
  * Accesly is a self-custodial **smart wallet** (C-address Soroban contract,
  * passkey + Shamir-MPC ed25519 signer) that Accesly itself deploys and manages.
- * So `custody` is `'smart'`, but — unlike Pollar's own smart wallets — signing
+ * So `custody` is `'smart'`, but - unlike Pollar's own smart wallets - signing
  * happens **client-side** via Accesly's SDK: Pollar never holds the key and does
  * not deploy/sponsor/submit through wallet-service. The signed XDR is broadcast
  * via RPC, the same routing as an external wallet.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -9,8 +9,9 @@ Core SDK for [Pollar](https://pollar.xyz) — authentication and transaction uti
 > keypair. `logout()` cancels a login still in flight, never destroys a session created while
 > it runs, rotates the keypair only when it still owns the teardown, and propagates to
 > sibling clients in the same document. Shared session-row writes are serialized and
-> ownership-gated, and the last server-issued `DPoP-Nonce` is persisted. New public method:
-> `setPasskeyDefaults()` on `PollarClient`.
+> ownership-gated, and the last server-issued `DPoP-Nonce` is persisted. New public API:
+> `setPasskeyDefaults()` on `PollarClient`, and `isPollarClient(value)`, a type guard that
+> recognizes a client even across duplicate copies of this package (`instanceof` cannot).
 >
 > Earlier: **0.11.2** added `client.stellar` — **SEP-53 message** and **SEP-10 challenge** ownership
 > proofs. External wallets sign client-side through their adapter (new optional

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,17 @@
 
 Core SDK for [Pollar](https://pollar.xyz) — authentication and transaction utilities for Stellar and Solana applications.
 
-> **0.11.2** adds `client.stellar` — **SEP-53 message** and **SEP-10 challenge** ownership
+> **0.11.3** is a patch, non-breaking, focused on session resilience. A session
+> **survives reloads when the DPoP keypair fails to persist**: the persisted session records
+> the thumbprint of the key its tokens are bound to (`dpopJkt`), a mismatch is detected
+> locally instead of looping through 401s, and clearing a session no longer destroys the
+> keypair. `logout()` cancels a login still in flight, never destroys a session created while
+> it runs, rotates the keypair only when it still owns the teardown, and propagates to
+> sibling clients in the same document. Shared session-row writes are serialized and
+> ownership-gated, and the last server-issued `DPoP-Nonce` is persisted. New public method:
+> `setPasskeyDefaults()` on `PollarClient`.
+>
+> Earlier: **0.11.2** added `client.stellar` — **SEP-53 message** and **SEP-10 challenge** ownership
 > proofs. External wallets sign client-side through their adapter (new optional
 > `signStellarMessage` on `WalletAdapter`; Freighter implements it, Albedo has no SEP-53
 > support), custodial wallets sign server-side, and both return the same `sep53` scheme so a

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/core",
-  "version": "0.11.2",
+  "version": "0.11.3-rc.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/core",
-  "version": "0.11.3-rc.1",
+  "version": "0.11.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/src/adapters/expo-secure-store.ts
+++ b/packages/core/src/adapters/expo-secure-store.ts
@@ -31,7 +31,7 @@ type SecureStoreApi = {
 
 /**
  * Hard cap per stored value. Generously above what the SDK actually writes
- * (sessions ≈ 600–800 bytes, private scalars ≈ 43 chars), and well within
+ * (sessions ~ 600-800 bytes, private scalars ~ 43 chars), and well within
  * iOS Keychain's practical limit. Refuses oversized writes loudly rather
  * than letting the platform truncate or silently fail.
  */
@@ -40,10 +40,10 @@ export const SECURE_STORE_MAX_VALUE_BYTES = 4096;
 /**
  * Map a logical storage key onto one Expo SecureStore accepts. SecureStore keys
  * must match `[A-Za-z0-9._-]`, but the SDK namespaces its keys with `:`
- * (`pollar:<apiKeyHash>:session`, `pollar:dpop-key:<apiKeyHash>`, …), which
+ * (`pollar:<apiKeyHash>:session`, `pollar:dpop-key:<apiKeyHash>`, ...), which
  * SecureStore rejects with an `Invalid key` error. Replace every disallowed
  * character with `_`. The transform is deterministic and collision-free for the
- * SDK's fixed key templates — their only variable segment is a hex hash — so a
+ * SDK's fixed key templates - their only variable segment is a hex hash - so a
  * given logical key always resolves to the same SecureStore key.
  */
 export function sanitizeKey(key: string): string {
@@ -83,7 +83,7 @@ function utf8ByteLength(value: string): number {
     if (code < 0x80) bytes += 1;
     else if (code < 0x800) bytes += 2;
     else if (code >= 0xd800 && code <= 0xdbff) {
-      // Surrogate pair → 4 bytes; advance the index.
+      // Surrogate pair -> 4 bytes; advance the index.
       bytes += 4;
       i++;
     } else bytes += 3;

--- a/packages/core/src/adapters/expo-secure-store.ts
+++ b/packages/core/src/adapters/expo-secure-store.ts
@@ -94,7 +94,7 @@ function utf8ByteLength(value: string): number {
 /**
  * Create a `Storage` adapter backed by Expo SecureStore.
  *
- * Throws synchronously (via the returned Promise) at construction time if
+ * Throws (via the returned Promise) at construction time if
  * `expo-secure-store` cannot be loaded.
  */
 export async function createSecureStoreAdapter(options: SecureStoreAdapterOptions = {}): Promise<Storage> {

--- a/packages/core/src/adapters/react-native-appstate.ts
+++ b/packages/core/src/adapters/react-native-appstate.ts
@@ -5,13 +5,13 @@ import type { VisibilityProvider } from '../visibility/types';
  *
  * Wire it into the silent-refresh scheduler so proactive token renewals are
  * skipped while the app is backgrounded and run the moment it returns to the
- * foreground — matching the web `visibilitychange` behavior and sidestepping
+ * foreground - matching the web `visibilitychange` behavior and sidestepping
  * RN's aggressive background timer throttling.
  *
  * `react-native` is the consumer's framework (not a dependency of this SDK),
  * so the module is loaded lazily via dynamic `import('react-native')`. That
  * keeps web/Node bundles from ever resolving it. Because loading is async, the
- * factory is async too — mirror the `createSecureStoreAdapter` usage:
+ * factory is async too - mirror the `createSecureStoreAdapter` usage:
  *
  *   import { createAppStateVisibilityProvider } from '@pollar/core/adapters/react-native-appstate';
  *   const visibilityProvider = await createAppStateVisibilityProvider();
@@ -61,7 +61,7 @@ export async function createAppStateVisibilityProvider(): Promise<VisibilityProv
   return {
     isVisible: () => isActive(AppState.currentState),
     onChange: (cb) => {
-      // Filter duplicate notifications — listeners only see real transitions,
+      // Filter duplicate notifications - listeners only see real transitions,
       // matching the web provider's contract. RN also emits 'inactive'
       // (iOS transition state) which we collapse into "not visible".
       let last = isActive(AppState.currentState);

--- a/packages/core/src/adapters/react-native-keychain.ts
+++ b/packages/core/src/adapters/react-native-keychain.ts
@@ -14,7 +14,7 @@ import type { Storage } from '../storage/types';
  * Storage model: one Keychain `service` per logical key. Each `Storage.set(k, v)`
  * call writes a separate Keychain entry under `service = k`; this keeps the
  * adapter simple but means the number of distinct keys you write should stay
- * bounded (the SDK uses 2–3 keys per `apiKeyHash`).
+ * bounded (the SDK uses 2-3 keys per `apiKeyHash`).
  */
 
 type KeychainOptions = {
@@ -50,7 +50,7 @@ export interface KeychainAdapterOptions {
   /**
    * Override the iOS Keychain accessibility class. Defaults to
    * `ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY` when available on the loaded
-   * module — that prevents iCloud Keychain backup from carrying the SDK's
+   * module - that prevents iCloud Keychain backup from carrying the SDK's
    * private key material to another device.
    */
   accessible?: string;

--- a/packages/core/src/api/client.ts
+++ b/packages/core/src/api/client.ts
@@ -17,7 +17,7 @@ export interface ApiClientOptions {
    * A DPoP proof is single-use: the server remembers each `jti` and answers a
    * replay with `SDK_AUTH_DPOP_INVALID` / `jti-replay` (401). A retry built with
    * `request.clone()` carries the very same `DPoP` header, so without this hook
-   * the retry of a proof-carrying request is guaranteed to fail — and its 401
+   * the retry of a proof-carrying request is guaranteed to fail - and its 401
    * then looks like an expired token, triggering a pointless refresh.
    *
    * Returns a request with a freshly-minted proof, or `null` when it cannot be
@@ -32,7 +32,7 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_ATTEMPTS = 2;
 const DEFAULT_BASE_DELAY_MS = 300;
 
-/** `true` for a transport-level failure (timeout / dropped connection) — the
+/** `true` for a transport-level failure (timeout / dropped connection) - the
  *  only class of error worth retrying. An HTTP response, even a 5xx, is NOT an
  *  error here: openapi-fetch resolves it, so it never reaches this path. */
 function isRetryableTransportError(err: unknown): boolean {
@@ -54,7 +54,7 @@ function backoffDelay(attempt: number, baseDelayMs: number): number {
 /**
  * Run a single fetch bounded by `timeoutMs`, combining the timeout with the
  * request's own abort signal (e.g. a caller's cancellation, or `destroy()`).
- * Rejects with {@link PollarNetworkError} when the timeout — not the caller —
+ * Rejects with {@link PollarNetworkError} when the timeout - not the caller -
  * fired, so the reason is distinguishable downstream.
  *
  * Exported so the DPoP-nonce retry inside the client (which rebuilds the Request
@@ -73,7 +73,7 @@ export async function fetchWithTimeout(request: Request, timeoutMs: number): Pro
   try {
     // Race the fetch against the timeout. The abort above is the clean path, but
     // some runtimes (older React Native / Hermes fetch polyfills) ignore an
-    // `init.signal` override on a Request argument — there the abort never
+    // `init.signal` override on a Request argument - there the abort never
     // reaches the socket and the promise would hang forever. Racing a rejection
     // GUARANTEES the call settles regardless of how the runtime treats the
     // signal, which is the whole point: a stalled refresh must never trap the
@@ -86,7 +86,7 @@ export async function fetchWithTimeout(request: Request, timeoutMs: number): Pro
       else timeout.signal.addEventListener('abort', onTimeout);
     });
   } catch (err) {
-    // The timeout fired (not the caller's own cancellation) — normalize the
+    // The timeout fired (not the caller's own cancellation) - normalize the
     // failure to a typed, catchable error so callers can branch on the code.
     if (timeout.signal.aborted && !request.signal?.aborted) {
       throw err instanceof PollarNetworkError ? err : new PollarNetworkError(`Request timed out after ${timeoutMs}ms`, err);
@@ -96,7 +96,7 @@ export async function fetchWithTimeout(request: Request, timeoutMs: number): Pro
     timeout.clear();
     combined.cleanup();
     // If the race settled via the timeout, the aborted fetch will reject shortly
-    // after — swallow it so it doesn't surface as an unhandled rejection.
+    // after - swallow it so it doesn't surface as an unhandled rejection.
     fetchPromise.catch(() => {});
   }
 }
@@ -109,7 +109,7 @@ export async function fetchWithTimeout(request: Request, timeoutMs: number): Pro
  *
  * Only **idempotent** methods (GET/HEAD) are transparently retried. A
  * transport error (timeout / dropped connection) does not tell us whether the
- * server received and processed the request — only that we did not get the
+ * server received and processed the request - only that we did not get the
  * response. Re-sending a POST/PUT/PATCH/DELETE that already landed can duplicate
  * its effect, and for a DPoP-bound request it also replays a single-use proof
  * (same `jti`), which the server rejects with `SDK_AUTH_DPOP_INVALID` /
@@ -165,7 +165,7 @@ function makeRetryingFetch(
         return await fetchWithTimeout(attemptReq, effectiveTimeoutMs);
       } catch (err) {
         lastErr = err;
-        // The CALLER aborted (cancellation / destroy) — never retry, propagate.
+        // The CALLER aborted (cancellation / destroy) - never retry, propagate.
         if (request.signal?.aborted) throw err;
         // A real HTTP response never lands here; only transport errors do.
         if (!isRetryableTransportError(err) || attempt >= maxAttempts) throw err;

--- a/packages/core/src/api/endpoints/ramps.ts
+++ b/packages/core/src/api/endpoints/ramps.ts
@@ -1,11 +1,15 @@
 import type { PollarApiClient } from '../client';
 import type {
+  RampRail,
   RampsCompleteResponse,
   RampsCountriesResponse,
+  RampsKycStatusResponse,
+  RampsLiquidityResponse,
   RampsOfframpBody,
   RampsOfframpResponse,
   RampsOnrampBody,
   RampsOnrampResponse,
+  RampsPixDecodeResponse,
   RampsQuoteQuery,
   RampsQuoteResponse,
   RampsSignatureBody,
@@ -97,6 +101,45 @@ export async function submitRampSignature(
 export async function getRampTransaction(api: PollarApiClient, txId: string): Promise<RampsTransactionResponse> {
   const { data, error } = await api.GET('/ramps/transaction/{txId}', { params: { path: { txId } } });
   if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get transaction');
+  return data.content;
+}
+
+/**
+ * GET /ramps/liquidity
+ * Live liquidity on a payout rail. `available: false` means the rail cannot be
+ * served right now — quoting it succeeds and then fails downstream, so check
+ * before offering the corridor.
+ */
+export async function getRampLiquidity(api: PollarApiClient, rail: RampRail): Promise<RampsLiquidityResponse> {
+  const { data, error } = await api.GET('/ramps/liquidity', { params: { query: { rail } } });
+  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get ramp liquidity');
+  return data.content;
+}
+
+/**
+ * GET /ramps/kyc-status
+ * Where the authenticated user stands with the ramp provider's identity checks.
+ * Poll after an off-ramp answered `kycRequired: true`: nothing was signed and no
+ * funds moved, so wait for `hasApproved` and then request a fresh quote.
+ */
+export async function getRampKycStatus(api: PollarApiClient): Promise<RampsKycStatusResponse> {
+  const { data, error } = await api.GET('/ramps/kyc-status');
+  if (!data?.content || error)
+    throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get ramp KYC status');
+  return data.content;
+}
+
+/**
+ * GET /ramps/pix/decode
+ * Reads a Pix "copia e cola" payload into payee + amount. `decoded: null` means
+ * the code no longer resolves: dynamic Pix QRs carry a per-charge id and go
+ * stale once used or expired. Decode immediately before quoting, quote the
+ * amount it returns, and send the ORIGINAL payload as `qrCode` on the off-ramp —
+ * paying the bare key it decodes to gets rejected by the payee's bank.
+ */
+export async function decodePixQr(api: PollarApiClient, qrCode: string): Promise<RampsPixDecodeResponse> {
+  const { data, error } = await api.GET('/ramps/pix/decode', { params: { query: { qrCode } } });
+  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to decode Pix QR');
   return data.content;
 }
 

--- a/packages/core/src/api/endpoints/ramps.ts
+++ b/packages/core/src/api/endpoints/ramps.ts
@@ -17,6 +17,21 @@ import type {
   RampsTransactionResponse,
   RampTxStatus,
 } from '../../types';
+import { PollarApiError } from '../../types';
+
+/**
+ * Wrap an error body into a {@link PollarApiError}, keeping every field the API
+ * sent. Ramp failures are the ones a UI most needs to explain — an amount below
+ * the provider's minimum, a stale quote, pending KYC — and collapsing them to
+ * the bare code left the caller with nothing to say beyond it.
+ *
+ * `message` stays the code, so anything rendering `err.message` is unaffected.
+ */
+function rampApiError(error: unknown, fallback: string): PollarApiError {
+  const body = (typeof error === 'object' && error !== null ? error : {}) as Record<string, unknown>;
+  const code = typeof body.code === 'string' ? body.code : typeof body.error === 'string' ? body.error : fallback;
+  return new PollarApiError(code, body);
+}
 
 /**
  * GET /ramps/countries
@@ -25,7 +40,7 @@ import type {
  */
 export async function getRampCountries(api: PollarApiClient): Promise<RampsCountriesResponse> {
   const { data, error } = await api.GET('/ramps/countries');
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get ramp countries');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to get ramp countries');
   return data.content;
 }
 
@@ -37,7 +52,7 @@ export async function getRampCountries(api: PollarApiClient): Promise<RampsCount
  */
 export async function getRampsQuote(api: PollarApiClient, query: RampsQuoteQuery): Promise<RampsQuoteResponse> {
   const { data, error } = await api.GET('/ramps/quote', { params: { query } });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get ramp quotes');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to get ramp quotes');
   return data.content;
 }
 
@@ -49,7 +64,7 @@ export async function getRampsQuote(api: PollarApiClient, query: RampsQuoteQuery
  */
 export async function createOnRamp(api: PollarApiClient, body: RampsOnrampBody): Promise<RampsOnrampResponse> {
   const { data, error } = await api.POST('/ramps/onramp', { body });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to create onramp');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to create onramp');
   return data.content;
 }
 
@@ -60,7 +75,7 @@ export async function createOnRamp(api: PollarApiClient, body: RampsOnrampBody):
  */
 export async function createOffRamp(api: PollarApiClient, body: RampsOfframpBody): Promise<RampsOfframpResponse> {
   const { data, error } = await api.POST('/ramps/offramp', { body });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to create offramp');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to create offramp');
   return data.content;
 }
 
@@ -73,8 +88,7 @@ export async function createOffRamp(api: PollarApiClient, body: RampsOfframpBody
  */
 export async function completeWithdraw(api: PollarApiClient, txId: string): Promise<RampsCompleteResponse> {
   const { data, error } = await api.POST('/ramps/transaction/{txId}/complete', { params: { path: { txId } } });
-  if (!data?.content || error)
-    throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to complete withdrawal');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to complete withdrawal');
   return data.content;
 }
 
@@ -90,7 +104,7 @@ export async function submitRampSignature(
   body: RampsSignatureBody,
 ): Promise<RampsSignatureResponse> {
   const { data, error } = await api.POST('/ramps/transaction/{txId}/signature', { params: { path: { txId } }, body });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to submit signature');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to submit signature');
   return data.content;
 }
 
@@ -100,7 +114,7 @@ export async function submitRampSignature(
  */
 export async function getRampTransaction(api: PollarApiClient, txId: string): Promise<RampsTransactionResponse> {
   const { data, error } = await api.GET('/ramps/transaction/{txId}', { params: { path: { txId } } });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get transaction');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to get transaction');
   return data.content;
 }
 
@@ -112,7 +126,7 @@ export async function getRampTransaction(api: PollarApiClient, txId: string): Pr
  */
 export async function getRampLiquidity(api: PollarApiClient, rail: RampRail): Promise<RampsLiquidityResponse> {
   const { data, error } = await api.GET('/ramps/liquidity', { params: { query: { rail } } });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get ramp liquidity');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to get ramp liquidity');
   return data.content;
 }
 
@@ -124,8 +138,7 @@ export async function getRampLiquidity(api: PollarApiClient, rail: RampRail): Pr
  */
 export async function getRampKycStatus(api: PollarApiClient): Promise<RampsKycStatusResponse> {
   const { data, error } = await api.GET('/ramps/kyc-status');
-  if (!data?.content || error)
-    throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to get ramp KYC status');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to get ramp KYC status');
   return data.content;
 }
 
@@ -139,7 +152,7 @@ export async function getRampKycStatus(api: PollarApiClient): Promise<RampsKycSt
  */
 export async function decodePixQr(api: PollarApiClient, qrCode: string): Promise<RampsPixDecodeResponse> {
   const { data, error } = await api.GET('/ramps/pix/decode', { params: { query: { qrCode } } });
-  if (!data?.content || error) throw new Error((error as any)?.code ?? (error as any)?.error ?? 'Failed to decode Pix QR');
+  if (!data?.content || error) throw rampApiError(error, 'Failed to decode Pix QR');
   return data.content;
 }
 

--- a/packages/core/src/api/endpoints/ramps.ts
+++ b/packages/core/src/api/endpoints/ramps.ts
@@ -21,8 +21,8 @@ import { PollarApiError } from '../../types';
 
 /**
  * Wrap an error body into a {@link PollarApiError}, keeping every field the API
- * sent. Ramp failures are the ones a UI most needs to explain — an amount below
- * the provider's minimum, a stale quote, pending KYC — and collapsing them to
+ * sent. Ramp failures are the ones a UI most needs to explain - an amount below
+ * the provider's minimum, a stale quote, pending KYC - and collapsing them to
  * the bare code left the caller with nothing to say beyond it.
  *
  * `message` stays the code, so anything rendering `err.message` is unaffected.
@@ -121,7 +121,7 @@ export async function getRampTransaction(api: PollarApiClient, txId: string): Pr
 /**
  * GET /ramps/liquidity
  * Live liquidity on a payout rail. `available: false` means the rail cannot be
- * served right now — quoting it succeeds and then fails downstream, so check
+ * served right now - quoting it succeeds and then fails downstream, so check
  * before offering the corridor.
  */
 export async function getRampLiquidity(api: PollarApiClient, rail: RampRail): Promise<RampsLiquidityResponse> {
@@ -147,7 +147,7 @@ export async function getRampKycStatus(api: PollarApiClient): Promise<RampsKycSt
  * Reads a Pix "copia e cola" payload into payee + amount. `decoded: null` means
  * the code no longer resolves: dynamic Pix QRs carry a per-charge id and go
  * stale once used or expired. Decode immediately before quoting, quote the
- * amount it returns, and send the ORIGINAL payload as `qrCode` on the off-ramp —
+ * amount it returns, and send the ORIGINAL payload as `qrCode` on the off-ramp -
  * paying the bare key it decodes to gets rejected by the payee's bank.
  */
 export async function decodePixQr(api: PollarApiClient, qrCode: string): Promise<RampsPixDecodeResponse> {

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -1121,6 +1121,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ramps/liquidity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get payout rail liquidity
+         * @description Live liquidity on a payout rail. `available: false` means the rail cannot be served right now and the corridor should not be offered — quoting it succeeds and then fails downstream. Only providers that publish liquidity answer (Abroad today).
+         */
+        get: operations["getRampsLiquidity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ramps/kyc-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the ramp provider KYC status
+         * @description Where the authenticated user stands with the ramp provider's identity checks. Poll this after an off-ramp answered `kycRequired: true`: that provider exposes no hosted KYC link, so the client waits for `hasApproved` and then requests a fresh quote.
+         */
+        get: operations["getRampsKycStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ramps/pix/decode": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Decode a Pix QR payload
+         * @description Reads a Pix "copia e cola" EMV payload into payee, amount and tax id. `decoded: null` means the code no longer resolves — dynamic Pix QRs carry a per-charge id and go stale once used or expired. Decode immediately before quoting, quote the amount returned, and pass the original payload as `qrCode` on POST /ramps/offramp.
+         */
+        get: operations["getRampsPixDecode"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ramps/onramp": {
         parameters: {
             query?: never;
@@ -6888,6 +6948,228 @@ export interface operations {
             };
         };
     };
+    getRampsLiquidity: {
+        parameters: {
+            query: {
+                /** @description Payout rail to check */
+                rail: "PIX" | "BREB";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current liquidity on the rail. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_LIQUIDITY";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            /** @enum {string} */
+                            rail: "PIX" | "BREB";
+                            liquidity: number;
+                            available: boolean;
+                            message?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    getRampsKycStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description KYC state for the authenticated user. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_KYC_STATUS";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            provider: string;
+                            hasApproved: boolean;
+                            status: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    getRampsPixDecode: {
+        parameters: {
+            query: {
+                /** @description The raw Pix "copia e cola" payload */
+                qrCode: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Decoded payee details, or null when the code is stale. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        code: "SDK_RAMPS_PIX_DECODED";
+                        /** @constant */
+                        success: true;
+                        content: {
+                            decoded: {
+                                account: string;
+                                amount: string | null;
+                                currency: string | null;
+                                name: string | null;
+                                taxId: string | null;
+                            } | null;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        success: false;
+                        code: string;
+                        message?: string;
+                        resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
     postRampsOnramp: {
         parameters: {
             query?: never;
@@ -6927,6 +7209,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "pending" | "processing" | "completed" | "failed";
                             kycUrl?: string;
+                            kycRequired?: boolean;
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
@@ -7038,6 +7321,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "pending" | "processing" | "completed" | "failed";
                             kycUrl?: string;
+                            kycRequired?: boolean;
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
@@ -7136,6 +7420,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "pending" | "processing" | "completed" | "failed";
                             kycUrl?: string;
+                            kycRequired?: boolean;
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
@@ -7241,6 +7526,7 @@ export interface operations {
                             /** @enum {string} */
                             status: "pending" | "processing" | "completed" | "failed";
                             kycUrl?: string;
+                            kycRequired?: boolean;
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -6907,7 +6907,12 @@ export interface operations {
                                     options?: {
                                         value: string;
                                         label: string;
+                                        placeholder?: string;
                                     }[];
+                                    placeholderFrom?: string;
+                                    optional?: boolean;
+                                    placeholder?: string;
+                                    hint?: string;
                                 }[];
                                 minAmount?: number;
                                 maxAmount?: number;
@@ -7219,7 +7224,29 @@ export interface operations {
                                 action: "sep10" | "withdraw_payment";
                             };
                             depositInstructions?: {
-                                [key: string]: unknown;
+                                scannable?: {
+                                    /** @enum {string} */
+                                    kind: "pix" | "stellar" | "url" | "opaque";
+                                    payload: string | null;
+                                    payloadLabel: string | null;
+                                    image: {
+                                        /** @enum {string} */
+                                        mediaType: "image/svg+xml" | "image/png";
+                                        /** @enum {string} */
+                                        encoding: "utf8" | "base64";
+                                        data: string;
+                                        inlineSafe: boolean;
+                                    };
+                                };
+                                fields: {
+                                    /** @enum {string} */
+                                    key: "amount" | "currency" | "rail" | "reference" | "expires_at" | "status_page" | "account_holder" | "bank_name" | "bank_address" | "bank_account" | "bank_routing" | "iban" | "bic" | "clabe" | "deposit_address" | "memo";
+                                    label: string;
+                                    value: string;
+                                    /** @enum {string} */
+                                    type: "text" | "code" | "amount" | "datetime" | "url";
+                                    copyable: boolean;
+                                }[];
                             };
                         };
                     };
@@ -7331,7 +7358,29 @@ export interface operations {
                                 action: "sep10" | "withdraw_payment";
                             };
                             depositInstructions?: {
-                                [key: string]: unknown;
+                                scannable?: {
+                                    /** @enum {string} */
+                                    kind: "pix" | "stellar" | "url" | "opaque";
+                                    payload: string | null;
+                                    payloadLabel: string | null;
+                                    image: {
+                                        /** @enum {string} */
+                                        mediaType: "image/svg+xml" | "image/png";
+                                        /** @enum {string} */
+                                        encoding: "utf8" | "base64";
+                                        data: string;
+                                        inlineSafe: boolean;
+                                    };
+                                };
+                                fields: {
+                                    /** @enum {string} */
+                                    key: "amount" | "currency" | "rail" | "reference" | "expires_at" | "status_page" | "account_holder" | "bank_name" | "bank_address" | "bank_account" | "bank_routing" | "iban" | "bic" | "clabe" | "deposit_address" | "memo";
+                                    label: string;
+                                    value: string;
+                                    /** @enum {string} */
+                                    type: "text" | "code" | "amount" | "datetime" | "url";
+                                    copyable: boolean;
+                                }[];
                             };
                         };
                     };
@@ -7430,7 +7479,29 @@ export interface operations {
                                 action: "sep10" | "withdraw_payment";
                             };
                             depositInstructions?: {
-                                [key: string]: unknown;
+                                scannable?: {
+                                    /** @enum {string} */
+                                    kind: "pix" | "stellar" | "url" | "opaque";
+                                    payload: string | null;
+                                    payloadLabel: string | null;
+                                    image: {
+                                        /** @enum {string} */
+                                        mediaType: "image/svg+xml" | "image/png";
+                                        /** @enum {string} */
+                                        encoding: "utf8" | "base64";
+                                        data: string;
+                                        inlineSafe: boolean;
+                                    };
+                                };
+                                fields: {
+                                    /** @enum {string} */
+                                    key: "amount" | "currency" | "rail" | "reference" | "expires_at" | "status_page" | "account_holder" | "bank_name" | "bank_address" | "bank_account" | "bank_routing" | "iban" | "bic" | "clabe" | "deposit_address" | "memo";
+                                    label: string;
+                                    value: string;
+                                    /** @enum {string} */
+                                    type: "text" | "code" | "amount" | "datetime" | "url";
+                                    copyable: boolean;
+                                }[];
                             };
                         };
                     };
@@ -7536,7 +7607,29 @@ export interface operations {
                                 action: "sep10" | "withdraw_payment";
                             };
                             depositInstructions?: {
-                                [key: string]: unknown;
+                                scannable?: {
+                                    /** @enum {string} */
+                                    kind: "pix" | "stellar" | "url" | "opaque";
+                                    payload: string | null;
+                                    payloadLabel: string | null;
+                                    image: {
+                                        /** @enum {string} */
+                                        mediaType: "image/svg+xml" | "image/png";
+                                        /** @enum {string} */
+                                        encoding: "utf8" | "base64";
+                                        data: string;
+                                        inlineSafe: boolean;
+                                    };
+                                };
+                                fields: {
+                                    /** @enum {string} */
+                                    key: "amount" | "currency" | "rail" | "reference" | "expires_at" | "status_page" | "account_holder" | "bank_name" | "bank_address" | "bank_account" | "bank_routing" | "iban" | "bic" | "clabe" | "deposit_address" | "memo";
+                                    label: string;
+                                    value: string;
+                                    /** @enum {string} */
+                                    type: "text" | "code" | "amount" | "datetime" | "url";
+                                    copyable: boolean;
+                                }[];
                             };
                         };
                     };
@@ -7640,7 +7733,29 @@ export interface operations {
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
                             depositInstructions?: {
-                                [key: string]: unknown;
+                                scannable?: {
+                                    /** @enum {string} */
+                                    kind: "pix" | "stellar" | "url" | "opaque";
+                                    payload: string | null;
+                                    payloadLabel: string | null;
+                                    image: {
+                                        /** @enum {string} */
+                                        mediaType: "image/svg+xml" | "image/png";
+                                        /** @enum {string} */
+                                        encoding: "utf8" | "base64";
+                                        data: string;
+                                        inlineSafe: boolean;
+                                    };
+                                };
+                                fields: {
+                                    /** @enum {string} */
+                                    key: "amount" | "currency" | "rail" | "reference" | "expires_at" | "status_page" | "account_holder" | "bank_name" | "bank_address" | "bank_account" | "bank_routing" | "iban" | "bic" | "clabe" | "deposit_address" | "memo";
+                                    label: string;
+                                    value: string;
+                                    /** @enum {string} */
+                                    type: "text" | "code" | "amount" | "datetime" | "url";
+                                    copyable: boolean;
+                                }[];
                             };
                             updatedAt: string;
                         };

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -5355,6 +5355,13 @@ export interface operations {
                                 theme?: string;
                                 accentColor?: string;
                                 logoUrl?: string;
+                                modalTitle?: string;
+                                backgroundColor?: string;
+                                textColor?: string;
+                                buttonColor?: string;
+                                modalBorderRadius?: number;
+                                buttonBorderRadius?: number;
+                                modalZIndex?: number;
                                 emailEnabled?: boolean;
                                 embeddedWallets?: boolean;
                                 smartWallet?: boolean;

--- a/packages/core/src/client/auth/authenticate.ts
+++ b/packages/core/src/client/auth/authenticate.ts
@@ -27,7 +27,7 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
     // generic handler unchanged.
     if (err instanceof SessionStatusError) {
       // App-level terminal session status rides on a 2xx stream, so the central
-      // HTTP middleware can't classify it — log it here.
+      // HTTP middleware can't classify it - log it here.
       logApiError(logger, 'session status', { data: err });
       const { message, errorCode } =
         err.code === 'LOGIN_TIMEOUT'
@@ -37,7 +37,7 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
             : { message: 'Login session is no longer valid — please try again', errorCode: AUTH_ERROR_CODES.SESSION_INVALID };
       // Clear the partial session FIRST, then emit the error. clearSession emits
       // `idle`, so emitting the error AFTER makes it the final state a consumer
-      // sees — otherwise the error (LOGIN_TIMEOUT / SESSION_EXPIRED / …) is
+      // sees - otherwise the error (LOGIN_TIMEOUT / SESSION_EXPIRED / ...) is
       // immediately overwritten by idle and lost.
       await clearSession();
       setAuthState({ step: 'error', previousStep: 'authenticating', message, errorCode });
@@ -48,7 +48,7 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
 
   // Pass `dpopJwk` so the server mints DPoP-bound tokens (`cnf.jkt`).
   const dpopJwk = await deps.getPublicJwk();
-  // Thumbprint of the JWK we are about to bind — threaded into storeSession so
+  // Thumbprint of the JWK we are about to bind - threaded into storeSession so
   // the persisted `dpopJkt` records the key the server actually bound, even if
   // the local key rotates between this bind and the store (see FlowDeps).
   // Best-effort: a thumbprint failure must not fail the login.
@@ -65,7 +65,7 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
 
   if (data?.code === 'SDK_LOGIN_SUCCESS' && isValidSession(data?.content, logger)) {
     // `isValidSession` doesn't validate the `data` (PII) subtree, so reach into
-    // it defensively — a contract-drifted response missing `data`/`providers`
+    // it defensively - a contract-drifted response missing `data`/`providers`
     // should surface as a clean wallet-mismatch error, not a raw TypeError.
     const sessionWallet = data.content.data?.providers?.wallet?.address;
     if (expectedWallet && sessionWallet !== expectedWallet) {
@@ -80,7 +80,7 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
       return;
     }
     // The login was cancelled (cancelLogin) or superseded by a newer attempt
-    // (_newController) while POST /auth/login was in flight — its `signal` is now
+    // (_newController) while POST /auth/login was in flight - its `signal` is now
     // aborted. Don't resurrect `authenticated` over the idle/new state. (The
     // intervening error/clearSession writes above are intentionally NOT guarded.)
     if (signal.aborted) return;

--- a/packages/core/src/client/auth/authenticate.ts
+++ b/packages/core/src/client/auth/authenticate.ts
@@ -1,3 +1,4 @@
+import { computeJwkThumbprint } from '../../keys/thumbprint';
 import { AUTH_ERROR_CODES } from '../../types';
 import { isValidSession } from '../session';
 import { SessionStatusError, waitForSessionReady } from '../stream';
@@ -47,6 +48,11 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
 
   // Pass `dpopJwk` so the server mints DPoP-bound tokens (`cnf.jkt`).
   const dpopJwk = await deps.getPublicJwk();
+  // Thumbprint of the JWK we are about to bind — threaded into storeSession so
+  // the persisted `dpopJkt` records the key the server actually bound, even if
+  // the local key rotates between this bind and the store (see FlowDeps).
+  // Best-effort: a thumbprint failure must not fail the login.
+  const boundDpopJkt = await computeJwkThumbprint(dpopJwk).catch(() => undefined);
   // HTTP-level `error` is not handled here; the `else` branch below catches
   // both "request failed" (data === undefined) and "request OK but body
   // wasn't a valid session" via the same generic path.
@@ -78,7 +84,7 @@ export async function authenticate(clientSessionId: string, deps: FlowDeps, expe
     // aborted. Don't resurrect `authenticated` over the idle/new state. (The
     // intervening error/clearSession writes above are intentionally NOT guarded.)
     if (signal.aborted) return;
-    await storeSession(data.content);
+    await storeSession(data.content, boundDpopJkt);
   } else {
     if (!error) logApiError(logger, 'POST /auth/login', { body, data });
     // Clear first, then emit error (see the LOGIN_TIMEOUT branch above).

--- a/packages/core/src/client/auth/deps.ts
+++ b/packages/core/src/client/auth/deps.ts
@@ -29,7 +29,7 @@ export type FlowDeps = {
   setAuthState: (state: AuthState) => void;
   /**
    * Persist the authenticated session. `boundDpopJkt` is the RFC 7638
-   * thumbprint of the JWK the flow actually sent as `dpopJwk` to /auth/login —
+   * thumbprint of the JWK the flow actually sent as `dpopJwk` to /auth/login -
    * i.e. the key the server bound the tokens to (`cnf.jkt`). Pass it so the
    * persisted `dpopJkt` records the BOUND key, not whatever key happens to be
    * loaded at store time (they differ if the key rotated mid-login).
@@ -52,7 +52,7 @@ export type FlowDeps = {
   getPublicJwk: () => Promise<PublicEcJwk>;
   /**
    * Optional UI label persisted on the server-side refresh-token row so the
-   * sessions UI can show "iPhone — Safari" instead of a raw user-agent.
+   * sessions UI can show "iPhone - Safari" instead of a raw user-agent.
    */
   deviceLabel?: string;
 };

--- a/packages/core/src/client/auth/deps.ts
+++ b/packages/core/src/client/auth/deps.ts
@@ -27,7 +27,14 @@ export type FlowDeps = {
   useStreaming: boolean;
   signal: AbortSignal;
   setAuthState: (state: AuthState) => void;
-  storeSession: (session: PollarApplicationConfigContent) => void | Promise<void>;
+  /**
+   * Persist the authenticated session. `boundDpopJkt` is the RFC 7638
+   * thumbprint of the JWK the flow actually sent as `dpopJwk` to /auth/login —
+   * i.e. the key the server bound the tokens to (`cnf.jkt`). Pass it so the
+   * persisted `dpopJkt` records the BOUND key, not whatever key happens to be
+   * loaded at store time (they differ if the key rotated mid-login).
+   */
+  storeSession: (session: PollarApplicationConfigContent, boundDpopJkt?: string) => void | Promise<void>;
   clearSession: () => void | Promise<void>;
   /** Persists the connected adapter (in memory + the stored wallet id) so a
    *  returning session restores it. Keyed by `adapter.type`. */

--- a/packages/core/src/client/auth/emailFlow.ts
+++ b/packages/core/src/client/auth/emailFlow.ts
@@ -17,7 +17,7 @@ export async function initEmailSession(ctx: AuthProviderContext): Promise<string
 export async function sendEmailCode(email: string, clientSessionId: string, ctx: AuthProviderContext): Promise<void> {
   const { api, logger, signal, setAuthState } = ctx;
 
-  // Validate before hitting the API — an empty email/session (e.g. login()
+  // Validate before hitting the API - an empty email/session (e.g. login()
   // called without an `email`, or an action with a missing payload) would
   // otherwise POST blanks to /auth/email and get an opaque 400.
   if (!email?.trim() || !clientSessionId) {
@@ -57,7 +57,7 @@ export async function verifyAndAuthenticate(
 ): Promise<void> {
   const { api, logger, signal, setAuthState } = ctx;
 
-  // Validate before hitting the API — a blank code/session would otherwise POST
+  // Validate before hitting the API - a blank code/session would otherwise POST
   // blanks to /auth/email/verify-code for an opaque 400.
   if (!code?.trim() || !clientSessionId) {
     setAuthState({
@@ -111,7 +111,7 @@ export async function verifyAndAuthenticate(
 
   if (!error) logApiError(logger, 'POST /auth/email/verify-code', { body, data });
   // Carry `clientSessionId`/`email` so this generic failure (transient 5xx,
-  // contract drift) stays RETRYABLE — the message says "try again" and the
+  // contract drift) stays RETRYABLE - the message says "try again" and the
   // session is usually still alive, so `verifyEmailCode()` must be able to
   // re-submit without restarting the whole flow.
   setAuthState({

--- a/packages/core/src/client/auth/errorMessages.ts
+++ b/packages/core/src/client/auth/errorMessages.ts
@@ -5,7 +5,7 @@ import { AUTH_ERROR_CODES, type AuthErrorCode } from '../../types';
  * wallet-service in `{ code, success: false }`) to a user-facing message and
  * the SDK's coarse `AuthErrorCode` bucket.
  *
- * The backend stays code-only by design — this catalog is the single place the
+ * The backend stays code-only by design - this catalog is the single place the
  * SDK turns those codes into human-readable English. Consumers that need i18n
  * can switch on `state.errorCode` (the bucket) or the raw `code` instead of the
  * message string.
@@ -16,7 +16,7 @@ interface ResolvedAuthError {
 }
 
 const CATALOG: Record<string, ResolvedAuthError> = {
-  // ── Smart-account deploy / sponsor wallet ──────────────────────────────────
+  // -- Smart-account deploy / sponsor wallet ----------------------------------
   SPONSOR_NOT_FUNDED: {
     message: "This app can't create your wallet yet — its sponsor account isn't funded. Please contact the app's developer.",
     errorCode: AUTH_ERROR_CODES.PASSKEY_FAILED,
@@ -34,7 +34,7 @@ const CATALOG: Record<string, ResolvedAuthError> = {
     errorCode: AUTH_ERROR_CODES.PASSKEY_FAILED,
   },
 
-  // ── Passkey ceremony ────────────────────────────────────────────────────────
+  // -- Passkey ceremony --------------------------------------------------------
   PASSKEY_ALREADY_REGISTERED: {
     message: 'A passkey is already registered for this account. Try signing in instead.',
     errorCode: AUTH_ERROR_CODES.PASSKEY_FAILED,
@@ -52,8 +52,8 @@ const CATALOG: Record<string, ResolvedAuthError> = {
     errorCode: AUTH_ERROR_CODES.PASSKEY_FAILED,
   },
 
-  // ── On-chain transaction failures (surfaced during deploy/transfer) ─────────
-  // These map to the TX_FAILED bucket (not PASSKEY_FAILED) — the precise reason
+  // -- On-chain transaction failures (surfaced during deploy/transfer) ---------
+  // These map to the TX_FAILED bucket (not PASSKEY_FAILED) - the precise reason
   // is the entry key itself, surfaced as the raw `code` on the tx outcome.
   TX_INSUFFICIENT_BALANCE: {
     message: 'Insufficient balance to complete this transaction.',
@@ -88,7 +88,7 @@ const CATALOG: Record<string, ResolvedAuthError> = {
 /**
  * Resolves a backend error `code` to a friendly message + bucket. Falls back to
  * the supplied default message when the code is unknown or absent, bucketing by
- * the code's domain prefix (`TX_`/`SDK_TX_` → `TX_FAILED`, else `PASSKEY_FAILED`).
+ * the code's domain prefix (`TX_`/`SDK_TX_` -> `TX_FAILED`, else `PASSKEY_FAILED`).
  */
 export function resolveAuthError(code: string | undefined, fallbackMessage: string): ResolvedAuthError {
   if (code && CATALOG[code]) return CATALOG[code];

--- a/packages/core/src/client/auth/errorMessages.ts
+++ b/packages/core/src/client/auth/errorMessages.ts
@@ -93,7 +93,7 @@ const CATALOG: Record<string, ResolvedAuthError> = {
 export function resolveAuthError(code: string | undefined, fallbackMessage: string): ResolvedAuthError {
   if (code && CATALOG[code]) return CATALOG[code];
   // Bucket an UNKNOWN code by its domain prefix so a transaction code isn't
-  // mislabeled as a passkey failure (the historical default).
+  // mislabeled as a passkey failure.
   const errorCode =
     code && (code.startsWith('TX_') || code.startsWith('SDK_TX_'))
       ? AUTH_ERROR_CODES.TX_FAILED

--- a/packages/core/src/client/auth/logging.ts
+++ b/packages/core/src/client/auth/logging.ts
@@ -2,7 +2,7 @@ import type { PollarLogger } from '../../lib/logger';
 import { redactBody, redactDeep } from '../../lib/logging';
 
 /**
- * Logs an auth failure that the central HTTP middleware can't see — namely an
+ * Logs an auth failure that the central HTTP middleware can't see - namely an
  * *application-level* failure riding on a `2xx` response (e.g. `200` with
  * `{ success: false }`, or `/auth/email/verify-code` returning
  * `INVALID_EMAIL_CODE` in a `200` body). Transport / HTTP-status errors are
@@ -21,7 +21,7 @@ export function logApiError(
     route,
     ...(body !== undefined ? { body: redactBody(body) } : {}),
     // The cause is a server `data`/`error` envelope that can carry nested token
-    // material — redact it recursively rather than logging it raw.
+    // material - redact it recursively rather than logging it raw.
     cause: redactDeep(error ?? data),
   });
 }

--- a/packages/core/src/client/auth/oauthFlow.ts
+++ b/packages/core/src/client/auth/oauthFlow.ts
@@ -13,7 +13,7 @@ type OAuthDeps = FlowDeps & {
 
 /**
  * Break the popup's `window.opener` back-reference so the OAuth window
- * cannot navigate the parent. Best-effort — older browsers expose the
+ * cannot navigate the parent. Best-effort - older browsers expose the
  * property as read-only.
  */
 function severOpener(popup: Window | null): void {
@@ -27,8 +27,8 @@ function severOpener(popup: Window | null): void {
 
 /**
  * Default web opener: reserve a blank popup synchronously (before any await)
- * so popup blockers — which only honor `window.open` inside the original
- * user-gesture tick — don't swallow it, then navigate it to the OAuth URL.
+ * so popup blockers - which only honor `window.open` inside the original
+ * user-gesture tick - don't swallow it, then navigate it to the OAuth URL.
  *
  * React Native consumers replace this via `PollarClientConfig.openAuthUrl`
  * (typically wrapping `expo-web-browser`'s `openAuthSessionAsync`).
@@ -73,7 +73,7 @@ export async function loginOAuth(provider: 'google' | 'github', deps: OAuthDeps)
 
   await openAuthUrl({ provider, getUrl, redirectUri, signal });
 
-  // Opener never called `getUrl`, or session creation failed — nothing to poll.
+  // Opener never called `getUrl`, or session creation failed - nothing to poll.
   if (!clientSessionId) return;
 
   await authenticate(clientSessionId, deps);

--- a/packages/core/src/client/auth/passkeyFlow.ts
+++ b/packages/core/src/client/auth/passkeyFlow.ts
@@ -15,7 +15,7 @@ import { logApiError } from './logging';
  * 2. Ask the server for a challenge bound to that session.
  * 3. Run the device ceremony (injected `deps.passkey`) in `mode`.
  * 4. Post the result to the matching endpoint.
- * 5. Hand off to `authenticate()` for the READY → `/auth/login` token exchange.
+ * 5. Hand off to `authenticate()` for the READY -> `/auth/login` token exchange.
  */
 export async function smartWalletFlow(deps: FlowDeps, mode: PasskeyMode): Promise<void> {
   const { api, logger, signal, setAuthState, passkey } = deps;
@@ -49,14 +49,14 @@ export async function smartWalletFlow(deps: FlowDeps, mode: PasskeyMode): Promis
       return failPasskey(setAuthState, extractErrorCode(challengeError, challengeData), 'Failed to start passkey');
     }
 
-    // 2. Device ceremony (Touch ID / biometric) — runtime-injected.
+    // 2. Device ceremony (Touch ID / biometric) - runtime-injected.
     setAuthState({ step: 'creating_passkey' });
     const ceremony = await passkey({ challenge, mode });
     // openapi-fetch types the WebAuthn payload as a loose object; the browser
     // PublicKeyCredential JSON satisfies it.
     const response = ceremony.response as { [key: string]: unknown };
 
-    // 3. New user → register (deploys the C-address); returning → login.
+    // 3. New user -> register (deploys the C-address); returning -> login.
     if (ceremony.kind === 'register') {
       setAuthState({ step: 'deploying_smart_account' });
       const body = { clientSessionId, response };
@@ -76,7 +76,7 @@ export async function smartWalletFlow(deps: FlowDeps, mode: PasskeyMode): Promis
       }
     }
   } catch (err) {
-    // A cancel (cancelLogin / destroy / new login) aborts the signal → the
+    // A cancel (cancelLogin / destroy / new login) aborts the signal -> the
     // WebAuthn/ceremony call rejects with an AbortError. Rethrow it so the flow's
     // handler maps it to `idle`, instead of mislabeling a user cancel as
     // PASSKEY_FAILED. (Mirrors walletFlow.)
@@ -85,7 +85,7 @@ export async function smartWalletFlow(deps: FlowDeps, mode: PasskeyMode): Promis
     return failPasskey(setAuthState, undefined, 'Passkey login failed');
   }
 
-  // 4. Session is READY → exchange for DPoP-bound tokens.
+  // 4. Session is READY -> exchange for DPoP-bound tokens.
   await authenticate(clientSessionId, deps);
 }
 

--- a/packages/core/src/client/auth/providers.ts
+++ b/packages/core/src/client/auth/providers.ts
@@ -4,7 +4,7 @@ import { initEmailSession, sendEmailCode, verifyAndAuthenticate } from './emailF
 /**
  * Built-in hosted-OAuth provider (`google` / `github`). The whole popup +
  * status-poll dance lives in `ctx.startHostedOAuth`, so the provider is a
- * one-liner — and any custom provider can reuse the same helper.
+ * one-liner - and any custom provider can reuse the same helper.
  */
 export function oauthProvider(provider: 'google' | 'github'): PollarAuthProvider {
   return {
@@ -27,7 +27,7 @@ export function emailProvider(): PollarAuthProvider {
       const email = (options as { email?: string }).email ?? '';
       // Reject a blank email BEFORE minting a server session, so an `email`-less
       // login() doesn't create an orphaned session that then errors. sendEmailCode
-      // validates too (the real safety net) — this just fails faster and avoids
+      // validates too (the real safety net) - this just fails faster and avoids
       // the wasted /auth/session round-trip.
       if (!email.trim()) {
         ctx.setAuthState({

--- a/packages/core/src/client/auth/sep10-challenge.ts
+++ b/packages/core/src/client/auth/sep10-challenge.ts
@@ -1,31 +1,31 @@
 /**
- * SEP-10 challenge sanity-check — pure JS, ZERO external dependencies.
+ * SEP-10 challenge sanity-check - pure JS, ZERO external dependencies.
  *
  * Hardening for the wallet-login flow: before asking the user's wallet to sign
  * the server's "challenge transaction", we cheaply verify it actually looks like
  * a SEP-10 challenge and not a real, submittable transaction smuggled in by a
  * compromised or MITM'd challenge endpoint.
  *
- * The single most important invariant — and the one this checks — is
+ * The single most important invariant - and the one this checks - is
  * `sequenceNumber === 0`. A genuine SEP-10 challenge ALWAYS has sequence 0, so it
  * can never be applied to the ledger; a non-zero sequence means it's a live
  * transaction that, once signed, could authorize a real operation. Asserting
  * seq == 0 blocks the most dangerous class of "sign this to log in" attacks.
  *
  * This is deliberately NOT a full SEP-10 verification: it does not check the
- * server signature, home domain, or operation source — that would need a full
+ * server signature, home domain, or operation source - that would need a full
  * XDR + crypto library (`@stellar/stellar-base`). The real security boundary
  * remains the server-side `verifyChallengeTxSigners`; this is client-side
  * defense-in-depth, kept dependency-free on purpose.
  *
- * ── Why hand-parsing is safe here ────────────────────────────────────────────
+ * -- Why hand-parsing is safe here --------------------------------------------
  * The field we read (the transaction `seqNum`) sits at a fixed offset because it
  * comes right after the transaction SOURCE account, which in a SEP-10 challenge
  * is always the SERVER's account: a plain ed25519 G-address. It is never muxed
- * (M-address) and never a contract (C-address) — the user's account appears only
+ * (M-address) and never a contract (C-address) - the user's account appears only
  * as the source of the inner `manageData` operation, which we never touch. So
  * the byte layout up to `seqNum` is fixed. Anything that does NOT match the
- * expected shape — a muxed source, a fee-bump envelope, truncated bytes — makes
+ * expected shape - a muxed source, a fee-bump envelope, truncated bytes - makes
  * this return `false`: it FAILS CLOSED and the challenge is rejected before the
  * user can sign it.
  *
@@ -36,12 +36,12 @@
  * over `EnvelopeType`:
  *
  *   v1  (ENVELOPE_TYPE_TX = 2):
- *     [envelopeType u32=2][MuxedAccount source][fee u32][seqNum i64] …
- *     MuxedAccount = [keyType u32][…]; KEY_TYPE_ED25519 (0) → 32-byte key.
+ *     [envelopeType u32=2][MuxedAccount source][fee u32][seqNum i64] ...
+ *     MuxedAccount = [keyType u32][...]; KEY_TYPE_ED25519 (0) -> 32-byte key.
  *     seqNum offset = 4 (env) + 4 (keyType) + 32 (key) + 4 (fee) = 44.
  *
  *   v0  (ENVELOPE_TYPE_TX_V0 = 0):
- *     [envelopeType u32=0][ed25519 32 (raw, no keyType)][fee u32][seqNum i64] …
+ *     [envelopeType u32=0][ed25519 32 (raw, no keyType)][fee u32][seqNum i64] ...
  *     seqNum offset = 4 (env) + 32 (key) + 4 (fee) = 40.
  */
 import { base64urlDecode } from '../../lib/base64url';
@@ -82,7 +82,7 @@ export function isValidSep10Challenge(challengeXdr: string): boolean {
 
     let seqOffset: number;
     if (envelopeType === ENVELOPE_TYPE_TX) {
-      // v1: source is a MuxedAccount — require a plain ed25519 key (reject muxed).
+      // v1: source is a MuxedAccount - require a plain ed25519 key (reject muxed).
       if (view.getUint32(4, false) !== KEY_TYPE_ED25519) return false;
       seqOffset = SEQ_OFFSET_V1;
     } else if (envelopeType === ENVELOPE_TYPE_TX_V0) {

--- a/packages/core/src/client/auth/solanaWalletFlow.ts
+++ b/packages/core/src/client/auth/solanaWalletFlow.ts
@@ -20,7 +20,7 @@ function withSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
 }
 
 /**
- * Sign In With Solana (SIWS) login for a `chain: 'SOLANA'` adapter — the Solana
+ * Sign In With Solana (SIWS) login for a `chain: 'SOLANA'` adapter - the Solana
  * counterpart of {@link loginWithAdapter} (which is SEP-10, Stellar). Solana has no
  * challenge TRANSACTION (its signature binds an expiring blockhash), so the server
  * issues a SIWS INPUT, the wallet signs the rendered message (`solana:signIn`), and
@@ -113,7 +113,7 @@ export async function loginWithSolanaAdapter(adapter: WalletAdapter, deps: FlowD
       return;
     }
 
-    // Key control is proven — persist the adapter (and its walletType) now, so a
+    // Key control is proven - persist the adapter (and its walletType) now, so a
     // failure above never strands one (mirrors the Stellar flow).
     await deps.storeWalletAdapter(adapter, type);
   } catch (err) {

--- a/packages/core/src/client/auth/walletFlow.ts
+++ b/packages/core/src/client/auth/walletFlow.ts
@@ -38,7 +38,7 @@ export async function requestWalletChallenge(
     return null;
   }
   const challengeXdr = data.content.challengeXdr;
-  // Defense-in-depth before ANY consumer hands this to a real wallet to sign —
+  // Defense-in-depth before ANY consumer hands this to a real wallet to sign -
   // the built-in flow AND custom providers (via `ctx.requestChallenge`). Refuse
   // anything that isn't a real SEP-10 challenge (e.g. a live, submittable tx with
   // sequence != 0 from a compromised/MITM'd challenge endpoint). The server's
@@ -55,7 +55,7 @@ export async function loginWithAdapter(adapter: WalletAdapter, deps: FlowDeps): 
   const type = adapter.type;
 
   let connectedWallet: string;
-  // Assigned after the wallet is confirmed installed (see below) — declared here
+  // Assigned after the wallet is confirmed installed (see below) - declared here
   // so it's in scope for the `authenticate()` call after the try/catch.
   let clientSessionId: string;
   // Track the phase so the catch reports where the failure ACTUALLY happened
@@ -127,14 +127,14 @@ export async function loginWithAdapter(adapter: WalletAdapter, deps: FlowDeps): 
       return;
     }
 
-    // Key control is proven — NOW persist the adapter (and its walletType).
+    // Key control is proven - NOW persist the adapter (and its walletType).
     // Storing it at connect time left a dangling adapter + walletType row with
     // NO session whenever any step above failed; doing it here means a failure
     // never strands one. If the `authenticate()` call below fails, it runs
     // `clearSession()` which clears the adapter again.
     await deps.storeWalletAdapter(adapter, type);
   } catch (err) {
-    // A cancel (cancelLogin / destroy / new login) aborts the signal → withSignal
+    // A cancel (cancelLogin / destroy / new login) aborts the signal -> withSignal
     // rejects with an AbortError. Rethrow it so the flow's handler maps it to
     // `idle`, instead of mislabeling a user cancel as WALLET_CONNECT_FAILED.
     // (Mirrors how the other flows let AbortError propagate.)

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -267,8 +267,11 @@ export class PollarClient {
   /** Registered wallet adapters, keyed by id. Seeded with the built-in
    *  Freighter/Albedo, then any `config.walletAdapters` (override by `type`). */
   private readonly _walletAdapters = new Map<WalletId, WalletAdapter>();
-  private readonly _passkey: PasskeyCeremony | null;
-  private readonly _passkeySign: PasskeySigner | null;
+  // Not readonly: `setPasskeyDefaults()` may fill these in after construction
+  // when the consumer built the client themselves and handed it to a UI layer
+  // that knows the platform ceremony (see the method's docblock).
+  private _passkey: PasskeyCeremony | null;
+  private _passkeySign: PasskeySigner | null;
   /**
    * Stellar SEP ownership-proof surface (`client.stellar.sep53`, `.sep10`). Set
    * in the constructor so it exists on both client and server runtimes.
@@ -1318,6 +1321,22 @@ export class PollarClient {
     smartWalletFlow(this._flowDeps(controller.signal), 'register').catch((err) =>
       this._handleFlowError(err, controller.signal),
     );
+  }
+
+  /**
+   * Fills in the passkey ceremony/signer when they were not configured at
+   * construction. Called by the UI layer that knows the platform ceremony
+   * (`@pollar/react` on web); core stays platform-agnostic and ships no
+   * WebAuthn implementation of its own, so React Native can keep injecting its
+   * native provider through the constructor.
+   *
+   * Only fills gaps — an explicitly configured ceremony is never replaced.
+   * Reading `_passkey`/`_passkeySign` happens per login/signature (never
+   * latched at construction), so filling them later takes effect immediately.
+   */
+  setPasskeyDefaults(defaults: { passkey?: PasskeyCeremony; passkeySign?: PasskeySigner }): void {
+    if (!this._passkey && defaults.passkey) this._passkey = defaults.passkey;
+    if (!this._passkeySign && defaults.passkeySign) this._passkeySign = defaults.passkeySign;
   }
 
   // ─── Cancel ───────────────────────────────────────────────────────────────

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -7,7 +7,10 @@ import {
   completeWithdraw,
   createOffRamp,
   createOnRamp,
+  decodePixQr,
   getRampCountries,
+  getRampKycStatus,
+  getRampLiquidity,
   getRampsQuote,
   getRampTransaction,
   pollRampTransaction,
@@ -66,8 +69,12 @@ import {
   RampsOnrampResponse,
   RampsCompleteResponse,
   RampsCountriesResponse,
+  RampsKycStatusResponse,
+  RampsLiquidityResponse,
+  RampsPixDecodeResponse,
   RampsQuoteQuery,
   RampsQuoteResponse,
+  RampRail,
   RampsSignatureBody,
   RampsSignatureResponse,
   RampsTransactionResponse,
@@ -3086,6 +3093,33 @@ export class PollarClient {
 
   pollRampTransaction(txId: string, opts?: { intervalMs?: number; timeoutMs?: number }): Promise<RampTxStatus> {
     return pollRampTransaction(this._api, txId, opts);
+  }
+
+  /**
+   * Live liquidity on a payout rail. `available: false` means the rail cannot be
+   * served right now — check before offering the corridor, because quoting it
+   * succeeds and only fails much further downstream.
+   */
+  getRampLiquidity(rail: RampRail): Promise<RampsLiquidityResponse> {
+    return getRampLiquidity(this._api, rail);
+  }
+
+  /**
+   * Where the user stands with the ramp provider's identity checks. Poll after an
+   * off-ramp answered `kycRequired: true`: nothing was signed and no funds moved,
+   * so wait for `hasApproved` and then request a fresh quote.
+   */
+  getRampKycStatus(): Promise<RampsKycStatusResponse> {
+    return getRampKycStatus(this._api);
+  }
+
+  /**
+   * Decode a Pix "copia e cola" payload into payee + amount. `decoded: null` means
+   * the code went stale (dynamic Pix QRs are per-charge). Quote the amount it
+   * returns and pass the ORIGINAL payload as `qrCode` on {@link createOffRamp}.
+   */
+  decodePixQr(qrCode: string): Promise<RampsPixDecodeResponse> {
+    return decodePixQr(this._api, qrCode);
   }
 
   // ─── Distribution ─────────────────────────────────────────────────────────

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -156,11 +156,22 @@ const liveClientsByApiKey = new Map<string, Map<PollarClient, () => void>>();
  * one-hop: the recipients' own clears find the row already gone, so
  * `_persistSession` reports no removal and they do not notify back.
  */
-function notifySiblingClients(origin: PollarClient, apiKey: string): void {
+function notifySiblingClients(origin: PollarClient, apiKey: string, log: PollarLogger): void {
   const siblings = liveClientsByApiKey.get(apiKey);
   if (!siblings) return;
   for (const [client, notify] of siblings) {
-    if (client !== origin) notify();
+    if (client === origin) continue;
+    // Each sibling is isolated. This is a courtesy call made on behalf of OTHER
+    // instances, so a failure inside one must not stop the rest from being told
+    // and must never surface as a failure of the teardown that triggered it -
+    // an unguarded throw here left the clearing client stuck reporting
+    // `authenticated` with its session row already gone, and `logout()` swallows
+    // the error, so nothing pointed at the sibling that caused it.
+    try {
+      notify();
+    } catch (err) {
+      log.error('[PollarClient] A sibling client failed to handle the session clear', err);
+    }
   }
 }
 
@@ -461,12 +472,14 @@ export class PollarClient {
     // N4: warn (don't throw — that would break StrictMode double-mounts / HMR)
     // when a second live client exists for this API key.
     //
-    // Client runtimes only, matching the deregistration in `destroy()` — the
-    // old unconditional registration leaked an entry (and its notify closure)
-    // per server-side client, since those never deregistered. Server-rendered
-    // code also legitimately builds one client per request, so the "multiple
-    // live clients" warning is only meaningful where instances actually share
-    // persisted state and refresh loops: the browser / RN.
+    // Client runtimes only, mirroring the deregistration in `destroy()`. The
+    // constructor already returns above when there is no client runtime, so
+    // this is belt-and-braces rather than a fix for a reachable leak: it keeps
+    // the two halves of the registry contract stated in the same terms, so a
+    // refactor that moves either one cannot silently retain a client that never
+    // deregisters. Server-rendered code also legitimately builds one client per
+    // request, and the "multiple live clients" warning is only meaningful where
+    // instances actually share persisted state and refresh loops: browser / RN.
     if (isClientRuntime) {
       let liveSet = liveClientsByApiKey.get(this.apiKey);
       if (!liveSet) {
@@ -4076,9 +4089,12 @@ export class PollarClient {
     // initializer leaves one behind, and it is never destroyed) converges to
     // logged-out instead of re-persisting its own copy of the session a moment
     // later. Mirrors exactly what the cross-document handler does.
-    if (droppedOwnRow) notifySiblingClients(this, this.apiKey);
     this._resetReactiveStores();
     this._setAuthState({ step: 'idle' });
+    // Announce only once this client's own teardown is complete. Telling the
+    // siblings first put their handlers between us and our terminal state, so
+    // anything that went wrong in one of them left this client mid-teardown.
+    if (droppedOwnRow) notifySiblingClients(this, this.apiKey, this._log);
     return droppedOwnRow;
   }
 

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -209,6 +209,11 @@ export class PollarClient {
    * re-arms the refresh timer.
    */
   private _sessionGeneration = 0;
+  /**
+   * Serializes every mutation of the shared session row so two overlapping
+   * writes cannot land out of order. See `_persistSession`.
+   */
+  private _persistQueue: Promise<void> = Promise.resolve();
   /** Set by `destroy()`; short-circuits timer re-arming and any post-teardown work. */
   private _destroyed = false;
   private _storageEventHandler: ((e: StorageEvent) => void) | null = null;
@@ -452,6 +457,11 @@ export class PollarClient {
     // Compute the storage namespace first — every subsequent storage op
     // (including the cross-tab listener below and `_restoreSession`) reads it.
     this._apiKeyHash = await hashApiKey(this.apiKey);
+    // `destroy()` can only unhook a listener that is already attached, so a
+    // client destroyed during the await above would otherwise leave the handler
+    // below wired to `window` for the document's lifetime — a dead client that
+    // still reacts to cross-tab events and mutates shared storage.
+    if (this._destroyed) return;
 
     // Cross-tab session sync. Browser-only — the `storage` event is a DOM
     // feature with no React Native equivalent (each RN process owns its
@@ -459,18 +469,38 @@ export class PollarClient {
     if (isBrowser) {
       const sessionKey = sessionStorageKey(this._apiKeyHash);
       const handler = (e: StorageEvent): void => {
-        // `localStorage.clear()` fires with key === null; a targeted set/remove
-        // fires with key === sessionKey. Ignore unrelated keys.
-        if (e.key !== null && e.key !== sessionKey) return;
+        if (this._destroyed) return;
 
-        // Cross-tab LOGOUT: the session key was removed (newValue === null) or
-        // all storage was cleared (key === null). Propagate the logout straight
-        // from the event WITHOUT re-reading storage — a tab whose adapter
-        // degraded to memory (Safari private mode, quota) still holds its own
-        // copy of the session, so a re-read would miss the logout and keep using
-        // the now-revoked token.
-        if (e.key === null || e.newValue === null) {
-          if (this._authState.step !== 'idle') {
+        // Only `localStorage` concerns us. `sessionStorage` fires the very same
+        // event type at other same-origin documents that share its area (an
+        // iframe in this tab), and its contents have nothing to do with the
+        // session. `storageArea` is absent on synthetic events — treat those as
+        // ours rather than dropping them.
+        if (e.storageArea != null && typeof localStorage !== 'undefined' && e.storageArea !== localStorage) return;
+
+        // `key === null` is what the browser sends for `clear()` of a whole
+        // area, fired by ANY code on the origin: an unrelated app sharing
+        // `localhost`, a demo page, an injected script. It carries no
+        // information about our row, and the session it would tear down is
+        // still valid server-side, so it is not a logout signal. A logout that
+        // must propagate removes the session key itself (see below) or calls
+        // `logout()`.
+        if (e.key === null) {
+          this._log.debug('[PollarClient] Ignoring a foreign storage clear()');
+          return;
+        }
+        if (e.key !== sessionKey) return;
+
+        // Cross-tab LOGOUT: the session key was removed (newValue === null).
+        // Propagate the logout straight from the event WITHOUT re-reading
+        // storage — a tab whose adapter degraded to memory (Safari private
+        // mode, quota) still holds its own copy of the session, so a re-read
+        // would miss the logout and keep using the now-revoked token.
+        if (e.newValue === null) {
+          // Guard on the SESSION, not on the auth step: a login in flight
+          // (`authenticating`) holds no session to tear down, and clearing
+          // under it would flap the state of a login this event predates.
+          if (this._session) {
             void this._clearSession().catch((err) => this._log.error('[PollarClient] Cross-tab logout failed', err));
           }
           return;
@@ -937,7 +967,11 @@ export class PollarClient {
     const refreshToken = this._session?.token?.refreshToken;
     if (!refreshToken) {
       this._log.warn('[PollarClient] Refresh skipped: no refresh token in session');
-      await this._clearSession();
+      // Only tear down if we actually hold a session. `refresh()` is public and
+      // reachable with no session at all (a consumer calling it on a cold
+      // client); tearing down then would remove the shared row of a session
+      // this client never owned and log every other document out.
+      if (this._session) await this._clearSession();
       throw new Error('No refresh token available');
     }
 
@@ -1020,7 +1054,7 @@ export class PollarClient {
 
     this._session = { ...this._session, token: newToken };
     try {
-      await writeStorage(this._storage, this.apiKeyHash, this._session);
+      await this._persistSession(gen, this._session);
       this._log.info('[PollarClient] Tokens refreshed');
     } catch (err) {
       this._log.error('[PollarClient] Failed to persist refreshed session', err);
@@ -3510,6 +3544,7 @@ export class PollarClient {
   }
 
   private async _restoreSession(): Promise<void> {
+    if (this._destroyed) return;
     // Capture the pre-restore state so we can tell a genuine restore (cold
     // start, or another user's session) apart from a cross-tab token ROTATION
     // of the session we already have verified.
@@ -3809,7 +3844,7 @@ export class PollarClient {
       };
     }
 
-    await writeStorage(this._storage, this.apiKeyHash, persisted);
+    await this._persistSession(gen, persisted);
     // A logout / destroy / newer login landed DURING the persist await — bail so
     // we don't emit `authenticated` (resurrecting a session that was just
     // cleared) or re-arm the refresh timer for a session this call no longer
@@ -3838,11 +3873,17 @@ export class PollarClient {
 
   private async _clearSession(): Promise<void> {
     this._log.info('[PollarClient] Session cleared');
+    // Identify the session being torn down BEFORE dropping it: the persisted
+    // row is shared by every document (and every client instance) on this
+    // origin using this API key, so it may only be removed by the client that
+    // actually owns it. See `_persistSession`.
+    const owned = this._session?.clientSessionId ?? null;
     // Invalidate any in-flight refresh/resume so a result that lands after this
     // clear (e.g. a refresh racing a logout) is discarded instead of
     // resurrecting the session, and abort the resume so it can't re-emit
     // `authenticated` after we go `idle`.
     this._sessionGeneration++;
+    const gen = this._sessionGeneration;
     this._resumeController?.abort();
     this._resumeController = null;
     this._resetResumeBackoff();
@@ -3870,9 +3911,88 @@ export class PollarClient {
     // the next login's first proof. (It is intentionally NOT persisted across
     // page loads: server nonces are short-lived HMACs, so a stored one is
     // usually stale and the cold-start challenge round trip is unavoidable.)
-    await removeStorage(this._storage, this.apiKeyHash);
+    await this._persistSession(gen, null, owned);
     this._resetReactiveStores();
     this._setAuthState({ step: 'idle' });
+  }
+
+  /**
+   * Single writer for the shared `pollar:<apiKeyHash>:session` row.
+   *
+   * Every document on the origin — and every client instance inside one
+   * document — writes that same row, and each mutation is preceded by an await
+   * (the network round-trip, the storage adapter itself). Without this queue two
+   * hazards are reachable:
+   *
+   *   - ORDERING: two overlapping writes land in the order their adapter
+   *     resolves, so an older session can win over a newer one.
+   *   - RESURRECTION: a write that started before a logout lands after it and
+   *     re-creates a row the user just cleared. Re-checking the generation
+   *     *after* the write (as the callers used to) skips the state emission but
+   *     leaves the row behind, so the session comes back on the next reload and
+   *     the write's own `storage` event can log other documents back in.
+   *
+   * So the generation is re-checked HERE, immediately before the mutation, with
+   * writes serialized against each other. `gen` is the caller's snapshot of
+   * `_sessionGeneration`; a mismatch means a logout or a newer login superseded
+   * this write while it was queued and the mutation is dropped.
+   *
+   * `session === null` removes the row, but only when it still holds the
+   * session named by `ownedId` — a client must never delete a row that now
+   * belongs to a newer login in another document or another instance (a second
+   * client sitting on a stale session used to delete the row a fresh login had
+   * just written, about one round trip after "Session stored").
+   *
+   * Returns whether the mutation was applied.
+   */
+  private async _persistSession(
+    gen: number,
+    session: PollarPersistedSession | null,
+    ownedId: string | null = null,
+  ): Promise<boolean> {
+    const run = this._persistQueue.then(async (): Promise<boolean> => {
+      // `destroy()` does not bump the generation, so check it explicitly: a
+      // write still queued when the client is torn down must not land.
+      if (this._destroyed || this._sessionGeneration !== gen) {
+        this._log.debug('[PollarClient] Session write dropped: superseded before it reached storage');
+        return false;
+      }
+      if (session) {
+        await writeStorage(this._storage, this.apiKeyHash, session);
+        return true;
+      }
+      if (!ownedId) return false;
+      let current: string | null;
+      try {
+        current = await this._storage.get(sessionStorageKey(this.apiKeyHash));
+      } catch {
+        current = null;
+      }
+      // Already gone (another document removed it, or a foreign clear wiped
+      // the area): there is nothing of ours left to drop.
+      if (current === null) return false;
+      let owns: boolean;
+      try {
+        owns = (JSON.parse(current) as { clientSessionId?: unknown }).clientSessionId === ownedId;
+      } catch {
+        // Unparseable row inside our own namespace: nobody can use it, so it is
+        // ours to clean up.
+        owns = true;
+      }
+      if (!owns) {
+        this._log.debug('[PollarClient] Session row now belongs to a newer session; leaving shared storage untouched');
+        return false;
+      }
+      await removeStorage(this._storage, this.apiKeyHash);
+      return true;
+    });
+    // Keep the chain resolved: a rejected mutation must not poison every write
+    // queued behind it. The rejection still reaches this call's caller.
+    this._persistQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   private _networkPassphrase(): string {

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -178,6 +178,36 @@ function notifySiblingClients(origin: PollarClient, apiKey: string, log: PollarL
 /** Renew the access token this many seconds before its `exp` to absorb clock skew + signing latency. */
 const REFRESH_SKEW_SECONDS = 60;
 
+/**
+ * Cross-copy brand for `PollarClient`, stamped on every instance.
+ *
+ * `instanceof` compares against one specific class object, so it answers `false`
+ * for an instance built by a DIFFERENT copy of this module - and a second copy
+ * is easy to end up with: a package listing `@pollar/core` in `dependencies`
+ * rather than only as a peer, an exact pin that disagrees with another
+ * package's, a bundler that does not dedupe. `PollarProvider` used that check to
+ * decide whether it was handed a ready client or a config, and answering
+ * `false` for a real client made it spread that instance into
+ * `new PollarClient({...})` - a failure that points nowhere near the dependency
+ * tree that caused it.
+ *
+ * `Symbol.for` resolves through the runtime-wide symbol registry, so every copy
+ * of this module gets the SAME symbol and recognises the others' instances.
+ */
+const POLLAR_CLIENT_BRAND = Symbol.for('@pollar/core.PollarClient');
+
+/**
+ * Is this a `PollarClient`, including one built by another copy of the module?
+ *
+ * Prefer this over `instanceof PollarClient` anywhere the value may have crossed
+ * a package boundary. Tries `instanceof` first, so it still recognises an
+ * instance from a build that predates the brand.
+ */
+export function isPollarClient(value: unknown): value is PollarClient {
+  if (value instanceof PollarClient) return true;
+  return typeof value === 'object' && value !== null && (value as Record<symbol, unknown>)[POLLAR_CLIENT_BRAND] === true;
+}
+
 function warnServerSide(method: string): void {
   // Module-level (no client instance / logger yet) — and a misuse warning the
   // developer should always see, so it stays on the raw console.
@@ -367,6 +397,10 @@ export class PollarClient {
   private readonly _providers = new Map<string, PollarAuthProvider>();
 
   constructor(config: PollarClientConfig) {
+    // Stamp the cross-copy brand FIRST, before any early return below, so even a
+    // server-side instance is recognisable. Non-enumerable and symbol-keyed, so
+    // it never appears in `Object.keys` or a spread. See `isPollarClient`.
+    Object.defineProperty(this, POLLAR_CLIENT_BRAND, { value: true, enumerable: false });
     this.apiKey = config.apiKey;
     this.id = randomUUID();
     // v2 is the multichain SDK surface. It is a superset of v1 — every v1 route is

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -285,8 +285,20 @@ export class PollarClient {
    */
   readonly stellar: StellarSepApi;
   private _loginController: AbortController | null = null;
-  /** Aborts an in-flight `/auth/session/resume` on destroy() or re-trigger. */
+  /** Aborts an in-flight `/auth/session/resume` on destroy() or session clear. */
   private _resumeController: AbortController | null = null;
+  /**
+   * Coalesces concurrent `_resume()` calls into one in-flight validation.
+   * The startup restore and the visibility handler can both fire within the
+   * same tick (and visibility can flap repeatedly at page load); without this,
+   * each trigger aborted the previous request and started another, turning one
+   * failing resume into a burst of identical 401s.
+   */
+  private _resumePromise: Promise<void> | null = null;
+  /** Consecutive non-terminal resume failures; drives the retry backoff below. */
+  private _resumeFailStreak = 0;
+  /** Epoch ms before which `_resume()` refuses to fire again (failure backoff). */
+  private _resumeBackoffUntil = 0;
   /** Platform strategy for opening the hosted-OAuth URL (popup on web; injected on RN). */
   private readonly _openAuthUrl: AuthUrlOpener;
   /** `redirect_uri` sent to the backend for hosted OAuth. */
@@ -1409,6 +1421,17 @@ export class PollarClient {
       await this._clearSession();
     } catch (err) {
       this._log.warn('[PollarClient] Local logout cleanup failed', err);
+    }
+
+    // Rotate the DPoP keypair ONLY here, on the user-initiated logout — not in
+    // `_clearSession()`, which also runs on transient failure paths where
+    // destroying the key would make every other session bound to it (persisted
+    // or held by the consumer) permanently unverifiable. On explicit logout the
+    // user is done with this identity, so fresh key hygiene wins.
+    try {
+      await this._keyManager.reset();
+    } catch (err) {
+      this._log.warn('[PollarClient] KeyManager reset failed during logout', err);
     }
   }
 
@@ -3402,8 +3425,8 @@ export class PollarClient {
       signal,
       // Suppress terminal writes from a flow that was CANCELLED or SUPERSEDED
       // (its `signal` is aborted) so a late-resolving loser can't clobber the
-      // active flow's state or, via clearSession, tear down a newer session /
-      // reset the DPoP key. The active flow's signal is never aborted, so the
+      // active flow's state or, via clearSession, tear down a newer session.
+      // The active flow's signal is never aborted, so the
       // happy path is unchanged. (Completes the C1 guard — covers error/clear
       // writes, not just storeSession.)
       setAuthState: (state: AuthState) => {
@@ -3412,7 +3435,30 @@ export class PollarClient {
       storeSession: (session: PollarApplicationConfigContent) =>
         signal.aborted ? Promise.resolve() : this._storeSession(session),
       clearSession: () => (signal.aborted ? Promise.resolve() : this._clearSession()),
-      getPublicJwk: () => this._keyManager.getPublicJwk(),
+      getPublicJwk: async () => {
+        const jwk = await this._keyManager.getPublicJwk();
+        // The login is about to bind its tokens to this key (`cnf.jkt`). Verify
+        // the key is durably persisted (re-writing it if needed) and warn loudly
+        // when it isn't: a non-persisted key means the session cannot survive a
+        // reload — every resume/refresh will 401 with `thumbprint-mismatch`.
+        // Previously this failure was swallowed inside the key manager and only
+        // surfaced as an unexplained logout on the next page load. Best-effort
+        // and optional: custom KeyManager implementations without
+        // `ensurePersisted` behave as before.
+        try {
+          // `undefined` (method not implemented) intentionally does not warn.
+          if ((await this._keyManager.ensurePersisted?.()) === false) {
+            this._log.warn(
+              '[PollarClient] The DPoP keypair could not be persisted (IndexedDB/secure storage ' +
+                'unavailable?). Login will work, but the session will NOT survive a reload — the ' +
+                'user will be logged out on the next page load.',
+            );
+          }
+        } catch (err) {
+          this._log.warn('[PollarClient] DPoP keypair persistence check failed', err);
+        }
+        return jwk;
+      },
       storeWalletAdapter: async (adapter: WalletAdapter, id: WalletId) => {
         // A cancelled/superseded flow must not leave a dangling adapter +
         // persisted walletType row with no session (the same reason the other
@@ -3479,6 +3525,46 @@ export class PollarClient {
       // so it doesn't disturb an in-flight refresh of the very same session.)
       if (prevSession && prevSession.clientSessionId !== this._session.clientSessionId) {
         this._sessionGeneration++;
+      }
+
+      // DPoP key binding precheck: the persisted session records the thumbprint
+      // of the keypair its tokens are bound to (`dpopJkt`, = the token's
+      // `cnf.jkt`). If the keypair we just loaded is a DIFFERENT one — the
+      // stored key was lost (IndexedDB evicted, unavailable, or reset by
+      // another tab) and a fresh key was generated — then EVERY proof-bound
+      // call is guaranteed to 401 (`thumbprint-mismatch`): resume, refresh,
+      // signing, all of them. Converge to logged-out locally, with a diagnostic
+      // that names the real cause, instead of burning a doomed resume round
+      // trip whose opaque 401 used to also nuke the (new, perfectly good)
+      // keypair. Sessions persisted by older SDKs have no `dpopJkt` and skip
+      // this — their resume decides, as before. If the thumbprint can't be
+      // computed (key manager init failed), skip too: the Bearer fallback may
+      // still be able to use the session.
+      if (this._session.dpopJkt) {
+        // A thumbprint that can't be computed (key manager unavailable) reads
+        // as null and skips the check — the resume path decides, as before.
+        const readJkt = (): Promise<string | null> => this._keyManager.getThumbprint().catch(() => null);
+        let currentJkt = await readJkt();
+        if (currentJkt !== null && currentJkt !== this._session.dpopJkt && this._keyManager.resync) {
+          // The cached key may simply be stale: another tab can rotate the
+          // shared persisted key (logout → fresh login) and then write the
+          // session this restore is picking up. Re-read persistent storage
+          // and re-compare before concluding the key is really lost —
+          // without this, a stale cache would clear the session the other
+          // tab just created.
+          this._keyManager.resync();
+          currentJkt = await readJkt();
+        }
+        if (currentJkt !== null && currentJkt !== this._session.dpopJkt) {
+          this._log.error(
+            '[PollarClient] Stored session is bound to a DPoP key that no longer exists locally ' +
+              '(key persistence failed or the key was reset). The session cannot be resumed or ' +
+              'refreshed — clearing it. The user must log in again.',
+            { expectedJkt: this._session.dpopJkt, currentJkt },
+          );
+          await this._clearSession();
+          return;
+        }
       }
       // Only restore an adapter for an EXTERNAL session — those are the only ones
       // signed via an adapter. `internal` is custodial (server-signed) and `smart`
@@ -3561,7 +3647,8 @@ export class PollarClient {
       this._log.info('[PollarClient] No session in storage');
       // Another tab (or this one) wiped the session key. If we were
       // authenticated, propagate the logout: tear down in-memory state, the
-      // refresh timer and DPoP keys, and emit `idle`. Guarded so the cold-start
+      // refresh timer, and emit `idle` (the DPoP keypair survives — see
+      // `_clearSession`). Guarded so the cold-start
       // call (step already `idle`) is a no-op and we never recurse — the
       // `removeStorage` inside `_clearSession` targets an already-removed key.
       if (this._authState.step !== 'idle') {
@@ -3588,10 +3675,37 @@ export class PollarClient {
    *                    out; keep the optimistic session for a later retry.
    * - network error  → stay optimistic; revalidated on `visibilitychange`/use.
    */
-  private async _resume(): Promise<void> {
+  private _resume(): Promise<void> {
+    // Coalesce: a resume already in flight IS the validation every caller
+    // wants — join it instead of aborting and restarting (which multiplied one
+    // failure into a burst when the startup restore and visibility handler
+    // fired together).
+    if (this._resumePromise) return this._resumePromise;
+    // Backoff after non-terminal failures (network, 5xx, 429): a visibility
+    // flap must not hammer the endpoint. Terminal outcomes (verified, or the
+    // session cleared) reset this.
+    if (Date.now() < this._resumeBackoffUntil) return Promise.resolve();
+    this._resumePromise = this._doResume().finally(() => {
+      this._resumePromise = null;
+    });
+    return this._resumePromise;
+  }
+
+  /** Record a retryable resume failure: exponential backoff, 1s → 30s cap. */
+  private _noteResumeFailure(): void {
+    this._resumeFailStreak++;
+    const delayMs = Math.min(1_000 * 2 ** (this._resumeFailStreak - 1), 30_000);
+    this._resumeBackoffUntil = Date.now() + delayMs;
+  }
+
+  private _resetResumeBackoff(): void {
+    this._resumeFailStreak = 0;
+    this._resumeBackoffUntil = 0;
+  }
+
+  private async _doResume(): Promise<void> {
     if (!this._session) return;
     const gen = this._sessionGeneration;
-    this._resumeController?.abort();
     const controller = new AbortController();
     this._resumeController = controller;
     try {
@@ -3608,6 +3722,8 @@ export class PollarClient {
         const status = response?.status ?? 0;
         if (status === 401 || status === 403 || status === 410) {
           await this._clearSession();
+        } else {
+          this._noteResumeFailure();
         }
         return;
       }
@@ -3615,11 +3731,14 @@ export class PollarClient {
       const content = (data as { content?: PollarUserProfile }).content;
       if (!content) return;
       this._profile = { ...content };
+      this._resetResumeBackoff();
       this._setAuthState({ step: 'authenticated', session: this._session, verified: true });
     } catch (err) {
       if ((err as { name?: string })?.name === 'AbortError') return;
       // Network failure (no response) — keep the optimistic (unverified) session
-      // and retry when the app next becomes visible or on the next authed request.
+      // and retry (with backoff) when the app next becomes visible or on the
+      // next authed request.
+      this._noteResumeFailure();
       this._log.warn('[PollarClient] resume failed (network); will retry', err);
     } finally {
       if (this._resumeController === controller) this._resumeController = null;
@@ -3652,12 +3771,20 @@ export class PollarClient {
       ...(w.deployTxHash !== undefined ? { deployTxHash: w.deployTxHash } : {}),
     });
 
+    // Record which DPoP key this session's tokens are bound to (= the token's
+    // `cnf.jkt`) so a later restore can detect key loss up front instead of
+    // discovering it through a burst of thumbprint-mismatch 401s. Best-effort:
+    // if the key manager is unavailable (Bearer fallback), omit the field and
+    // the restore-time check is skipped.
+    const dpopJkt = await this._keyManager.getThumbprint().catch(() => null);
+
     const persisted: PollarPersistedSession = {
       clientSessionId: session.clientSessionId,
       userId: session.userId ?? null,
       status: session.status,
       token: session.token,
       user: session.user,
+      ...(dpopJkt ? { dpopJkt } : {}),
       wallet: toPersistedWallet(session.wallet),
       // Absent on logins against an sdk-api that predates `wallets[]` — persist
       // nothing rather than an empty array, so consumers can tell "not reported"
@@ -3665,8 +3792,10 @@ export class PollarClient {
       ...(session.wallets ? { wallets: session.wallets.map(toPersistedWallet) } : {}),
     };
     // A fresh login replaces the session: invalidate any refresh/resume still
-    // in flight against the previous one.
+    // in flight against the previous one, and drop any resume backoff the old
+    // session accumulated.
     this._sessionGeneration++;
+    this._resetResumeBackoff();
     const gen = this._sessionGeneration;
     this._session = persisted;
 
@@ -3716,16 +3845,31 @@ export class PollarClient {
     this._sessionGeneration++;
     this._resumeController?.abort();
     this._resumeController = null;
+    this._resetResumeBackoff();
     this._clearRefreshTimer();
     this._session = null;
     this._profile = null;
     this._walletAdapter = null;
-    this._dpopNonce = null;
-    try {
-      await this._keyManager.reset();
-    } catch (err) {
-      this._log.warn('[PollarClient] KeyManager reset failed during clearSession', err);
-    }
+    // The DPoP keypair deliberately SURVIVES this teardown. It is device-scoped,
+    // not session-scoped: nothing about a dropped session invalidates the key,
+    // and `_clearSession` also runs on failure paths (a rejected resume, a
+    // failed refresh, a cross-tab clear, a login attempt superseding another).
+    // Resetting it here made every such failure destructive — any session still
+    // bound to the key (persisted, or a token a consumer held elsewhere) became
+    // permanently unverifiable, and a stale clear racing a fresh login could
+    // discard the very key the login had just bound (persisting a session that
+    // could never resume). The keypair is rotated ONLY on explicit `logout()`.
+    // The in-memory CACHE is dropped, though: the persisted key is shared per
+    // origin across tabs, and a cross-tab logout (one of the paths that land
+    // here) deletes/rotates it — the next use must re-read storage instead of
+    // signing with a stale cached copy. Persistent storage is untouched, so
+    // after a same-tab failure clear the next init re-loads the very same key.
+    this._keyManager.resync?.();
+    // `_dpopNonce` likewise survives: it is origin-scoped server state, not
+    // session state — keeping it saves the guaranteed `use_dpop_nonce` 401 on
+    // the next login's first proof. (It is intentionally NOT persisted across
+    // page loads: server nonces are short-lived HMACs, so a stored one is
+    // usually stale and the cold-start challenge round trip is unavoidable.)
     await removeStorage(this._storage, this.apiKeyHash);
     this._resetReactiveStores();
     this._setAuthState({ step: 'idle' });

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -1424,6 +1424,16 @@ export class PollarClient {
     }
     this._log.info('[PollarClient] Logout requested', { everywhere: !!options.everywhere });
 
+    // Abort any login still in flight FIRST. Without this, a /auth/login
+    // response landing after the logout re-ran `_storeSession` and resurrected
+    // the session — the user pressed logout and ended up logged in. Worse, the
+    // keypair reset below rotated the key between that login's bind and its
+    // store, so the resurrected session was bound to a destroyed key. The
+    // flow's other deps (storeSession/clearSession/setAuthState) already no-op
+    // on an aborted signal, so aborting here is all it takes.
+    this._loginController?.abort();
+    this._loginController = null;
+
     if (this._session?.token?.accessToken) {
       try {
         await this._api.POST('/auth/logout', {
@@ -3466,8 +3476,8 @@ export class PollarClient {
       setAuthState: (state: AuthState) => {
         if (!signal.aborted) this._setAuthState(state);
       },
-      storeSession: (session: PollarApplicationConfigContent) =>
-        signal.aborted ? Promise.resolve() : this._storeSession(session),
+      storeSession: (session: PollarApplicationConfigContent, boundDpopJkt?: string) =>
+        signal.aborted ? Promise.resolve() : this._storeSession(session, boundDpopJkt),
       clearSession: () => (signal.aborted ? Promise.resolve() : this._clearSession()),
       getPublicJwk: async () => {
         const jwk = await this._keyManager.getPublicJwk();
@@ -3780,7 +3790,7 @@ export class PollarClient {
     }
   }
 
-  private async _storeSession(session: PollarApplicationConfigContent): Promise<void> {
+  private async _storeSession(session: PollarApplicationConfigContent, boundDpopJkt?: string): Promise<void> {
     this._log.info('[PollarClient] Session stored');
 
     // The wire response still carries the legacy `publicKey` alias (kept for
@@ -3808,10 +3818,18 @@ export class PollarClient {
 
     // Record which DPoP key this session's tokens are bound to (= the token's
     // `cnf.jkt`) so a later restore can detect key loss up front instead of
-    // discovering it through a burst of thumbprint-mismatch 401s. Best-effort:
-    // if the key manager is unavailable (Bearer fallback), omit the field and
-    // the restore-time check is skipped.
-    const dpopJkt = await this._keyManager.getThumbprint().catch(() => null);
+    // discovering it through a burst of thumbprint-mismatch 401s.
+    //
+    // Prefer `boundDpopJkt` — the thumbprint of the JWK the login flow ACTUALLY
+    // sent to /auth/login. Re-reading `getThumbprint()` here records whatever
+    // key is loaded NOW, which is the wrong key if it rotated between the bind
+    // and this store (a reset racing the login, a cross-tab rotation): the
+    // field would then vouch for a key the server never bound, and the restore
+    // precheck would wave through a session guaranteed to 401. The fallback
+    // read covers the refresh path and custom flows that don't thread the
+    // bound value; best-effort — if the key manager is unavailable (Bearer
+    // fallback), omit the field and the restore-time check is skipped.
+    const dpopJkt = boundDpopJkt ?? (await this._keyManager.getThumbprint().catch(() => null));
 
     const persisted: PollarPersistedSession = {
       clientSessionId: session.clientSessionId,
@@ -3908,9 +3926,13 @@ export class PollarClient {
     this._keyManager.resync?.();
     // `_dpopNonce` likewise survives: it is origin-scoped server state, not
     // session state — keeping it saves the guaranteed `use_dpop_nonce` 401 on
-    // the next login's first proof. (It is intentionally NOT persisted across
-    // page loads: server nonces are short-lived HMACs, so a stored one is
-    // usually stale and the cold-start challenge round trip is unavoidable.)
+    // the next login's first proof. It is NOT persisted across page loads —
+    // a deliberate simplicity trade-off, not a freshness constraint: sdk-api
+    // nonces actually verify for days (24h active + 3-day rotation overlap,
+    // see sdk-api lib/dpop-nonce.ts), so persisting one would eliminate the
+    // cold-start challenge round trip on nearly every reload. If that ever
+    // matters for latency, persist it best-effort under the apiKeyHash
+    // namespace; the challenge-retry path already handles a stale value.
     await this._persistSession(gen, null, owned);
     this._resetReactiveStores();
     this._setAuthState({ step: 'idle' });

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -133,8 +133,8 @@ const isReactNative = typeof navigator !== 'undefined' && (navigator as { produc
 /**
  * True wherever the SDK can persist state and do crypto — browser OR React
  * Native. False only in true server-side renders (Node/SSR) where there is no
- * client runtime. Gates everything that previously keyed off `isBrowser`; that
- * check alone wrongly treated RN (no `localStorage`) as server-side.
+ * client runtime. Gate runtime checks on this, not on `isBrowser` alone, which
+ * treats RN (no `localStorage`) as server-side.
  */
 const isClientRuntime = isBrowser || isReactNative;
 
@@ -422,7 +422,7 @@ export class PollarClient {
       defaultStorage({
         logger: this._log,
         onDegrade: (reason, error) => {
-          // N6: on React Native the default storage falls back to memory because
+          // On React Native the default storage falls back to memory because
           // there is no localStorage — make that misconfiguration obvious rather
           // than letting sessions silently vanish on every cold start.
           if (isReactNative && reason === 'unavailable') {
@@ -510,7 +510,7 @@ export class PollarClient {
       `[PollarClient] Initialized v${POLLAR_CORE_VERSION} — endpoint: ${this.basePath}, network: ${this._networkState.network}`,
     );
 
-    // N4: warn (don't throw — that would break StrictMode double-mounts / HMR)
+    // Warn (don't throw - that would break StrictMode double-mounts / HMR)
     // when a second live client exists for this API key.
     //
     // Client runtimes only, mirroring the deregistration in `destroy()`. The
@@ -540,7 +540,7 @@ export class PollarClient {
       }
     }
 
-    // N5: on a non-browser client runtime (React Native) the default visibility
+    // On a non-browser client runtime (React Native) the default visibility
     // provider is a no-op, so proactive refresh can't resume when the app
     // returns to the foreground (the OS suspended the timer in the background).
     if (!isBrowser && !config.visibilityProvider) {
@@ -647,7 +647,7 @@ export class PollarClient {
     this._visibilityUnsubscribe = this._visibilityProvider.onChange((visible) => {
       if (!visible) return;
       void this._maybeProactiveRefresh();
-      // B5: if the session is still optimistic (e.g. the startup resume failed
+      // If the session is still optimistic (e.g. the startup resume failed
       // offline), retry validation now that the app is foreground again.
       if (this._authState.step === 'authenticated' && !this._authState.verified) {
         void this._resume();
@@ -709,7 +709,7 @@ export class PollarClient {
         request.headers.set('x-pollar-api-key', self.apiKey);
         self._lastRequestAt = Date.now();
         // Every request waits until the client is initialized — EXCEPT a
-        // /auth/refresh: the expired-AT restore (F5) issues one from WITHIN
+        // /auth/refresh: the expired-AT restore issues one from WITHIN
         // _restoreSession (before `_initialized` resolves), so awaiting here would
         // deadlock. Post-init this is a no-op (already resolved), and the refresh
         // has everything it needs by then (keyManager init'd, `_session` set).
@@ -718,9 +718,9 @@ export class PollarClient {
         // call request.clone() once the body is consumed. Gate only on the
         // method: GET/HEAD carry no body. Do NOT gate on `request.body` — in
         // RN's fetch polyfill that getter is `undefined` even for a POST with a
-        // JSON body, so the old `request.body != null` check silently skipped
-        // the snapshot and a /auth/refresh retry (after a DPoP nonce challenge)
-        // was replayed with an empty body → server 400 "Malformed JSON". We
+        // JSON body, so a `request.body != null` gate would silently skip the
+        // snapshot and a /auth/refresh retry (after a DPoP nonce challenge)
+        // would replay with an empty body -> server 400 "Malformed JSON". We
         // snapshot via clone().arrayBuffer() (works in RN by reading the
         // polyfill's internal body) and only store non-empty buffers so a
         // genuinely body-less POST never gets a phantom body on retry.
@@ -2320,19 +2320,6 @@ export class PollarClient {
   }
 
   /**
-   * Signs the given unsigned XDR and returns the signed XDR.
-   *
-   * - External wallets: signs locally via the wallet adapter.
-   * - Custodial wallets: posts to `/tx/sign`. The backend signs (through
-   *   wallet-service or the app's customer-managed adapter) and returns the
-   *   signed XDR plus an `idempotencyKey` the caller should echo back to
-   *   `submitTx`.
-   *
-   * Drives `_setTransactionState`: emits `signing` while in flight and
-   * `signed` on success (or `error[phase: 'signing']` on failure). `buildData`
-   * is threaded through if the consumer previously called `buildTx`.
-   */
-  /**
    * For an EXTERNAL-wallet session whose signing adapter isn't attached (the host
    * didn't re-register the same `walletAdapters` this run, or the persisted
    * walletType row was lost), the custodial signer can't help: the platform holds
@@ -2348,6 +2335,19 @@ export class PollarClient {
     return null;
   }
 
+  /**
+   * Signs the given unsigned XDR and returns the signed XDR.
+   *
+   * - External wallets: signs locally via the wallet adapter.
+   * - Custodial wallets: posts to `/tx/sign`. The backend signs (through
+   *   wallet-service or the app's customer-managed adapter) and returns the
+   *   signed XDR plus an `idempotencyKey` the caller should echo back to
+   *   `submitTx`.
+   *
+   * Drives `_setTransactionState`: emits `signing` while in flight and
+   * `signed` on success (or `error[phase: 'signing']` on failure). `buildData`
+   * is threaded through if the consumer previously called `buildTx`.
+   */
   async signTx(unsignedXdr: string, options?: { skipSponsorship?: boolean }): Promise<SignOutcome> {
     this._txStartGen = this._sessionGeneration;
     const noSigner = this._externalSignerMissing();
@@ -2628,24 +2628,6 @@ export class PollarClient {
   }
 
   /**
-   * Submits a signed XDR via `/tx/submit` regardless of wallet type
-   * (custodial or external). Routing through sdk-api gives us:
-   *   - End-to-end tx_records persistence with full phase lifecycle so the
-   *     developer dashboard can show every tx (both custodial and external
-   *     wallet flows) at `/apps/:id/monitor/transactions`.
-   *   - Idempotency tracking via `submissionToken` (returned by `signTx`).
-   *   - A single response shape (SUCCESS / PENDING / FAILED) shared by both
-   *     flows — previously external wallets could only return SUCCESS or
-   *     error since the direct-to-Horizon path was synchronous.
-   *
-   * The extra hop adds ~50–150 ms vs. the legacy direct-Horizon path; the
-   * persistence + observability win is worth it.
-   *
-   * Drives `_setTransactionState`: emits `submitting` while in flight,
-   * `submitted` on Horizon ack (pending), `success` on ledger confirmation,
-   * or `error[phase: 'submitting']` on failure.
-   */
-  /**
    * Normalize a backend API error into { details, code, message }. `code` is the
    * precise backend ErrorCode (e.g. `TX_FEE_LIMIT_EXCEEDED`) for programmatic
    * handling; `message` is a friendly string from the error catalog; `details`
@@ -2747,6 +2729,24 @@ export class PollarClient {
     return { status: 'pending', hash, ...outcomeExtra };
   }
 
+  /**
+   * Submits a signed XDR via `/tx/submit` regardless of wallet type
+   * (custodial or external). Routing through sdk-api gives us:
+   *   - End-to-end tx_records persistence with full phase lifecycle so the
+   *     developer dashboard can show every tx (both custodial and external
+   *     wallet flows) at `/apps/:id/monitor/transactions`.
+   *   - Idempotency tracking via `submissionToken` (returned by `signTx`).
+   *   - A single response shape (SUCCESS / PENDING / FAILED) shared by both
+   *     flows (a direct-to-Horizon submit is synchronous, so on its own it can
+   *     only report SUCCESS or error).
+   *
+   * The extra hop adds ~50-150 ms vs. submitting straight to Horizon; the
+   * persistence + observability win is worth it.
+   *
+   * Drives `_setTransactionState`: emits `submitting` while in flight,
+   * `submitted` on Horizon ack (pending), `success` on ledger confirmation,
+   * or `error[phase: 'submitting']` on failure.
+   */
   async submitTx(signedXdr: string, opts?: { submissionToken?: string }): Promise<SubmitOutcome> {
     this._txStartGen = this._sessionGeneration;
     const buildData = this._currentBuildData();
@@ -3383,14 +3383,6 @@ export class PollarClient {
   // ─── Swap (DEX/AMM) ───────────────────────────────────────────────────────
 
   /**
-   * Quote an asset-to-asset swap across the requested venue(s). Read-only: no
-   * funds move. Returns quotes ranked by output (best first) — pick `[0]` for the
-   * best price, or let the user choose a route. An empty array means no route
-   * exists for the pair on this network. `provider` defaults to `'auto'` (the best
-   * of every available venue); `slippageBps` defaults to 50 (0.5%) and sets the
-   * on-chain minimum each quote's `build` will accept.
-   */
-  /**
    * The swap venues this app exposes to end-users (operator's dashboard
    * selection, intersected with server capability). An empty array means swap is
    * disabled for this app — hide any swap UI. `'auto'` is not returned here; add
@@ -3411,6 +3403,14 @@ export class PollarClient {
     return content.tokens;
   }
 
+  /**
+   * Quote an asset-to-asset swap across the requested venue(s). Read-only: no
+   * funds move. Returns quotes ranked by output (best first) - pick `[0]` for the
+   * best price, or let the user choose a route. An empty array means no route
+   * exists for the pair on this network. `provider` defaults to `'auto'` (the best
+   * of every available venue); `slippageBps` defaults to 50 (0.5%) and sets the
+   * on-chain minimum each quote's `build` will accept.
+   */
   async getSwapQuote(params: SwapQuoteParams): Promise<SwapQuote[]> {
     const wallet = this.getWallet();
     if (!wallet) throw new Error('No wallet connected');
@@ -3652,7 +3652,7 @@ export class PollarClient {
       // (its `signal` is aborted) so a late-resolving loser can't clobber the
       // active flow's state or, via clearSession, tear down a newer session.
       // The active flow's signal is never aborted, so the
-      // happy path is unchanged. (Completes the C1 guard — covers error/clear
+      // happy path is unchanged. (Completes the cancelled-flow guard - covers error/clear
       // writes, not just storeSession.)
       setAuthState: (state: AuthState) => {
         if (!signal.aborted) this._setAuthState(state);
@@ -3764,8 +3764,8 @@ export class PollarClient {
       // call is guaranteed to 401 (`thumbprint-mismatch`): resume, refresh,
       // signing, all of them. Converge to logged-out locally, with a diagnostic
       // that names the real cause, instead of burning a doomed resume round
-      // trip whose opaque 401 used to also nuke the (new, perfectly good)
-      // keypair. Sessions persisted by older SDKs have no `dpopJkt` and skip
+      // trip that can only fail with an opaque 401. Sessions persisted by older
+      // SDKs have no `dpopJkt` and skip
       // this — their resume decides, as before. If the thumbprint can't be
       // computed (key manager init failed), skip too: the Bearer fallback may
       // still be able to use the session.
@@ -3838,7 +3838,7 @@ export class PollarClient {
         return;
       }
 
-      // F5: if the stored access token is ALREADY expired, refresh inline BEFORE
+      // If the stored access token is ALREADY expired, refresh inline BEFORE
       // surfacing the session — otherwise a consumer reading `session.token` in
       // the optimistic `verified:false` window forwards a token we already know is
       // dead. A successful refresh both rotates the token AND proves the session
@@ -4130,8 +4130,8 @@ export class PollarClient {
     // the shared row. They never see the `storage` event that removal emits -
     // browsers fire it at OTHER documents only - so a second instance in this
     // document would otherwise keep its session and re-persist the row a moment
-    // later. (`PollarProvider` no longer leaves one behind under StrictMode, but
-    // a consumer can still hold two clients, and non-React callers always
+    // later. (`PollarProvider` reuses one client per config under StrictMode,
+    // but a consumer can still hold two clients, and non-React callers always
     // could.) This mirrors the cross-document handler.
     //
     // It runs AFTER the teardown above on purpose: announcing first put the
@@ -4154,6 +4154,16 @@ export class PollarClient {
     void this._clearSession().catch((err) => this._log.error('[PollarClient] Same-document logout failed', err));
   }
 
+  /** Record a session this instance held; bounded so a long-lived SPA cannot grow it unboundedly. */
+  private _recordOwnedSession(id: string): void {
+    if (this._ownedSessionIds.has(id)) return;
+    this._ownedSessionIds.add(id);
+    if (this._ownedSessionIds.size > 10) {
+      const oldest = this._ownedSessionIds.values().next().value;
+      if (oldest !== undefined) this._ownedSessionIds.delete(oldest);
+    }
+  }
+
   /**
    * Single writer for the shared `pollar:<apiKeyHash>:session` row.
    *
@@ -4165,10 +4175,10 @@ export class PollarClient {
    *   - ORDERING: two overlapping writes land in the order their adapter
    *     resolves, so an older session can win over a newer one.
    *   - RESURRECTION: a write that started before a logout lands after it and
-   *     re-creates a row the user just cleared. Re-checking the generation
-   *     *after* the write (as the callers used to) skips the state emission but
-   *     leaves the row behind, so the session comes back on the next reload and
-   *     the write's own `storage` event can log other documents back in.
+   *     re-creates a row the user just cleared. Re-checking the generation only
+   *     *after* the write would skip the state emission but leave the row
+   *     behind, so the session would come back on the next reload and the
+   *     write's own `storage` event could log other documents back in.
    *
    * So the generation is re-checked HERE, immediately before the mutation, with
    * writes serialized against each other. `gen` is the caller's snapshot of
@@ -4176,23 +4186,14 @@ export class PollarClient {
    * this write while it was queued and the mutation is dropped.
    *
    * `session === null` removes the row, but only when it still holds the
-   * session named by `ownedId` — a client must never delete a row that now
-   * belongs to a newer login in another document or another instance (a second
-   * client sitting on a stale session used to delete the row a fresh login had
-   * just written, about one round trip after "Session stored").
+   * session named by `ownedId` - a client must never delete a row that now
+   * belongs to a newer login in another document or another instance. Without
+   * the ownership check, a second client sitting on a stale session would
+   * delete the row a fresh login had just written, about one round trip after
+   * "Session stored".
    *
    * Returns whether the mutation was applied.
    */
-  /** Record a session this instance held; bounded so a long-lived SPA cannot grow it unboundedly. */
-  private _recordOwnedSession(id: string): void {
-    if (this._ownedSessionIds.has(id)) return;
-    this._ownedSessionIds.add(id);
-    if (this._ownedSessionIds.size > 10) {
-      const oldest = this._ownedSessionIds.values().next().value;
-      if (oldest !== undefined) this._ownedSessionIds.delete(oldest);
-    }
-  }
-
   private async _persistSession(
     gen: number,
     session: PollarPersistedSession | null,
@@ -4289,7 +4290,7 @@ export class PollarClient {
    * in-flight fetch that resolves into the new session's store.
    *
    * The tx store is dispatched DIRECTLY (not via `_setTransactionState`) on
-   * purpose: re-arming `_txStartGen` to satisfy that method's F2 generation guard
+   * purpose: re-arming `_txStartGen` to satisfy that method's session-generation guard
    * would also let an in-flight tx's late write through. Leaving `_txStartGen`
    * untouched keeps a late tx write dropped by the guard. Callers must bump
    * `_sessionGeneration` BEFORE calling this (both already do).
@@ -4316,10 +4317,11 @@ export class PollarClient {
   private _currentBuildData(): TxBuildContent | undefined {
     const s = this._transactionState;
     if (!s) return undefined;
-    // A terminal step belongs to a FINISHED tx. `_transactionState` is only
-    // reset on `_clearSession`, so without this a standalone signTx/submitTx
+    // A terminal step belongs to a FINISHED tx. Between txs the state machine is
+    // only reset by `resetTransactionState()` (modal open) or a session change
+    // (`_resetReactiveStores`), so without this a standalone signTx/submitTx
     // (no preceding buildTx) would thread the previous tx's buildData into the
-    // new one — mislabeling its UI summary. Only carry buildData forward from
+    // new one - mislabeling its UI summary. Only carry buildData forward from
     // live, in-progress steps; the composed paths (buildTx→signTx→submitTx) read
     // it while non-terminal (`built`/`signed`), so they're unaffected.
     if (s.step === 'success' || s.step === 'submitted' || s.step === 'error') return undefined;

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -116,7 +116,16 @@ import { smartWalletFlow } from './auth/passkeyFlow';
 import { emailProvider, oauthProvider } from './auth/providers';
 import { loginWithSolanaAdapter } from './auth/solanaWalletFlow';
 import { loginWithAdapter, requestWalletChallenge } from './auth/walletFlow';
-import { readStorage, readWalletType, removeStorage, sessionStorageKey, writeStorage, writeWalletType } from './session';
+import {
+  dpopNonceStorageKey,
+  MAX_DPOP_NONCE,
+  readStorage,
+  readWalletType,
+  removeStorage,
+  sessionStorageKey,
+  writeStorage,
+  writeWalletType,
+} from './session';
 
 const isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'undefined';
 /** React Native runtime: `navigator.product === 'ReactNative'` (set by the RN runtime). */
@@ -135,7 +144,25 @@ const isClientRuntime = isBrowser || isReactNative;
  * DPoP key and run independent refresh loops; the single-use refresh-token
  * rotation then trips server-side reuse-detection and logs all of them out.
  */
-const liveClientsByApiKey = new Map<string, number>();
+const liveClientsByApiKey = new Map<string, Map<PollarClient, () => void>>();
+
+/**
+ * Tell every OTHER live client in this document that `origin` dropped the
+ * shared session row.
+ *
+ * The cross-document path is the `storage` event, which browsers deliberately
+ * do not deliver to the document that wrote the change - so instances sitting
+ * next to each other were the one blind spot. Notification is synchronous and
+ * one-hop: the recipients' own clears find the row already gone, so
+ * `_persistSession` reports no removal and they do not notify back.
+ */
+function notifySiblingClients(origin: PollarClient, apiKey: string): void {
+  const siblings = liveClientsByApiKey.get(apiKey);
+  if (!siblings) return;
+  for (const [client, notify] of siblings) {
+    if (client !== origin) notify();
+  }
+}
 
 /** Renew the access token this many seconds before its `exp` to absorb clock skew + signing latency. */
 const REFRESH_SKEW_SECONDS = 60;
@@ -421,9 +448,15 @@ export class PollarClient {
 
     // N4: warn (don't throw — that would break StrictMode double-mounts / HMR)
     // when a second live client exists for this API key.
-    const liveForKey = (liveClientsByApiKey.get(this.apiKey) ?? 0) + 1;
-    liveClientsByApiKey.set(this.apiKey, liveForKey);
-    if (liveForKey > 1) {
+    let liveSet = liveClientsByApiKey.get(this.apiKey);
+    if (!liveSet) {
+      liveSet = new Map<PollarClient, () => void>();
+      liveClientsByApiKey.set(this.apiKey, liveSet);
+    }
+    // Register a closure rather than the instance method so the handler stays
+    // private to the class.
+    liveSet.set(this, () => this._onSiblingSessionCleared());
+    if (liveSet.size > 1) {
       this._log.warn(
         '[PollarClient] Another PollarClient is already active for this API key. Multiple ' +
           'instances share one persisted session + DPoP key and run independent refresh loops; ' +
@@ -515,6 +548,17 @@ export class PollarClient {
       this._storageEventHandler = handler;
     }
 
+    // Reload the last server-issued DPoP nonce before anything is signed. The
+    // server requires a nonce on every proof, so without this the first
+    // authenticated request of every page load is a guaranteed 401
+    // `use_dpop_nonce` challenge plus a retry.
+    try {
+      const storedNonce = await this._storage.get(dpopNonceStorageKey(this._apiKeyHash));
+      if (storedNonce && storedNonce.length <= MAX_DPOP_NONCE) this._dpopNonce = storedNonce;
+    } catch (err) {
+      this._log.debug('[PollarClient] Could not read the stored DPoP nonce', err);
+    }
+
     try {
       await this._keyManager.init();
     } catch (err) {
@@ -544,9 +588,11 @@ export class PollarClient {
     if (this._destroyed) return; // idempotent — don't double-decrement the registry
     this._destroyed = true;
     if (isClientRuntime) {
-      const remaining = (liveClientsByApiKey.get(this.apiKey) ?? 1) - 1;
-      if (remaining <= 0) liveClientsByApiKey.delete(this.apiKey);
-      else liveClientsByApiKey.set(this.apiKey, remaining);
+      const siblings = liveClientsByApiKey.get(this.apiKey);
+      if (siblings) {
+        siblings.delete(this);
+        if (siblings.size === 0) liveClientsByApiKey.delete(this.apiKey);
+      }
     }
     if (this._storageEventHandler && isBrowser) {
       window.removeEventListener('storage', this._storageEventHandler);
@@ -655,7 +701,10 @@ export class PollarClient {
       },
       onResponse: async ({ request, response }: { request: Request; response: Response }) => {
         const newNonce = response.headers.get('DPoP-Nonce');
-        if (newNonce) self._dpopNonce = newNonce;
+        if (newNonce && newNonce !== self._dpopNonce) {
+          self._dpopNonce = newNonce;
+          void self._persistDpopNonce(newNonce);
+        }
 
         // Learn the clock skew from the server's `Date` header BEFORE any retry
         // or refresh below, so a proof rejected for a bad `iat` is rebuilt with
@@ -785,6 +834,20 @@ export class PollarClient {
       return /^\/v\d+\//.test(pathname) ? pathname.slice(pathname.indexOf('/', 1)) : pathname;
     } catch {
       return url;
+    }
+  }
+
+  /**
+   * Persist the newest `DPoP-Nonce` so the next page load can sign its first
+   * proof with it. Fire-and-forget and failure-tolerant: the nonce is a latency
+   * optimization, and a client that loses it just pays one challenge + retry.
+   */
+  private async _persistDpopNonce(nonce: string): Promise<void> {
+    if (this._apiKeyHash === null || nonce.length > MAX_DPOP_NONCE) return;
+    try {
+      await this._storage.set(dpopNonceStorageKey(this._apiKeyHash), nonce);
+    } catch (err) {
+      this._log.debug('[PollarClient] Could not persist the DPoP nonce', err);
     }
   }
 
@@ -1433,6 +1496,16 @@ export class PollarClient {
     // on an aborted signal, so aborting here is all it takes.
     this._loginController?.abort();
     this._loginController = null;
+    // Snapshot the session identity AFTER that abort: from here on the whole
+    // teardown is guarded on it. `logout()` awaits a network call and an adapter
+    // disconnect, and consumers routinely do NOT await it (`@pollar/react` fires
+    // it from the login modal and the wallet button and immediately offers the
+    // login UI), so a complete new login can land inside that window - the abort
+    // above only cancels a login that was already running. Without the guard the
+    // teardown below ran against whatever state existed when the awaits
+    // resolved: it wiped the new session and rotated away the very key that
+    // session had just been bound to.
+    const gen = this._sessionGeneration;
 
     if (this._session?.token?.accessToken) {
       try {
@@ -1461,17 +1534,37 @@ export class PollarClient {
       }
     }
 
+    // A newer session landed while we were awaiting above (a login started
+    // after this logout, or a cross-tab login this client adopted). It is not
+    // ours to tear down, and the user asked for it more recently than they
+    // asked for this logout - the server-side revocation already happened, so
+    // stop here rather than destroying state we no longer own.
+    if (this._destroyed || this._sessionGeneration !== gen) {
+      this._log.info('[PollarClient] Logout superseded by a newer session; leaving it in place');
+      return;
+    }
+
+    let droppedOwnRow = false;
     try {
-      await this._clearSession();
+      droppedOwnRow = await this._clearSession();
     } catch (err) {
       this._log.warn('[PollarClient] Local logout cleanup failed', err);
     }
 
-    // Rotate the DPoP keypair ONLY here, on the user-initiated logout — not in
+    // Rotate the DPoP keypair ONLY here, on the user-initiated logout - not in
     // `_clearSession()`, which also runs on transient failure paths where
     // destroying the key would make every other session bound to it (persisted
     // or held by the consumer) permanently unverifiable. On explicit logout the
     // user is done with this identity, so fresh key hygiene wins.
+    //
+    // Gated on actually having dropped our own row, for the same reason that
+    // removal is: the keypair record (`pollar-keys/<apiKeyHash>`) is shared by
+    // every document on the origin, and it is MORE shared than the session row,
+    // not less. A client whose session was already superseded must not destroy
+    // the key the current session is bound to - that session would survive in
+    // storage pointing at a `cnf.jkt` that no longer exists locally, and get
+    // cleared on its next restore with its refresh token still valid.
+    if (!droppedOwnRow) return;
     try {
       await this._keyManager.reset();
     } catch (err) {
@@ -3478,7 +3571,9 @@ export class PollarClient {
       },
       storeSession: (session: PollarApplicationConfigContent, boundDpopJkt?: string) =>
         signal.aborted ? Promise.resolve() : this._storeSession(session, boundDpopJkt),
-      clearSession: () => (signal.aborted ? Promise.resolve() : this._clearSession()),
+      clearSession: async () => {
+        if (!signal.aborted) await this._clearSession();
+      },
       getPublicJwk: async () => {
         const jwk = await this._keyManager.getPublicJwk();
         // The login is about to bind its tokens to this key (`cnf.jkt`). Verify
@@ -3889,7 +3984,16 @@ export class PollarClient {
     this._scheduleNextRefresh();
   }
 
-  private async _clearSession(): Promise<void> {
+  /**
+   * Tear down the local session and converge to `idle`.
+   *
+   * Returns whether this client actually removed the shared persisted row -
+   * i.e. whether it still owned the session it was clearing. `logout()` gates
+   * the DPoP keypair rotation on that answer: the keypair is the most shared
+   * piece of state on the origin, so a client that was not entitled to drop the
+   * row is not entitled to destroy the key either.
+   */
+  private async _clearSession(): Promise<boolean> {
     this._log.info('[PollarClient] Session cleared');
     // Identify the session being torn down BEFORE dropping it: the persisted
     // row is shared by every document (and every client instance) on this
@@ -3924,18 +4028,35 @@ export class PollarClient {
     // signing with a stale cached copy. Persistent storage is untouched, so
     // after a same-tab failure clear the next init re-loads the very same key.
     this._keyManager.resync?.();
-    // `_dpopNonce` likewise survives: it is origin-scoped server state, not
-    // session state — keeping it saves the guaranteed `use_dpop_nonce` 401 on
-    // the next login's first proof. It is NOT persisted across page loads —
-    // a deliberate simplicity trade-off, not a freshness constraint: sdk-api
-    // nonces actually verify for days (24h active + 3-day rotation overlap,
-    // see sdk-api lib/dpop-nonce.ts), so persisting one would eliminate the
-    // cold-start challenge round trip on nearly every reload. If that ever
-    // matters for latency, persist it best-effort under the apiKeyHash
-    // namespace; the challenge-retry path already handles a stale value.
-    await this._persistSession(gen, null, owned);
+    // `_dpopNonce` likewise survives, in memory AND in storage: it is
+    // origin-scoped server state, not session state. sdk-api nonces verify for
+    // days (24h active + a 3-day rotation overlap, see its lib/dpop-nonce.ts),
+    // so the stored one stays usable across page loads and saves the guaranteed
+    // `use_dpop_nonce` 401 on the next first proof. See `dpopNonceStorageKey`.
+    const droppedOwnRow = await this._persistSession(gen, null, owned);
+    // Same-document siblings never see the `storage` event this removal emits -
+    // browsers fire it only at OTHER documents. Tell them directly, so a second
+    // instance in this document (a React StrictMode double-invoked `useState`
+    // initializer leaves one behind, and it is never destroyed) converges to
+    // logged-out instead of re-persisting its own copy of the session a moment
+    // later. Mirrors exactly what the cross-document handler does.
+    if (droppedOwnRow) notifySiblingClients(this, this.apiKey);
     this._resetReactiveStores();
     this._setAuthState({ step: 'idle' });
+    return droppedOwnRow;
+  }
+
+  /**
+   * A sibling client in THIS document dropped the shared session row. Same
+   * reasoning as the cross-document `storage` handler: propagate the logout
+   * from the notification without re-reading storage, and guard on holding a
+   * session rather than on the auth step, so a login in flight (which owns no
+   * session yet) is left alone.
+   */
+  private _onSiblingSessionCleared(): void {
+    if (this._destroyed || !this._session) return;
+    this._log.info('[PollarClient] Session cleared by another client in this document');
+    void this._clearSession().catch((err) => this._log.error('[PollarClient] Same-document logout failed', err));
   }
 
   /**

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -131,7 +131,7 @@ const isBrowser = typeof window !== 'undefined' && typeof localStorage !== 'unde
 /** React Native runtime: `navigator.product === 'ReactNative'` (set by the RN runtime). */
 const isReactNative = typeof navigator !== 'undefined' && (navigator as { product?: string }).product === 'ReactNative';
 /**
- * True wherever the SDK can persist state and do crypto — browser OR React
+ * True wherever the SDK can persist state and do crypto - browser OR React
  * Native. False only in true server-side renders (Node/SSR) where there is no
  * client runtime. Gate runtime checks on this, not on `isBrowser` alone, which
  * treats RN (no `localStorage`) as server-side.
@@ -216,7 +216,7 @@ export function isPollarClient(value: unknown): value is PollarClient {
 }
 
 function warnServerSide(method: string): void {
-  // Module-level (no client instance / logger yet) — and a misuse warning the
+  // Module-level (no client instance / logger yet) - and a misuse warning the
   // developer should always see, so it stays on the raw console.
   console.warn(
     `[PollarClient] ${method}() called server-side — browser APIs unavailable. Use PollarClient only in Client Components.`,
@@ -258,11 +258,11 @@ export class PollarClient {
   /** Last `DPoP-Nonce` we saw from a server response. Carried into the next proof. */
   private _dpopNonce: string | null = null;
   /**
-   * Clock skew compensation, in seconds (`serverTime − localTime`), learned from
+   * Clock skew compensation, in seconds (`serverTime - localTime`), learned from
    * the `Date` header of every server response and added to the DPoP proof
    * `iat`. Keeps proofs inside the server's acceptance window on devices whose
-   * clock is wrong, and self-heals when the clock changes mid-session — so a
-   * skewed clock can't trigger a proof-rejection → refresh-failure → logout loop.
+   * clock is wrong, and self-heals when the clock changes mid-session - so a
+   * skewed clock can't trigger a proof-rejection -> refresh-failure -> logout loop.
    */
   private _clockOffsetSec = 0;
   /**
@@ -272,7 +272,7 @@ export class PollarClient {
    * / 401 refresh) must rebuild the request from scratch instead of cloning.
    */
   private _requestBodyCache = new WeakMap<Request, ArrayBuffer>();
-  /** Singleton in-flight refresh — concurrent 401s coalesce into one /auth/refresh call. */
+  /** Singleton in-flight refresh - concurrent 401s coalesce into one /auth/refresh call. */
   private _refreshPromise: Promise<void> | null = null;
   /**
    * Bumped on every session teardown/replacement (`_clearSession`,
@@ -295,7 +295,7 @@ export class PollarClient {
    * membership here, not equality with the CURRENT session: a logout that
    * races a login-over-login can find the row still holding this client's
    * PREVIOUS session (its replacement write was superseded in the persist
-   * queue), and that row is this client's to remove — leaving it behind would
+   * queue), and that row is this client's to remove - leaving it behind would
    * restore the old, never-revoked session on the next reload. Rows from
    * sessions this instance never held (another document's or instance's newer
    * login) are still protected: they are never in this set.
@@ -340,7 +340,7 @@ export class PollarClient {
   /**
    * Per-reader request generations. Each reactive fetch (`fetchTxHistory`,
    * `refreshBalance`, `refreshAssets`, `fetchSessions`) bumps its counter and,
-   * after awaiting, drops its result if a newer call superseded it — so two
+   * after awaiting, drops its result if a newer call superseded it - so two
    * overlapping calls (fast pagination, pull-to-refresh spam) can't land
    * last-writer-wins with the wrong page's data.
    */
@@ -354,7 +354,7 @@ export class PollarClient {
   private _networkStateListeners = new Set<(state: NetworkState) => void>();
   /**
    * Latched once the storage adapter degrades. We dedupe (the adapter only
-   * fires once anyway) and use it to replay state to late-subscribers — same
+   * fires once anyway) and use it to replay state to late-subscribers - same
    * pattern as `onAuthStateChange` replaying `_authState` on subscribe.
    * Only populated when the SDK constructed the default storage adapter; if
    * the consumer passes `config.storage`, they own degradation notifications.
@@ -410,7 +410,7 @@ export class PollarClient {
     Object.defineProperty(this, POLLAR_CLIENT_BRAND, { value: true, enumerable: false });
     this.apiKey = config.apiKey;
     this.id = randomUUID();
-    // v2 is the multichain SDK surface. It is a superset of v1 — every v1 route is
+    // v2 is the multichain SDK surface. It is a superset of v1 - every v1 route is
     // re-exposed unchanged, with a `chain` discriminator added where a feature went
     // multichain (today: wallet balance/tokens/transfer). So the whole client rides
     // /v2 and only the shapes that actually changed are handled specially.
@@ -423,7 +423,7 @@ export class PollarClient {
         logger: this._log,
         onDegrade: (reason, error) => {
           // On React Native the default storage falls back to memory because
-          // there is no localStorage — make that misconfiguration obvious rather
+          // there is no localStorage - make that misconfiguration obvious rather
           // than letting sessions silently vanish on every cold start.
           if (isReactNative && reason === 'unavailable') {
             this._log.warn(
@@ -485,7 +485,7 @@ export class PollarClient {
       timeoutMs: this._requestTimeoutMs,
       retry: config.retry,
       // A DPoP proof is single-use, so the transport-level retry cannot replay
-      // the cloned request's header — it hands each new attempt back here to be
+      // the cloned request's header - it hands each new attempt back here to be
       // signed afresh. See `_resignForRetry`.
       resignRetry: (request) => this._resignForRetry(request),
     });
@@ -559,19 +559,19 @@ export class PollarClient {
     return this._initialized;
   }
 
-  // ─── Lifecycle ────────────────────────────────────────────────────────────
+  // --- Lifecycle ------------------------------------------------------------
 
   private async _initialize(): Promise<void> {
-    // Compute the storage namespace first — every subsequent storage op
+    // Compute the storage namespace first - every subsequent storage op
     // (including the cross-tab listener below and `_restoreSession`) reads it.
     this._apiKeyHash = await hashApiKey(this.apiKey);
     // `destroy()` can only unhook a listener that is already attached, so a
     // client destroyed during the await above would otherwise leave the handler
-    // below wired to `window` for the document's lifetime — a dead client that
+    // below wired to `window` for the document's lifetime - a dead client that
     // still reacts to cross-tab events and mutates shared storage.
     if (this._destroyed) return;
 
-    // Cross-tab session sync. Browser-only — the `storage` event is a DOM
+    // Cross-tab session sync. Browser-only - the `storage` event is a DOM
     // feature with no React Native equivalent (each RN process owns its
     // SecureStore/Keychain), so we gate on `isBrowser`, not `isClientRuntime`.
     if (isBrowser) {
@@ -582,7 +582,7 @@ export class PollarClient {
         // Only `localStorage` concerns us. `sessionStorage` fires the very same
         // event type at other same-origin documents that share its area (an
         // iframe in this tab), and its contents have nothing to do with the
-        // session. `storageArea` is absent on synthetic events — treat those as
+        // session. `storageArea` is absent on synthetic events - treat those as
         // ours rather than dropping them.
         if (e.storageArea != null && typeof localStorage !== 'undefined' && e.storageArea !== localStorage) return;
 
@@ -601,7 +601,7 @@ export class PollarClient {
 
         // Cross-tab LOGOUT: the session key was removed (newValue === null).
         // Propagate the logout straight from the event WITHOUT re-reading
-        // storage — a tab whose adapter degraded to memory (Safari private
+        // storage - a tab whose adapter degraded to memory (Safari private
         // mode, quota) still holds its own copy of the session, so a re-read
         // would miss the logout and keep using the now-revoked token.
         if (e.newValue === null) {
@@ -615,7 +615,7 @@ export class PollarClient {
         }
 
         // Cross-tab LOGIN / token rotation: re-sync from storage (this also
-        // keeps a verified session verified on a pure rotation — see
+        // keeps a verified session verified on a pure rotation - see
         // _restoreSession's same-session fast path).
         this._restoreSession().catch((err) => this._log.error('[PollarClient] Cross-tab restore failed', err));
       };
@@ -641,7 +641,7 @@ export class PollarClient {
     }
     await this._restoreSession();
 
-    // Wire after restore so the first scheduled refresh — if any — is set up
+    // Wire after restore so the first scheduled refresh - if any - is set up
     // by `_restoreSession` itself, and the visibility listener only fires
     // re-checks for transitions that happen from this point forward.
     this._visibilityUnsubscribe = this._visibilityProvider.onChange((visible) => {
@@ -660,7 +660,7 @@ export class PollarClient {
     // Latch first so anything still in flight (a refresh resolving, a queued
     // proactive-refresh timer callback) sees a destroyed client and bails
     // instead of re-arming a timer or writing state after teardown.
-    if (this._destroyed) return; // idempotent — don't double-decrement the registry
+    if (this._destroyed) return; // idempotent - don't double-decrement the registry
     this._destroyed = true;
     if (isClientRuntime) {
       const siblings = liveClientsByApiKey.get(this.apiKey);
@@ -694,7 +694,7 @@ export class PollarClient {
     this._storageDegradeListeners.clear();
   }
 
-  // ─── Middlewares (DPoP + auto-refresh) ────────────────────────────────────
+  // --- Middlewares (DPoP + auto-refresh) ------------------------------------
 
   private _wireMiddlewares(): void {
     // Aliasing `this` is deliberate: every middleware callback below is an
@@ -708,15 +708,15 @@ export class PollarClient {
       onRequest: async ({ request }: { request: Request }) => {
         request.headers.set('x-pollar-api-key', self.apiKey);
         self._lastRequestAt = Date.now();
-        // Every request waits until the client is initialized — EXCEPT a
+        // Every request waits until the client is initialized - EXCEPT a
         // /auth/refresh: the expired-AT restore issues one from WITHIN
         // _restoreSession (before `_initialized` resolves), so awaiting here would
         // deadlock. Post-init this is a no-op (already resolved), and the refresh
         // has everything it needs by then (keyManager init'd, `_session` set).
         if (!request.url.includes('/auth/refresh')) await self._initialized;
-        // Cache the body before fetch() disturbs the stream — retries can't
+        // Cache the body before fetch() disturbs the stream - retries can't
         // call request.clone() once the body is consumed. Gate only on the
-        // method: GET/HEAD carry no body. Do NOT gate on `request.body` — in
+        // method: GET/HEAD carry no body. Do NOT gate on `request.body` - in
         // RN's fetch polyfill that getter is `undefined` even for a POST with a
         // JSON body, so a `request.body != null` gate would silently skip the
         // snapshot and a /auth/refresh retry (after a DPoP nonce challenge)
@@ -730,7 +730,7 @@ export class PollarClient {
           try {
             // TODO(files): this assumes a JSON-string body. If/when an endpoint
             // sends FormData/Blob (e.g. a KYC file upload), arrayBuffer() on RN's
-            // fetch polyfill is unreliable for those — the DPoP-nonce retry could
+            // fetch polyfill is unreliable for those - the DPoP-nonce retry could
             // replay an empty body (same class as the rc.1 bug). Handle multipart
             // bodies explicitly before adding any non-JSON upload route.
             const snapshot = await request.clone().arrayBuffer();
@@ -739,19 +739,19 @@ export class PollarClient {
             this._log.warn('[PollarClient] Could not snapshot request body for retry', err);
           }
         }
-        // The refresh endpoint must not wait on its own in-flight refresh —
+        // The refresh endpoint must not wait on its own in-flight refresh -
         // that would deadlock the singleton. Other requests wait so they
         // pick up the freshly-rotated token.
         const isRefresh = request.url.includes('/auth/refresh');
         // Swallow the refresh outcome: this request only needs to wait until the
         // rotation settles, then proceed with whatever token is current. If the
-        // refresh REJECTED, that's the refreshing caller's problem — an
+        // refresh REJECTED, that's the refreshing caller's problem - an
         // unrelated request must not inherit/re-throw it (and a bare `await`
         // would surface it as an unhandled rejection here).
         if (!isRefresh && self._refreshPromise) await self._refreshPromise.catch(() => {});
 
         if (isRefresh) {
-          // RFC 9449 §5 / §6.1: token-endpoint proofs MUST NOT carry `ath`
+          // RFC 9449 section 5 / section 6.1: token-endpoint proofs MUST NOT carry `ath`
           // and MUST NOT use the access token in the Authorization header.
           // The DPoP proof alone authenticates the request; the RT goes in
           // the body and binds via `cnf.jkt`.
@@ -791,9 +791,9 @@ export class PollarClient {
           const serverSec = Math.floor(Date.parse(serverDate) / 1000);
           // Only learn the offset from a PLAUSIBLE absolute server time (the
           // server clock is always ~now). This still compensates any local-clock
-          // skew (the offset is server−local), but ignores a garbage/hostile
+          // skew (the offset is server-local), but ignores a garbage/hostile
           // `Date` (epoch, year 2099, a CDN error page's wrong clock) that would
-          // otherwise poison every proof's `iat` and wedge auth. Window: 2020–2100.
+          // otherwise poison every proof's `iat` and wedge auth. Window: 2020-2100.
           if (Number.isFinite(serverSec) && serverSec > 1_577_836_800 && serverSec < 4_102_444_800) {
             self._clockOffsetSec = serverSec - Math.floor(Date.now() / 1000);
           }
@@ -804,7 +804,7 @@ export class PollarClient {
         // Case-insensitive: RFC 9449 carries this as `error="use_dpop_nonce"`,
         // but header casing isn't guaranteed end-to-end (a proxy/CDN can rewrite
         // it). A case-sensitive match would misclassify the nonce challenge as a
-        // plain token-expiry 401 → a pointless refresh and, for a POST, no retry
+        // plain token-expiry 401 -> a pointless refresh and, for a POST, no retry
         // (POSTs don't auto-retry after a token refresh), surfacing as a spurious
         // failure on the first DPoP request behind such infra.
         const wwwAuth = response.headers.get('WWW-Authenticate') ?? '';
@@ -815,11 +815,11 @@ export class PollarClient {
         // Treating it as an expiry (the default 401 path) burns a refresh per
         // occurrence, which on a polling loop is enough to hit the /auth/refresh
         // rate limit and take the session down with it. Retrying is all it
-        // needs — `_retryRequest` mints a brand-new proof.
+        // needs - `_retryRequest` mints a brand-new proof.
         const isProofReplay = !isNonceChallenge && (await self._isDpopReplay(response));
 
         // The refresh endpoint has special handling: don't recursively trigger
-        // refresh from inside itself. But DO honor a nonce challenge — the
+        // refresh from inside itself. But DO honor a nonce challenge - the
         // fresh `DPoP-Nonce` was already captured above, so a single retry
         // with the new nonce succeeds. Any other 401 (RT expired, reused,
         // invalid) propagates to `_doRefresh` which clears the session.
@@ -836,7 +836,7 @@ export class PollarClient {
           }
           // Token-expired retries (post-refresh) are only safe for idempotent
           // methods. POST/PUT/DELETE/PATCH might have already executed
-          // server-side before auth was rejected — replaying could duplicate
+          // server-side before auth was rejected - replaying could duplicate
           // effects (double-create a transaction, etc.). The original 401
           // bubbles up so the caller decides; the access token is now fresh,
           // so a manual retry by the caller will succeed. Nonce-challenge and
@@ -880,7 +880,7 @@ export class PollarClient {
       try {
         requestBody = redactBody(JSON.parse(new TextDecoder().decode(cached)));
       } catch {
-        // Non-JSON / unparseable body — omit it rather than log raw bytes.
+        // Non-JSON / unparseable body - omit it rather than log raw bytes.
       }
     }
 
@@ -892,7 +892,7 @@ export class PollarClient {
         // wouldn't catch. Never log a raw response body.
         responseBody = redactDeep(await response.json());
       } catch {
-        // Body already consumed or not valid JSON — omit it.
+        // Body already consumed or not valid JSON - omit it.
       }
     }
 
@@ -952,7 +952,7 @@ export class PollarClient {
    * access token and spends a `/auth/refresh` on it. A replay is neither: the
    * server refused the proof and never ran the handler, so the token is fine and
    * a refresh only burns rate-limit budget. Narrowed to the replay `reason`
-   * specifically — every other DPoP failure (thumbprint mismatch, `ath`
+   * specifically - every other DPoP failure (thumbprint mismatch, `ath`
    * mismatch) genuinely can be fixed by re-issuing a token bound to the current
    * key, so those keep the refresh.
    *
@@ -979,8 +979,8 @@ export class PollarClient {
    * concurrent refresh may have rotated in the meantime) is what makes the retry
    * actually retry.
    *
-   * Returns `null` when the request can no longer be signed — no session (a
-   * concurrent logout) or no DPoP key — so the caller drops the retry instead of
+   * Returns `null` when the request can no longer be signed - no session (a
+   * concurrent logout) or no DPoP key - so the caller drops the retry instead of
    * replaying revoked credentials. Only reached for GET/HEAD, so there is no
    * body to carry over.
    */
@@ -1005,13 +1005,13 @@ export class PollarClient {
     // Rebuild instead of clone(): the original's body stream was consumed by
     // the first fetch() and clone() would throw `Request body is already used`.
     // openapi-fetch runs onResponse a single time per request, so no
-    // RETRIED_HEADER guard is needed — the retry's response is returned to
+    // RETRIED_HEADER guard is needed - the retry's response is returned to
     // the caller directly and never re-enters this middleware.
     const headers = new Headers(originalRequest.headers);
     const isRefresh = originalRequest.url.includes('/auth/refresh');
 
     if (isRefresh) {
-      // Token-endpoint proof per RFC 9449 §5 / §6.1: NO `ath`, NO
+      // Token-endpoint proof per RFC 9449 section 5 / section 6.1: NO `ath`, NO
       // Authorization header. Mirrors the initial-request branch in
       // `onRequest`. The DPoP header is rebuilt so it picks up the fresh
       // server-issued nonce captured in `onResponse`.
@@ -1023,7 +1023,7 @@ export class PollarClient {
       // Strip any stale auth copied from the original request FIRST: if the
       // session was cleared between the original send and this retry (e.g. a
       // concurrent logout), `accessToken` is undefined and we must NOT replay the
-      // old — now revoked — Authorization/DPoP headers. Mirrors the refresh
+      // old - now revoked - Authorization/DPoP headers. Mirrors the refresh
       // branch above, which always deletes them.
       headers.delete('Authorization');
       headers.delete('DPoP');
@@ -1039,7 +1039,7 @@ export class PollarClient {
       }
     }
 
-    // Never attach a body to a GET/HEAD retry — the Fetch API (and RN's
+    // Never attach a body to a GET/HEAD retry - the Fetch API (and RN's
     // polyfill) throws "Body not allowed for GET or HEAD requests". This is
     // the retry that the `/auth/session/resume` GET hits after a DPoP nonce
     // challenge.
@@ -1071,7 +1071,7 @@ export class PollarClient {
     return fetchWithTimeout(retried, isSubmit ? this._submitTimeoutMs : this._requestTimeoutMs);
   }
 
-  // ─── Refresh (race-safe singleton) ───────────────────────────────────────
+  // --- Refresh (race-safe singleton) ---------------------------------------
 
   /**
    * Coalesce concurrent refresh attempts. The first caller does the work;
@@ -1088,7 +1088,7 @@ export class PollarClient {
 
   /**
    * Tear down the session ONLY if it's still the one identified by `gen`. A
-   * refresh that fails AFTER a logout/login landed must not `_clearSession()` —
+   * refresh that fails AFTER a logout/login landed must not `_clearSession()` -
    * that would wipe a session it no longer owns (the new login's, or re-clear an
    * already-cleared one). Used by `_doRefresh`'s error branches.
    */
@@ -1122,7 +1122,7 @@ export class PollarClient {
     } catch (err) {
       // A transient transport failure (timeout / dropped connection) must NOT
       // tear down the session: the refresh token is almost certainly still
-      // valid — the network just hiccuped — so clearing here would log the user
+      // valid - the network just hiccuped - so clearing here would log the user
       // out over a momentary stall. Keep the session and rethrow a catchable
       // error; the caller can fall back to the cached token, and the next
       // request (or proactive timer) will refresh once connectivity returns.
@@ -1143,7 +1143,7 @@ export class PollarClient {
     }
     const successData = data as { success?: boolean; content?: { token?: PollarPersistedSession['token'] } };
     if (!successData.success || !successData.content?.token) {
-      // Don't log `successData` — its `content.token` would write access/refresh
+      // Don't log `successData` - its `content.token` would write access/refresh
       // tokens to the console. Log only the non-sensitive shape.
       this._log.error('[PollarClient] /auth/refresh response malformed', {
         success: successData.success,
@@ -1157,7 +1157,7 @@ export class PollarClient {
     if (
       typeof newToken.accessToken !== 'string' ||
       typeof newToken.refreshToken !== 'string' ||
-      // `typeof NaN === 'number'`, so the old check let NaN/Infinity through —
+      // `typeof NaN === 'number'`, so the old check let NaN/Infinity through -
       // require a finite, positive Unix-seconds value.
       !Number.isFinite(newToken.expiresAt) ||
       newToken.expiresAt <= 0
@@ -1174,7 +1174,7 @@ export class PollarClient {
     }
     // Sanity (non-fatal): `expiresAt` is Unix SECONDS. A value implausibly far
     // ahead (e.g. the server mistakenly sending milliseconds) would silently
-    // disable proactive refresh — the scheduler clamps the huge delay — so the
+    // disable proactive refresh - the scheduler clamps the huge delay - so the
     // token would only ever be refreshed reactively on a 401. Surface it.
     if (newToken.expiresAt > Math.floor(Date.now() / 1000) + 400 * 24 * 60 * 60) {
       this._log.warn('[PollarClient] /auth/refresh expiresAt is implausibly far ahead (seconds vs ms?)', {
@@ -1183,7 +1183,7 @@ export class PollarClient {
     }
 
     // Discard the result if the session was torn down or replaced (logout / new
-    // login), or the client was destroyed, while the request was in flight —
+    // login), or the client was destroyed, while the request was in flight -
     // writing it back would undo a logout or re-arm a timer post-teardown.
     if (this._destroyed || this._sessionGeneration !== gen || !this._session) {
       this._log.info('[PollarClient] Refresh result discarded: session changed during refresh');
@@ -1197,11 +1197,11 @@ export class PollarClient {
     } catch (err) {
       this._log.error('[PollarClient] Failed to persist refreshed session', err);
       // In-memory state is still updated; the session works for this
-      // process but won't survive reload. Don't clear — that'd surprise
+      // process but won't survive reload. Don't clear - that'd surprise
       // the user with a logout for what's essentially a storage hiccup.
     }
 
-    // Re-check after the awaited write — a logout could have landed during it.
+    // Re-check after the awaited write - a logout could have landed during it.
     if (this._destroyed || this._sessionGeneration !== gen) return;
 
     // Emit the rotated session so getAuthState()/onAuthStateChange consumers
@@ -1209,7 +1209,7 @@ export class PollarClient {
     // directly and already see the rotation, but external readers (e.g. code
     // that forwards the access token to a customer backend, or a
     // `getFreshAccessToken` helper that awaits an onAuthStateChange emission)
-    // only see `_authState` — without this they keep handing out the stale,
+    // only see `_authState` - without this they keep handing out the stale,
     // now-expired token. Preserve `step`/`verified`; only swap the session.
     if (this._authState.step === 'authenticated') {
       this._setAuthState({ ...this._authState, session: this._session });
@@ -1217,11 +1217,11 @@ export class PollarClient {
     this._scheduleNextRefresh();
   }
 
-  // ─── Silent refresh scheduler ────────────────────────────────────────────────
+  // --- Silent refresh scheduler ------------------------------------------------
 
   /**
    * Arm a single setTimeout to fire shortly before the current access token
-   * expires. Idempotent — clearing any previous timer first. Safe to call
+   * expires. Idempotent - clearing any previous timer first. Safe to call
    * from any session-write site (initial login, restore-from-storage, after
    * a successful rotation). No-op if there's no session in memory.
    *
@@ -1254,15 +1254,15 @@ export class PollarClient {
    *
    * Skip if:
    *   - no session / no RT (nothing to refresh)
-   *   - app is hidden — wait for the visibility listener to re-trigger us
-   *   - `maxIdleMs` configured and no client request since that window — let
+   *   - app is hidden - wait for the visibility listener to re-trigger us
+   *   - `maxIdleMs` configured and no client request since that window - let
    *     the next reactive 401-refresh handle it whenever the user comes back
-   *   - the AT still has more than `REFRESH_SKEW_SECONDS` of life — reschedule
+   *   - the AT still has more than `REFRESH_SKEW_SECONDS` of life - reschedule
    *
    * Otherwise call `refresh()`, which uses the existing in-flight singleton
    * so we never collide with a reactive 401-triggered refresh. On a genuine
    * failure `_doRefresh` clears the session (listeners see `step:'idle'`); on a
-   * transient network timeout it keeps the session and rejects — we just log and
+   * transient network timeout it keeps the session and rejects - we just log and
    * leave it for the next reactive refresh / foreground re-trigger.
    */
   private async _maybeProactiveRefresh(): Promise<void> {
@@ -1289,15 +1289,15 @@ export class PollarClient {
     }
   }
 
-  // ─── Auth state ──────────────────────────────────────────────────────────────
+  // --- Auth state --------------------------------------------------------------
 
   /**
    * Copy an auth state so an external reader can't mutate the live `_authState` /
-   * `_session` — which the SDK's own request middleware reads
-   * (`_session.token.accessToken`) and the next writeStorage() serializes —
+   * `_session` - which the SDK's own request middleware reads
+   * (`_session.token.accessToken`) and the next writeStorage() serializes -
    * through the object it received. Clones the nested `token`/`wallet`/`user`
    * too: a shallow session copy still shares those object refs, so
-   * `state.session.token.accessToken = …` (or `.user.ready = …`) would otherwise
+   * `state.session.token.accessToken = ...` (or `.user.ready = ...`) would otherwise
    * corrupt the live session the SDK signs with and persists.
    */
   private _cloneAuthState(s: AuthState): AuthState {
@@ -1327,7 +1327,7 @@ export class PollarClient {
   /**
    * Subscribe to persistent-storage degradation (Safari private mode,
    * sandboxed iframes, quota errors, etc.). The SDK keeps running off
-   * in-memory storage after degrade, but sessions won't survive reload — a
+   * in-memory storage after degrade, but sessions won't survive reload - a
    * host UI typically wants to show "your session won't be saved" so the
    * user isn't blindsided after a refresh.
    *
@@ -1336,7 +1336,7 @@ export class PollarClient {
    *
    * Only fires when the SDK constructs the default storage adapter. If you
    * pass a custom `config.storage`, wire your own notification path through
-   * that adapter's API — the SDK has no hook into it.
+   * that adapter's API - the SDK has no hook into it.
    */
   onStorageDegrade(cb: OnStorageDegrade): () => void {
     this._storageDegradeListeners.add(cb);
@@ -1358,20 +1358,20 @@ export class PollarClient {
     }
   }
 
-  /** PII (email, names, avatar, providers). Held in memory only — never persisted. */
+  /** PII (email, names, avatar, providers). Held in memory only - never persisted. */
   getUserProfile(): PollarUserProfile | null {
     return this._profile;
   }
 
-  // ─── Login (unified entry point) ─────────────────────────────────────────
+  // --- Login (unified entry point) -----------------------------------------
 
   login(options: PollarLoginOptions): void {
     if (!isClientRuntime) {
       warnServerSide('login');
       return;
     }
-    // A registered wallet adapter (freighter/albedo/privy/xbull/solana…): run the
-    // wallet flow for its chain — SEP-10 for Stellar, SIWS for Solana. It yields a
+    // A registered wallet adapter (freighter/albedo/privy/xbull/solana...): run the
+    // wallet flow for its chain - SEP-10 for Stellar, SIWS for Solana. It yields a
     // persistent adapter reused for signing long after login.
     const walletAdapter = this._walletAdapters.get(options.provider);
     if (walletAdapter) {
@@ -1409,7 +1409,7 @@ export class PollarClient {
    * Reuses the in-flight login `AbortController` when one exists so the step
    * stays cancellable via `cancelLogin()`; otherwise starts a fresh one. The
    * built-in email steps also have dedicated typed methods
-   * ({@link sendEmailCode} / {@link verifyEmailCode}) — prefer those for email.
+   * ({@link sendEmailCode} / {@link verifyEmailCode}) - prefer those for email.
    */
   providerAction(provider: string, action: string, payload?: unknown): void {
     if (!isClientRuntime) {
@@ -1421,13 +1421,13 @@ export class PollarClient {
       throw new PollarFlowError(`Auth provider '${provider}' has no action '${action}'`);
     }
     const signal = this._activeLoginSignal();
-    // See login() — guard against a custom action throwing synchronously.
+    // See login() - guard against a custom action throwing synchronously.
     Promise.resolve()
       .then(() => fn(this._providerContext(signal), payload))
       .catch((err) => this._handleFlowError(err, signal));
   }
 
-  // ─── Email OTP flow (3 steps) ─────────────────────────────────────────────
+  // --- Email OTP flow (3 steps) ---------------------------------------------
 
   beginEmailLogin(): void {
     if (!isClientRuntime) {
@@ -1447,7 +1447,7 @@ export class PollarClient {
       throw new PollarFlowError(`sendEmailCode() requires step 'entering_email', current step is '${this._authState.step}'`);
     }
     const { clientSessionId } = this._authState;
-    // Reuse the active login controller if present, else mint one — matching the
+    // Reuse the active login controller if present, else mint one - matching the
     // other entry points; mint a fresh controller if there's none or the
     // existing one is already aborted (else this resend would hit a dead signal).
     const signal = this._activeLoginSignal();
@@ -1465,7 +1465,7 @@ export class PollarClient {
       (this._authState.errorCode === AUTH_ERROR_CODES.EMAIL_CODE_INVALID ||
         this._authState.errorCode === AUTH_ERROR_CODES.EMAIL_CODE_EXPIRED ||
         // A generic verify failure (transient 5xx / contract drift) is also
-        // retryable — its error state now carries the clientSessionId/email.
+        // retryable - its error state now carries the clientSessionId/email.
         this._authState.errorCode === AUTH_ERROR_CODES.EMAIL_VERIFY_FAILED);
 
     if (this._authState.step !== 'entering_code' && !isRetryableError) {
@@ -1521,7 +1521,7 @@ export class PollarClient {
    * WebAuthn implementation of its own, so React Native can keep injecting its
    * native provider through the constructor.
    *
-   * Only fills gaps — an explicitly configured ceremony is never replaced.
+   * Only fills gaps - an explicitly configured ceremony is never replaced.
    * Reading `_passkey`/`_passkeySign` happens per login/signature (never
    * latched at construction), so filling them later takes effect immediately.
    */
@@ -1530,19 +1530,19 @@ export class PollarClient {
     if (!this._passkeySign && defaults.passkeySign) this._passkeySign = defaults.passkeySign;
   }
 
-  // ─── Cancel ───────────────────────────────────────────────────────────────
+  // --- Cancel ---------------------------------------------------------------
 
   cancelLogin(): void {
     this._loginController?.abort();
     this._loginController = null;
     // Only reset to idle if a login was actually in progress. Don't flap an
-    // already-authenticated session to idle — the session stays in storage and
+    // already-authenticated session to idle - the session stays in storage and
     // would re-surface, a confusing visible logout-then-login. (Use logout() to
     // end an authenticated session.)
     if (this._authState.step !== 'authenticated') this._setAuthState({ step: 'idle' });
   }
 
-  // ─── Logout ───────────────────────────────────────────────────────────────
+  // --- Logout ---------------------------------------------------------------
 
   /**
    * Revoke the current session server-side, then clear local storage.
@@ -1550,7 +1550,7 @@ export class PollarClient {
    * Server revocation is best-effort: if the POST fails (offline, server
    * down), local state is wiped regardless. The orphan refresh token then
    * remains unused until its natural expiry. The in-flight access token
-   * stays valid until its own TTL elapses (≤10 min for DPoP-bound tokens).
+   * stays valid until its own TTL elapses (<=10 min for DPoP-bound tokens).
    *
    * Pass `everywhere: true` to revoke every active session for this user
    * across all devices.
@@ -1564,7 +1564,7 @@ export class PollarClient {
 
     // Abort any login still in flight FIRST. Without this, a /auth/login
     // response landing after the logout re-ran `_storeSession` and resurrected
-    // the session — the user pressed logout and ended up logged in. Worse, the
+    // the session - the user pressed logout and ended up logged in. Worse, the
     // keypair reset below rotated the key between that login's bind and its
     // store, so the resurrected session was bound to a destroyed key. The
     // flow's other deps (storeSession/clearSession/setAuthState) already no-op
@@ -1599,7 +1599,7 @@ export class PollarClient {
     // the OLD session already happened, so stop here rather than destroying
     // state we no longer own. This guard sits BEFORE the adapter disconnect on
     // purpose: registered adapters are per-type singletons, so the "old"
-    // adapter reference can be the very instance the new login is now using —
+    // adapter reference can be the very instance the new login is now using -
     // disconnecting it would cut the new session's provider connection and
     // break external signing. When superseded, the old provider session is
     // left alone: it is either in use by the new login or benign to keep.
@@ -1613,7 +1613,7 @@ export class PollarClient {
     // reference; without this, the provider session persists across a reload and
     // the auto-login effect in `@pollar/react` (which subscribes to
     // `onProviderAuthChange`) silently re-authenticates the user. Only done here,
-    // in the user-initiated logout path — not inside `_clearSession()`, which
+    // in the user-initiated logout path - not inside `_clearSession()`, which
     // also runs on transient refresh/resume failures where the provider session
     // must survive. Best-effort: a disconnect failure must not block the clear.
     const adapter = this._walletAdapter;
@@ -1698,7 +1698,7 @@ export class PollarClient {
   /**
    * Fire-and-forget variant of {@link listSessions} that drives the observable
    * `SessionsState` store instead of returning the array. UI layers subscribe
-   * via `onSessionsStateChange` and stay pure readers — mirrors `fetchTxHistory`.
+   * via `onSessionsStateChange` and stay pure readers - mirrors `fetchTxHistory`.
    */
   async fetchSessions(): Promise<void> {
     const gen = ++this._sessionsGen;
@@ -1717,7 +1717,7 @@ export class PollarClient {
   /**
    * Revoke a specific refresh-token family (a single device session). Use
    * `listSessions` to enumerate the familyIds. Revoking the current session
-   * does NOT clear local state — call `logout()` for that case.
+   * does NOT clear local state - call `logout()` for that case.
    */
   async revokeSession(familyId: string): Promise<void> {
     if (!isClientRuntime) {
@@ -1735,7 +1735,7 @@ export class PollarClient {
     }
   }
 
-  // ─── Network ──────────────────────────────────────────────────────────────
+  // --- Network --------------------------------------------------------------
 
   getNetwork(): StellarNetwork {
     return this._networkState.step === 'connected' ? this._networkState.network : 'testnet';
@@ -1764,7 +1764,7 @@ export class PollarClient {
     return () => this._networkStateListeners.delete(cb);
   }
 
-  // ─── Transaction state ────────────────────────────────────────────────────
+  // --- Transaction state ----------------------------------------------------
 
   getTransactionState(): TransactionState | null {
     return this._transactionState;
@@ -1778,8 +1778,8 @@ export class PollarClient {
 
   /**
    * Reset the transaction state machine back to `idle`. Modal UIs (send / swap /
-   * earn) call this when they (re)open so a prior terminal state — a `success`
-   * or `error` left over from an earlier flow — can't leak in as a stale "Done!"
+   * earn) call this when they (re)open so a prior terminal state - a `success`
+   * or `error` left over from an earlier flow - can't leak in as a stale "Done!"
    * or error screen.
    */
   resetTransactionState(): void {
@@ -1789,7 +1789,7 @@ export class PollarClient {
     this._setTransactionState({ step: 'idle' });
   }
 
-  // ─── Tx history ──────────────────────────────────────────────────────────
+  // --- Tx history ----------------------------------------------------------
 
   getTxHistoryState(): TxHistoryState {
     return this._txHistoryState;
@@ -1819,7 +1819,7 @@ export class PollarClient {
     }
   }
 
-  // ─── Wallet balance ───────────────────────────────────────────────────────
+  // --- Wallet balance -------------------------------------------------------
 
   getWalletBalanceState(): WalletBalanceState {
     return this._walletBalanceState;
@@ -1833,7 +1833,7 @@ export class PollarClient {
 
   /**
    * Refreshes the balances of the authenticated user's OWN wallet. The wallet
-   * and network are resolved server-side from the session — no arguments. Drives
+   * and network are resolved server-side from the session - no arguments. Drives
    * `walletBalanceState`. For an arbitrary wallet, use {@link getWalletBalance}.
    */
   async refreshBalance(): Promise<void> {
@@ -1867,8 +1867,8 @@ export class PollarClient {
    * Collapses the v2 multichain balance (`{ balances: [{ chain, ... }] }`) into the
    * flat, chain-tagged {@link WalletBalanceContent} the UI consumes.
    *
-   * Every chain reports the same `balances` array — its native coin plus each token
-   * the app enabled — so one loop handles all three. `multichain` is set when more
+   * Every chain reports the same `balances` array - its native coin plus each token
+   * the app enabled - so one loop handles all three. `multichain` is set when more
    * than one chain came back: the modal uses it to decide whether to show a
    * per-asset network tag. A chain that failed to resolve carries `error` instead
    * of `balances` and contributes nothing.
@@ -1920,7 +1920,7 @@ export class PollarClient {
   /**
    * The {@link _flattenBalances} twin for `/wallet/assets`: collapses the v2
    * per-chain answer into one chain-tagged catalog. Same envelope (`chains`),
-   * same rules — a chain carrying `error` contributes nothing, and only Stellar
+   * same rules - a chain carrying `error` contributes nothing, and only Stellar
    * restates the network.
    */
   private _flattenAssets(content: unknown, ownAddress: string): WalletAssetsContent {
@@ -1955,7 +1955,7 @@ export class PollarClient {
   }
 
   /**
-   * General-purpose balance lookup for ANY wallet on ANY network — not scoped
+   * General-purpose balance lookup for ANY wallet on ANY network - not scoped
    * to this application. Enumerates the account's real on-chain holdings via
    * Horizon (server-side) and returns the data directly (no reactive state).
    * `network` defaults to the client's current network.
@@ -1970,7 +1970,7 @@ export class PollarClient {
     return data.content;
   }
 
-  // ─── Enabled assets ───────────────────────────────────────────────────────
+  // --- Enabled assets -------------------------------------------------------
 
   getEnabledAssetsState(): EnabledAssetsState {
     return this._enabledAssetsState;
@@ -1984,7 +1984,7 @@ export class PollarClient {
 
   /**
    * Loads the application's enabled assets paired with the authenticated
-   * wallet's on-chain trustline state — so the SDK knows which trustlines still
+   * wallet's on-chain trustline state - so the SDK knows which trustlines still
    * need to be added. Wallet and network are resolved server-side from the
    * session. Drives `enabledAssetsState`; mirrors {@link refreshBalance}.
    */
@@ -2018,28 +2018,28 @@ export class PollarClient {
   /**
    * Establishes (omit `limit`) or removes (`limit: '0'`) a trustline for an asset.
    *
-   * The app config decides who pays, server-side — the SDK never pre-decides.
+   * The app config decides who pays, server-side - the SDK never pre-decides.
    * Sponsorship is **on by default** (the app covers the 0.5 XLM reserve + fee
    * when eligible); pass `skipSponsorship` to force the user's own wallet to pay,
    * mirroring the opt-out on the payment / swap / contract fee-bump surfaces. The
    * route is by wallet type, and each server endpoint sponsors-or-self-pays:
-   *  - **Custodial** (internal wallet, no adapter) → one call to
+   *  - **Custodial** (internal wallet, no adapter) -> one call to
    *    `/wallet/assets/trustline`: the server holds the trustor key and either
    *    sponsors or self-pays, then submits, returning the refreshed asset list.
-   *  - **External/adapter** → `/wallet/assets/trustline/build` returns a
+   *  - **External/adapter** -> `/wallet/assets/trustline/build` returns a
    *    `changeTrust` XDR (sponsor-signed when covered, or a plain self-pay one
    *    otherwise); the user's own wallet adds the trustor signature and submits.
-   *  - **`skipSponsorship`** → a plain self-pay `change_trust` via {@link runTx},
+   *  - **`skipSponsorship`** -> a plain self-pay `change_trust` via {@link runTx},
    *    bypassing the sponsoring endpoints for both wallet types.
    *
-   * Does not refresh on its own — callers should `refreshAssets()` afterwards.
+   * Does not refresh on its own - callers should `refreshAssets()` afterwards.
    */
   async setTrustline(
     asset: { code: string; issuer: string },
     opts?: {
       limit?: string;
       /**
-       * Force self-pay even when the app would sponsor the trustline — the
+       * Force self-pay even when the app would sponsor the trustline - the
        * opt-out that mirrors `skipSponsorship` on the payment / swap / contract
        * fee-bump surfaces.
        */
@@ -2053,18 +2053,18 @@ export class PollarClient {
       return { status: 'error', details: 'No wallet connected' };
     }
     if (walletType === 'smart') {
-      // Passkey C-addresses hold SAC tokens — they don't use classic trustlines.
+      // Passkey C-addresses hold SAC tokens - they don't use classic trustlines.
       return { status: 'error', details: 'Trustlines do not apply to smart wallets' };
     }
-    // A Stellar asset code is 1–12 chars (alphanum4 ≤4, alphanum12 5–12). Reject
-    // out-of-range codes up front — otherwise the self-paid path would emit an
+    // A Stellar asset code is 1-12 chars (alphanum4 <=4, alphanum12 5-12). Reject
+    // out-of-range codes up front - otherwise the self-paid path would emit an
     // empty-code alphanum4 or an invalid >12 alphanum12 and the backend 400s.
     if (asset.code.length < 1 || asset.code.length > 12) {
       return { status: 'error', details: 'Asset code must be 1–12 characters' };
     }
 
     // The backend's change_trust schema is a discriminated union on `type`, so
-    // derive it from the code length (1–4 → alphanum4, 5–12 → alphanum12).
+    // derive it from the code length (1-4 -> alphanum4, 5-12 -> alphanum12).
     const changeTrustParams = {
       asset: {
         type: asset.code.length <= 4 ? 'credit_alphanum4' : 'credit_alphanum12',
@@ -2082,7 +2082,7 @@ export class PollarClient {
 
     // Custodial: one server call. The server sponsors when the app config allows
     // and self-pays otherwise, submitting either way and returning the refreshed
-    // asset list — the client no longer decides the route.
+    // asset list - the client no longer decides the route.
     if (!this._walletAdapter && walletType === 'internal') {
       try {
         const { data, error } = await this._api.POST('/wallet/assets/trustline', {
@@ -2107,8 +2107,8 @@ export class PollarClient {
     }
 
     // External/adapter: the trustor key lives client-side. The server returns a
-    // changeTrust XDR — sponsor-signed when the app covers it, or a plain self-pay
-    // one otherwise — and we add the trustor signature with the user's own wallet
+    // changeTrust XDR - sponsor-signed when the app covers it, or a plain self-pay
+    // one otherwise - and we add the trustor signature with the user's own wallet
     // and submit either way.
     try {
       const { data, error } = await this._api.POST('/wallet/assets/trustline/build', {
@@ -2140,8 +2140,8 @@ export class PollarClient {
    * and fee) and signs only the sponsor. This client adds the new-account
    * signature with the user's own wallet and broadcasts it via the submit path.
    *
-   * Not applicable to custodial (internal) wallets — those are created on the
-   * server at login — nor to smart (C-address) wallets, which don't use classic
+   * Not applicable to custodial (internal) wallets - those are created on the
+   * server at login - nor to smart (C-address) wallets, which don't use classic
    * accounts. Trustlines are a separate step: see {@link setTrustline}.
    */
   async createAccount(): Promise<SubmitOutcome> {
@@ -2174,7 +2174,7 @@ export class PollarClient {
     }
   }
 
-  // ─── Transactions ─────────────────────────────────────────────────────────
+  // --- Transactions ---------------------------------------------------------
 
   /**
    * Builds an unsigned XDR. Drives `_setTransactionState` for modal-style UIs
@@ -2274,7 +2274,7 @@ export class PollarClient {
   }
 
   /**
-   * Every wallet the user holds, one per chain, as {@link WalletInfo} values —
+   * Every wallet the user holds, one per chain, as {@link WalletInfo} values -
    * a superset of {@link getWallet}. Each entry carries `chain` when the
    * backend reported it.
    *
@@ -2308,7 +2308,7 @@ export class PollarClient {
     switch (w.type) {
       case 'external':
         // The on-chain adapter id is only known client-side, from the adapter
-        // currently attached — it is never persisted.
+        // currently attached - it is never persisted.
         return { custody: 'external', address: w.address, provider: this._walletAdapter?.type ?? null, ...extra };
       case 'smart':
         return { custody: 'smart', address: w.address, provider: 'passkey', ...extra };
@@ -2399,7 +2399,7 @@ export class PollarClient {
     // Custodial path: backend signs and returns the XDR + idempotencyKey. By
     // default the backend also applies sponsorship (per the app's dashboard
     // config), returning a fee-bumped envelope the caller can broadcast directly
-    // — the app pays the fee. Pass `skipSponsorship` to force the user to pay.
+    // - the app pays the fee. Pass `skipSponsorship` to force the user to pay.
     const address = this._session?.wallet?.address ?? '';
     try {
       const { data, error } = await this._api.POST('/tx/sign', {
@@ -2448,7 +2448,7 @@ export class PollarClient {
    * - External wallets (Freighter/Albedo) sign the entry via the provider.
    * - Custodial wallets are signed by the backend, which FIRST validates the
    *   entry's invocation tree against the app's contract/function allowlist and
-   *   caps the validity window — entries touching a non-allowlisted contract or
+   *   caps the validity window - entries touching a non-allowlisted contract or
    *   function, or expiring too far ahead, are rejected.
    *
    * @param entryXdr base64 XDR of the unsigned `SorobanAuthorizationEntry`.
@@ -2461,7 +2461,7 @@ export class PollarClient {
     if (noSigner) return noSigner;
     // External adapter: the provider signs the entry directly. Skip it for a
     // smart-wallet session (passkey-signed) so a stale/foreign adapter can't
-    // hijack signing — consistent with the type-first signing paths.
+    // hijack signing - consistent with the type-first signing paths.
     if (this._walletAdapter && this._session?.wallet?.type !== 'smart') {
       const accountToSign = this._session?.wallet?.address;
       // Soroban auth-entry signing is Stellar-only; a non-Stellar adapter never
@@ -2513,7 +2513,7 @@ export class PollarClient {
     }
   }
 
-  // ─── Stellar SEP ownership proofs (client.stellar.*) ──────────────────────────
+  // --- Stellar SEP ownership proofs (client.stellar.*) --------------------------
 
   /**
    * SEP-53 message signing (`client.stellar.sep53.signMessage`). Returns a base64
@@ -2636,7 +2636,7 @@ export class PollarClient {
    */
   private _resolveTxApiError(error: unknown, data?: unknown): { details?: string; code?: string; message?: string } {
     // On a non-2xx the failure envelope is in `error`; on a 2xx with
-    // `success:false` it rides in `data` — fall back to it so the backend's
+    // `success:false` it rides in `data` - fall back to it so the backend's
     // code/message contract isn't dropped on the 2xx-failure path.
     const e = (error ?? data) as { details?: string; code?: string; message?: string } | undefined;
     const details = e?.details ?? e?.message;
@@ -2824,8 +2824,8 @@ export class PollarClient {
    * Signs and submits in one logical step. Returns a {@link SubmitOutcome}.
    *
    * - **External wallets**: composes `signTx` + `submitTx` client-side. State
-   *   machine sees the full granular sequence `signing → signed → submitting
-   *   → success` because the underlying methods each emit.
+   *   machine sees the full granular sequence `signing -> signed -> submitting
+   *   -> success` because the underlying methods each emit.
    * - **Custodial wallets**: atomic `/tx/sign-and-send` round-trip. State
    *   machine emits the compound `signing-submitting` step (the SDK can't
    *   observe when one phase ends and the next begins inside that single
@@ -2836,7 +2836,7 @@ export class PollarClient {
     this._txStartGen = this._sessionGeneration;
     const noSigner = this._externalSignerMissing();
     if (noSigner) return noSigner;
-    // Smart wallet: there is no unsigned XDR — sign the prepared auth digest
+    // Smart wallet: there is no unsigned XDR - sign the prepared auth digest
     // with the passkey and submit, using the build already on the state machine.
     if (this._session?.wallet?.type === 'smart') {
       const buildData = this._currentBuildData();
@@ -2854,7 +2854,7 @@ export class PollarClient {
     }
 
     if (this._walletAdapter) {
-      // External — the composed signTx+submitTx already emit the granular
+      // External - the composed signTx+submitTx already emit the granular
       // state-machine sequence. We just pass outcomes through.
       const signed = await this.signTx(unsignedXdr);
       if (signed.status === 'error') {
@@ -2868,7 +2868,7 @@ export class PollarClient {
       return this.submitTx(signed.signedXdr);
     }
 
-    // Custodial — atomic single backend call. Compound state.
+    // Custodial - atomic single backend call. Compound state.
     const buildData = this._currentBuildData();
     const outcomeExtra: { buildData?: TxBuildContent } = buildData ? { buildData } : {};
 
@@ -2946,11 +2946,11 @@ export class PollarClient {
   }
 
   /**
-   * One-shot: build → sign → submit, returning the final {@link SubmitOutcome}.
+   * One-shot: build -> sign -> submit, returning the final {@link SubmitOutcome}.
    *
    * - **External wallets**: composes `buildTx` + `signAndSubmitTx` client-side.
-   *   State machine sees the full granular sequence (`building → built →
-   *   signing → signed → submitting → success`) because each composed call
+   *   State machine sees the full granular sequence (`building -> built ->
+   *   signing -> signed -> submitting -> success`) because each composed call
    *   emits its own transitions.
    * - **Custodial wallets**: single round-trip to `/tx/build-sign-submit`. The
    *   signed XDR never leaves the backend. State machine emits the compound
@@ -2959,7 +2959,7 @@ export class PollarClient {
    *   `submitted` / `success` / `error[phase: 'building-signing-submitting']`.
    *
    * If you need granular UI feedback for custodial flows (separate
-   * "Building…", "Signing…", "Submitting…" indicators), call `buildTx`,
+   * "Building...", "Signing...", "Submitting..." indicators), call `buildTx`,
    * `signTx`, and `submitTx` separately instead.
    */
   async buildAndSignAndSubmitTx(
@@ -2970,8 +2970,8 @@ export class PollarClient {
     this._txStartGen = this._sessionGeneration;
     const noSigner = this._externalSignerMissing();
     if (noSigner) return noSigner;
-    // Smart wallet (passkey / C-address): build (prepare) → sign the auth digest
-    // with the passkey → submit. The signed entry is assembled server-side.
+    // Smart wallet (passkey / C-address): build (prepare) -> sign the auth digest
+    // with the passkey -> submit. The signed entry is assembled server-side.
     if (this._session?.wallet?.type === 'smart') {
       return this._runSmartTx(operation, params, options);
     }
@@ -2987,7 +2987,7 @@ export class PollarClient {
       return this.signAndSubmitTx(built.buildData.unsignedXdr);
     }
 
-    // Custodial path — single backend call, compound state-machine step.
+    // Custodial path - single backend call, compound state-machine step.
     if (!this._session?.wallet?.address) {
       this._setTransactionState({ step: 'error', phase: 'building-signing-submitting', details: 'No wallet connected' });
       return { status: 'error', details: 'No wallet connected' };
@@ -3129,7 +3129,7 @@ export class PollarClient {
     }
   }
 
-  /** Alias for {@link buildAndSignAndSubmitTx} — shorter "just do the thing" name. */
+  /** Alias for {@link buildAndSignAndSubmitTx} - shorter "just do the thing" name. */
   async runTx(
     operation: TxBuildBody['operation'],
     params: TxBuildBody['params'],
@@ -3140,10 +3140,10 @@ export class PollarClient {
 
   /**
    * Smart-wallet (passkey / C-address) transaction: build (server prepares the
-   * SAC transfer + returns the auth digest) → sign the digest with the passkey
-   * → submit (server assembles the signed auth entry and broadcasts; the
-   * sponsor pays the fee). State machine: building → built → signing →
-   * submitting → success.
+   * SAC transfer + returns the auth digest) -> sign the digest with the passkey
+   * -> submit (server assembles the signed auth entry and broadcasts; the
+   * sponsor pays the fee). State machine: building -> built -> signing ->
+   * submitting -> success.
    */
   private async _runSmartTx(
     operation: TxBuildBody['operation'],
@@ -3162,7 +3162,7 @@ export class PollarClient {
       return { status: 'error', details };
     }
 
-    // 1. Build (prepare) — returns the auth digest to sign, not an unsigned XDR.
+    // 1. Build (prepare) - returns the auth digest to sign, not an unsigned XDR.
     this._setTransactionState({ step: 'building' });
     let buildData: TxBuildContent;
     try {
@@ -3190,7 +3190,7 @@ export class PollarClient {
   }
 
   /**
-   * Steps 2–3 of the smart-wallet flow: sign the prepared auth digest with the
+   * Steps 2-3 of the smart-wallet flow: sign the prepared auth digest with the
    * passkey, then submit. Shared by `_runSmartTx` (atomic) and `signAndSubmitTx`
    * (split flow, when a smart build is already on the state machine).
    */
@@ -3220,7 +3220,7 @@ export class PollarClient {
       return { status: 'error', buildData, ...(details && { details }) };
     }
 
-    // 3. Submit — server assembles the signed auth entry and broadcasts.
+    // 3. Submit - server assembles the signed auth entry and broadcasts.
     this._setTransactionState({ step: 'submitting', buildData });
     const outcomeExtra: { buildData: TxBuildContent } = { buildData };
     try {
@@ -3272,7 +3272,7 @@ export class PollarClient {
     }
   }
 
-  // ─── App config ───────────────────────────────────────────────────────────
+  // --- App config -----------------------------------------------------------
 
   async getAppConfig(): Promise<unknown> {
     try {
@@ -3284,7 +3284,7 @@ export class PollarClient {
     }
   }
 
-  // ─── KYC ──────────────────────────────────────────────────────────────────
+  // --- KYC ------------------------------------------------------------------
 
   getKycStatus(providerId?: string) {
     return getKycStatus(this._api, providerId);
@@ -3306,7 +3306,7 @@ export class PollarClient {
     return pollKycStatus(this._api, providerId, opts);
   }
 
-  // ─── Ramps ────────────────────────────────────────────────────────────────
+  // --- Ramps ----------------------------------------------------------------
 
   getRampsQuote(query: RampsQuoteQuery): Promise<RampsQuoteResponse> {
     return getRampsQuote(this._api, query);
@@ -3345,7 +3345,7 @@ export class PollarClient {
 
   /**
    * Live liquidity on a payout rail. `available: false` means the rail cannot be
-   * served right now — check before offering the corridor, because quoting it
+   * served right now - check before offering the corridor, because quoting it
    * succeeds and only fails much further downstream.
    */
   getRampLiquidity(rail: RampRail): Promise<RampsLiquidityResponse> {
@@ -3370,7 +3370,7 @@ export class PollarClient {
     return decodePixQr(this._api, qrCode);
   }
 
-  // ─── Distribution ─────────────────────────────────────────────────────────
+  // --- Distribution ---------------------------------------------------------
 
   listDistributionRules(): Promise<DistributionRule[]> {
     return listDistributionRules(this._api);
@@ -3380,12 +3380,12 @@ export class PollarClient {
     return claimDistributionRule(this._api, body);
   }
 
-  // ─── Swap (DEX/AMM) ───────────────────────────────────────────────────────
+  // --- Swap (DEX/AMM) -------------------------------------------------------
 
   /**
    * The swap venues this app exposes to end-users (operator's dashboard
    * selection, intersected with server capability). An empty array means swap is
-   * disabled for this app — hide any swap UI. `'auto'` is not returned here; add
+   * disabled for this app - hide any swap UI. `'auto'` is not returned here; add
    * it client-side when the list is non-empty.
    */
   async getSwapConfig(): Promise<SwapVenue[]> {
@@ -3433,14 +3433,14 @@ export class PollarClient {
    * XLM and smart (C-address) wallets need none. The quote's `build` payload then
    * runs through the normal tx pipeline, so it re-simulates server-side and the
    * on-chain `minReceived` enforces slippage. Drives the same transaction state
-   * machine as {@link runTx} — subscribe via {@link onTransactionStateChange}.
+   * machine as {@link runTx} - subscribe via {@link onTransactionStateChange}.
    */
   async swap(quote: SwapQuote, opts?: { autoTrustline?: boolean }): Promise<SubmitOutcome> {
     const wallet = this.getWallet();
     if (!wallet) return { status: 'error', details: 'No wallet connected' };
 
     // TODO(phase-4 / C-address swaps): smart (passkey C-address) wallets can't
-    // swap yet. The backend smart-account build path (buildSmartAccountTransfer →
+    // swap yet. The backend smart-account build path (buildSmartAccountTransfer ->
     // wallet-service prepareTransfer) only supports `payment`, and the AMM router
     // plus its SAC sub-invocations must be allowlisted in SorobanAuthPolicy.
     // Fail fast with a clear message until that lands, instead of a confusing
@@ -3464,7 +3464,7 @@ export class PollarClient {
           ? assetsState.data.assets.find((a) => a.code === buy.code && a.issuer === buy.issuer)
           : undefined;
       if (!record?.trustlineEstablished) {
-        // Sponsorship is derived automatically from the app config now — no flag.
+        // Sponsorship is derived automatically from the app config now - no flag.
         const tl = await this.setTrustline({ code: buy.code, issuer: buy.issuer });
         if (tl.status === 'error') {
           return { status: 'error', details: `Trustline for ${buy.code} failed: ${tl.details ?? 'unknown error'}` };
@@ -3480,11 +3480,11 @@ export class PollarClient {
     return this.runTx(build.operation, build.params);
   }
 
-  // ─── Earn (yield vaults / lending) ──────────────────────────────────────────
+  // --- Earn (yield vaults / lending) ------------------------------------------
 
   /**
    * The yield providers this app exposes to end-users (enabled + server-capable).
-   * An empty array means Earn is disabled for this app — hide any Earn UI.
+   * An empty array means Earn is disabled for this app - hide any Earn UI.
    */
   async getEarnProviders(): Promise<EarnProviderId[]> {
     const content = await getEarnProviders(this._api);
@@ -3502,7 +3502,7 @@ export class PollarClient {
 
   /**
    * The connected wallet's position (balance + APY) in a specific vault/pool.
-   * Read-only — poll it to show the position updating live. `withdrawUnit` tells
+   * Read-only - poll it to show the position updating live. `withdrawUnit` tells
    * you whether {@link earnWithdraw} expects an asset amount (Blend) or a share
    * count (DeFindex); `withdrawable` is the max in that unit.
    */
@@ -3522,7 +3522,7 @@ export class PollarClient {
    * + submits it, driving the same transaction state machine as {@link runTx}.
    *
    * The `amount` is the underlying asset amount. The deposit asset's trustline
-   * must already exist on classic (G-address) wallets — auto-trustline is a
+   * must already exist on classic (G-address) wallets - auto-trustline is a
    * follow-up (the opportunity does not yet expose the asset's classic issuer).
    */
   async earnDeposit(params: EarnTxParams): Promise<SubmitOutcome> {
@@ -3531,7 +3531,7 @@ export class PollarClient {
 
   /**
    * Withdraw from a vault/pool. The `amount` is in the position's `withdrawUnit`
-   * (asset amount for Blend, share count for DeFindex) — read it from
+   * (asset amount for Blend, share count for DeFindex) - read it from
    * {@link getEarnPosition}. Signs + submits the provider-built XDR.
    */
   async earnWithdraw(params: EarnTxParams): Promise<SubmitOutcome> {
@@ -3543,7 +3543,7 @@ export class PollarClient {
     if (!wallet) return { status: 'error', details: 'No wallet connected' };
 
     // Both providers return a prebuilt XDR, which smart (passkey C-address)
-    // wallets can't sign — their build path must run server-side and return a
+    // wallets can't sign - their build path must run server-side and return a
     // passkey digest. Fail fast until that lands (same limitation as swap).
     if (wallet.custody === 'smart') {
       return { status: 'error', details: 'Earn is not yet supported for smart (passkey) wallets' };
@@ -3583,7 +3583,7 @@ export class PollarClient {
     for (const cb of this._enabledAssetsStateListeners) cb(next);
   }
 
-  // ─── Private ──────────────────────────────────────────────────────────────
+  // --- Private --------------------------------------------------------------
 
   private _newController(): AbortController {
     this._loginController?.abort();
@@ -3594,7 +3594,7 @@ export class PollarClient {
   /**
    * Signal for a continuation of the current login (e.g. `sendEmailCode`,
    * `providerAction`). Reuses the active login controller, but mints a fresh one
-   * if there's none OR the existing one is already aborted — a prior terminal
+   * if there's none OR the existing one is already aborted - a prior terminal
    * flow can leave `_loginController` set-but-aborted, and reusing that dead
    * signal would make the continuation's first request reject immediately and
    * drop the user to `idle`.
@@ -3606,8 +3606,8 @@ export class PollarClient {
 
   /**
    * Build the {@link AuthProviderContext} facade for one login attempt. Wraps
-   * the internal `FlowDeps` so providers get only the curated primitives —
-   * `createSession`, `authenticate`, `requestChallenge`, `startHostedOAuth` —
+   * the internal `FlowDeps` so providers get only the curated primitives -
+   * `createSession`, `authenticate`, `requestChallenge`, `startHostedOAuth` -
    * while storage / wallet-adapter / key-manager internals stay private. All
    * legs share the same `signal`, so `cancelLogin()` aborts the whole chain.
    */
@@ -3667,7 +3667,7 @@ export class PollarClient {
         // The login is about to bind its tokens to this key (`cnf.jkt`). Verify
         // the key is durably persisted (re-writing it if needed) and warn loudly
         // when it isn't: a non-persisted key means the session cannot survive a
-        // reload — every resume/refresh will 401 with `thumbprint-mismatch`.
+        // reload - every resume/refresh will 401 with `thumbprint-mismatch`.
         // Previously this failure was swallowed inside the key manager and only
         // surfaced as an unexplained logout on the next page load. Best-effort
         // and optional: custom KeyManager implementations without
@@ -3708,7 +3708,7 @@ export class PollarClient {
   }
 
   private _handleFlowError(error: unknown, signal?: AbortSignal): void {
-    // A cancelled/superseded flow's signal is aborted — drop its terminal write
+    // A cancelled/superseded flow's signal is aborted - drop its terminal write
     // so it can't clobber the active flow (e.g. flash `idle`/`error` over a new
     // login). cancelLogin already set the right state.
     if (signal?.aborted) return;
@@ -3750,7 +3750,7 @@ export class PollarClient {
       // overwrote storage): invalidate any refresh/resume still in flight against
       // the OLD session, so its rotated token can't be written over the
       // newly-restored one. (A same-session cross-tab rotation keeps the same
-      // clientSessionId and is handled by the verified fast path below — no bump,
+      // clientSessionId and is handled by the verified fast path below - no bump,
       // so it doesn't disturb an in-flight refresh of the very same session.)
       if (prevSession && prevSession.clientSessionId !== this._session.clientSessionId) {
         this._sessionGeneration++;
@@ -3758,27 +3758,27 @@ export class PollarClient {
 
       // DPoP key binding precheck: the persisted session records the thumbprint
       // of the keypair its tokens are bound to (`dpopJkt`, = the token's
-      // `cnf.jkt`). If the keypair we just loaded is a DIFFERENT one — the
+      // `cnf.jkt`). If the keypair we just loaded is a DIFFERENT one - the
       // stored key was lost (IndexedDB evicted, unavailable, or reset by
-      // another tab) and a fresh key was generated — then EVERY proof-bound
+      // another tab) and a fresh key was generated - then EVERY proof-bound
       // call is guaranteed to 401 (`thumbprint-mismatch`): resume, refresh,
       // signing, all of them. Converge to logged-out locally, with a diagnostic
       // that names the real cause, instead of burning a doomed resume round
       // trip that can only fail with an opaque 401. Sessions persisted by older
       // SDKs have no `dpopJkt` and skip
-      // this — their resume decides, as before. If the thumbprint can't be
+      // this - their resume decides, as before. If the thumbprint can't be
       // computed (key manager init failed), skip too: the Bearer fallback may
       // still be able to use the session.
       if (this._session.dpopJkt) {
         // A thumbprint that can't be computed (key manager unavailable) reads
-        // as null and skips the check — the resume path decides, as before.
+        // as null and skips the check - the resume path decides, as before.
         const readJkt = (): Promise<string | null> => this._keyManager.getThumbprint().catch(() => null);
         let currentJkt = await readJkt();
         if (currentJkt !== null && currentJkt !== this._session.dpopJkt && this._keyManager.resync) {
           // The cached key may simply be stale: another tab can rotate the
-          // shared persisted key (logout → fresh login) and then write the
+          // shared persisted key (logout -> fresh login) and then write the
           // session this restore is picking up. Re-read persistent storage
-          // and re-compare before concluding the key is really lost —
+          // and re-compare before concluding the key is really lost -
           // without this, a stale cache would clear the session the other
           // tab just created.
           this._keyManager.resync();
@@ -3795,7 +3795,7 @@ export class PollarClient {
           return;
         }
       }
-      // Only restore an adapter for an EXTERNAL session — those are the only ones
+      // Only restore an adapter for an EXTERNAL session - those are the only ones
       // signed via an adapter. `internal` is custodial (server-signed) and `smart`
       // is passkey-signed; attaching an adapter to either (from a stale walletType
       // row left by a prior external login that was switched away from without a
@@ -3816,11 +3816,11 @@ export class PollarClient {
 
       // Cross-tab token rotation of the SAME already-verified session: another
       // tab just refreshed and wrote a fresh token. The server issued that
-      // token, so the session is still valid — keep `verified: true`, pick up
+      // token, so the session is still valid - keep `verified: true`, pick up
       // the new token, and skip the redundant `/auth/session/resume`. Without
-      // this, every sibling tab's rotation would flap `verified` true→false→true
+      // this, every sibling tab's rotation would flap `verified` true->false->true
       // and fire an extra resume round-trip.
-      // Key on `clientSessionId` — the canonical per-session identity, always
+      // Key on `clientSessionId` - the canonical per-session identity, always
       // present. Do NOT also require `userId`: a valid session can have
       // `userId: null` (isValidSession allows it), and gating on it would make
       // those sessions miss this fast path and keep flapping `verified` on every
@@ -3839,7 +3839,7 @@ export class PollarClient {
       }
 
       // If the stored access token is ALREADY expired, refresh inline BEFORE
-      // surfacing the session — otherwise a consumer reading `session.token` in
+      // surfacing the session - otherwise a consumer reading `session.token` in
       // the optimistic `verified:false` window forwards a token we already know is
       // dead. A successful refresh both rotates the token AND proves the session
       // is alive server-side, so emit `verified:true` and skip the resume.
@@ -3850,7 +3850,7 @@ export class PollarClient {
         try {
           await this.refresh();
         } catch {
-          return; // refresh failed → session was cleared; stay logged out
+          return; // refresh failed -> session was cleared; stay logged out
         }
         if (this._session) {
           this._setAuthState({ step: 'authenticated', session: this._session, verified: true });
@@ -3876,9 +3876,9 @@ export class PollarClient {
       this._log.info('[PollarClient] No session in storage');
       // Another tab (or this one) wiped the session key. If we were
       // authenticated, propagate the logout: tear down in-memory state, the
-      // refresh timer, and emit `idle` (the DPoP keypair survives — see
+      // refresh timer, and emit `idle` (the DPoP keypair survives - see
       // `_clearSession`). Guarded so the cold-start
-      // call (step already `idle`) is a no-op and we never recurse — the
+      // call (step already `idle`) is a no-op and we never recurse - the
       // `removeStorage` inside `_clearSession` targets an already-removed key.
       if (this._authState.step !== 'idle') {
         await this._clearSession();
@@ -3893,20 +3893,20 @@ export class PollarClient {
    * in-flight refresh (onRequest awaits `_refreshPromise`) and, being a GET,
    * is auto-retried after a 401-triggered refresh.
    *
-   * - 200            → store profile, mark the session `verified`.
-   * - 401            → the refresh-on-401 path already ran; if the family was
+   * - 200            -> store profile, mark the session `verified`.
+   * - 401            -> the refresh-on-401 path already ran; if the family was
    *                    revoked, refresh failed and `_clearSession()` took us to
    *                    idle. We also clear here as a belt-and-suspenders.
-   * - 403 / 410      → the session was revoked elsewhere while its access token
-   *                    is still unexpired (so the 401→refresh path never fired).
+   * - 403 / 410      -> the session was revoked elsewhere while its access token
+   *                    is still unexpired (so the 401->refresh path never fired).
    *                    Definitive: converge to logged-out.
-   * - 404/429/5xx    → endpoint mismatch / rate limit / transient: do NOT log
+   * - 404/429/5xx    -> endpoint mismatch / rate limit / transient: do NOT log
    *                    out; keep the optimistic session for a later retry.
-   * - network error  → stay optimistic; revalidated on `visibilitychange`/use.
+   * - network error  -> stay optimistic; revalidated on `visibilitychange`/use.
    */
   private _resume(): Promise<void> {
     // Coalesce: a resume already in flight IS the validation every caller
-    // wants — join it instead of aborting and restarting (which multiplied one
+    // wants - join it instead of aborting and restarting (which multiplied one
     // failure into a burst when the startup restore and visibility handler
     // fired together).
     if (this._resumePromise) return this._resumePromise;
@@ -3920,7 +3920,7 @@ export class PollarClient {
     return this._resumePromise;
   }
 
-  /** Record a retryable resume failure: exponential backoff, 1s → 30s cap. */
+  /** Record a retryable resume failure: exponential backoff, 1s -> 30s cap. */
   private _noteResumeFailure(): void {
     this._resumeFailStreak++;
     const delayMs = Math.min(1_000 * 2 ** (this._resumeFailStreak - 1), 30_000);
@@ -3940,7 +3940,7 @@ export class PollarClient {
     try {
       const { data, error, response } = await this._api.GET('/auth/session/resume', { signal: controller.signal });
       // Bail if the session was cleared/replaced (logout / refresh / new login)
-      // or the client destroyed while resume was in flight — don't emit over, or
+      // or the client destroyed while resume was in flight - don't emit over, or
       // clear, a session that's no longer the one we started with.
       if (this._destroyed || this._sessionGeneration !== gen || !this._session) return;
 
@@ -3964,7 +3964,7 @@ export class PollarClient {
       this._setAuthState({ step: 'authenticated', session: this._session, verified: true });
     } catch (err) {
       if ((err as { name?: string })?.name === 'AbortError') return;
-      // Network failure (no response) — keep the optimistic (unverified) session
+      // Network failure (no response) - keep the optimistic (unverified) session
       // and retry (with backoff) when the app next becomes visible or on the
       // next authed request.
       this._noteResumeFailure();
@@ -4004,14 +4004,14 @@ export class PollarClient {
     // `cnf.jkt`) so a later restore can detect key loss up front instead of
     // discovering it through a burst of thumbprint-mismatch 401s.
     //
-    // Prefer `boundDpopJkt` — the thumbprint of the JWK the login flow ACTUALLY
+    // Prefer `boundDpopJkt` - the thumbprint of the JWK the login flow ACTUALLY
     // sent to /auth/login. Re-reading `getThumbprint()` here records whatever
     // key is loaded NOW, which is the wrong key if it rotated between the bind
     // and this store (a reset racing the login, a cross-tab rotation): the
     // field would then vouch for a key the server never bound, and the restore
     // precheck would wave through a session guaranteed to 401. The fallback
     // read covers the refresh path and custom flows that don't thread the
-    // bound value; best-effort — if the key manager is unavailable (Bearer
+    // bound value; best-effort - if the key manager is unavailable (Bearer
     // fallback), omit the field and the restore-time check is skipped.
     const dpopJkt = boundDpopJkt ?? (await this._keyManager.getThumbprint().catch(() => null));
 
@@ -4023,7 +4023,7 @@ export class PollarClient {
       user: session.user,
       ...(dpopJkt ? { dpopJkt } : {}),
       wallet: toPersistedWallet(session.wallet),
-      // Absent on logins against an sdk-api that predates `wallets[]` — persist
+      // Absent on logins against an sdk-api that predates `wallets[]` - persist
       // nothing rather than an empty array, so consumers can tell "not reported"
       // apart from "genuinely none".
       ...(session.wallets ? { wallets: session.wallets.map(toPersistedWallet) } : {}),
@@ -4048,28 +4048,28 @@ export class PollarClient {
     }
 
     await this._persistSession(gen, persisted);
-    // A logout / destroy / newer login landed DURING the persist await — bail so
+    // A logout / destroy / newer login landed DURING the persist await - bail so
     // we don't emit `authenticated` (resurrecting a session that was just
     // cleared) or re-arm the refresh timer for a session this call no longer
     // owns. Mirrors the generation guard in `_doRefresh`.
     if (this._destroyed || this._sessionGeneration !== gen) return;
     // Drop a stale external adapter when switching to a non-external session
-    // (e.g. external-wallet login → later email/passkey login). The wallet flow
-    // sets `_walletAdapter` BEFORE calling us (storeWalletAdapter → authenticate
-    // → storeSession), so only clear it when the NEW session isn't external —
+    // (e.g. external-wallet login -> later email/passkey login). The wallet flow
+    // sets `_walletAdapter` BEFORE calling us (storeWalletAdapter -> authenticate
+    // -> storeSession), so only clear it when the NEW session isn't external -
     // that preserves the adapter an external login just stored for itself, while
     // fixing getWalletType()/signing reporting a stale wallet after a switch.
     if (persisted.wallet.type !== 'external') {
       this._walletAdapter = null;
     }
     // Account switch without a logout (login-over-login) bypasses _clearSession,
-    // so reset the read/tx stores here too — otherwise the previous user's
+    // so reset the read/tx stores here too - otherwise the previous user's
     // balance/history/tx-state would linger and an in-flight fetch could land
     // their data in the new session's store. On a first login (from idle) the
     // stores are already idle, so this is a harmless no-op.
     this._resetReactiveStores();
     // Fresh login/refresh response came straight from the server, so the
-    // session is already server-validated → `verified: true`.
+    // session is already server-validated -> `verified: true`.
     this._setAuthState({ step: 'authenticated', session: persisted, verified: true });
     this._scheduleNextRefresh();
   }
@@ -4107,14 +4107,14 @@ export class PollarClient {
     // not session-scoped: nothing about a dropped session invalidates the key,
     // and `_clearSession` also runs on failure paths (a rejected resume, a
     // failed refresh, a cross-tab clear, a login attempt superseding another).
-    // Resetting it here made every such failure destructive — any session still
+    // Resetting it here made every such failure destructive - any session still
     // bound to the key (persisted, or a token a consumer held elsewhere) became
     // permanently unverifiable, and a stale clear racing a fresh login could
     // discard the very key the login had just bound (persisting a session that
     // could never resume). The keypair is rotated ONLY on explicit `logout()`.
     // The in-memory CACHE is dropped, though: the persisted key is shared per
     // origin across tabs, and a cross-tab logout (one of the paths that land
-    // here) deletes/rotates it — the next use must re-read storage instead of
+    // here) deletes/rotates it - the next use must re-read storage instead of
     // signing with a stale cached copy. Persistent storage is untouched, so
     // after a same-tab failure clear the next init re-loads the very same key.
     this._keyManager.resync?.();
@@ -4167,8 +4167,8 @@ export class PollarClient {
   /**
    * Single writer for the shared `pollar:<apiKeyHash>:session` row.
    *
-   * Every document on the origin — and every client instance inside one
-   * document — writes that same row, and each mutation is preceded by an await
+   * Every document on the origin - and every client instance inside one
+   * document - writes that same row, and each mutation is preceded by an await
    * (the network round-trip, the storage adapter itself). Without this queue two
    * hazards are reachable:
    *
@@ -4224,7 +4224,7 @@ export class PollarClient {
       try {
         const rowId = (JSON.parse(current) as { clientSessionId?: unknown }).clientSessionId;
         // Membership in the instance's session history, not equality with the
-        // one being cleared — see `_ownedSessionIds` for the race this covers.
+        // one being cleared - see `_ownedSessionIds` for the race this covers.
         owns = typeof rowId === 'string' && (rowId === ownedId || this._ownedSessionIds.has(rowId));
       } catch {
         // Unparseable row inside our own namespace: nobody can use it, so it is
@@ -4267,14 +4267,14 @@ export class PollarClient {
     // signs with, so a subscriber that mutates `state.session.token` would
     // otherwise corrupt it. `getAuthState()` already clones; this makes the
     // push path symmetric. (`@pollar/react` dedupes by value, so a fresh object
-    // per emission is safe — verified no useSyncExternalStore / ref-dedupe.)
+    // per emission is safe - verified no useSyncExternalStore / ref-dedupe.)
     const snapshot = this._cloneAuthState(next);
     for (const cb of this._authStateListeners) cb(snapshot);
   }
 
   private _setTransactionState(next: TransactionState): void {
     // Drop a write from a tx whose session was torn down (logout) or replaced
-    // (new login) after it started — see `_txStartGen`.
+    // (new login) after it started - see `_txStartGen`.
     if (this._sessionGeneration !== this._txStartGen) return;
     this._transactionState = next;
     this._log.debug(`[PollarClient] transaction:${next.step}`);
@@ -4284,8 +4284,8 @@ export class PollarClient {
   /**
    * Reset the tx store + the 4 reactive read stores (txHistory / balance /
    * assets / sessions) to idle and bump their generations. Called on ANY session
-   * change — logout (`_clearSession`) AND login-over-login (`_storeSession`, a
-   * no-logout account switch) — so the previous user's balance/history/sessions
+   * change - logout (`_clearSession`) AND login-over-login (`_storeSession`, a
+   * no-logout account switch) - so the previous user's balance/history/sessions
    * and the last tx's terminal state can't linger or be repopulated by an
    * in-flight fetch that resolves into the new session's store.
    *
@@ -4322,7 +4322,7 @@ export class PollarClient {
     // (`_resetReactiveStores`), so without this a standalone signTx/submitTx
     // (no preceding buildTx) would thread the previous tx's buildData into the
     // new one - mislabeling its UI summary. Only carry buildData forward from
-    // live, in-progress steps; the composed paths (buildTx→signTx→submitTx) read
+    // live, in-progress steps; the composed paths (buildTx->signTx->submitTx) read
     // it while non-terminal (`built`/`signed`), so they're unaffected.
     if (s.step === 'success' || s.step === 'submitted' || s.step === 'error') return undefined;
     if ('buildData' in s && s.buildData) return s.buildData;

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -241,6 +241,18 @@ export class PollarClient {
    * writes cannot land out of order. See `_persistSession`.
    */
   private _persistQueue: Promise<void> = Promise.resolve();
+  /**
+   * Every `clientSessionId` this instance has held (stored OR restored),
+   * newest last, capped. Ownership for removing the shared session row is
+   * membership here, not equality with the CURRENT session: a logout that
+   * races a login-over-login can find the row still holding this client's
+   * PREVIOUS session (its replacement write was superseded in the persist
+   * queue), and that row is this client's to remove — leaving it behind would
+   * restore the old, never-revoked session on the next reload. Rows from
+   * sessions this instance never held (another document's or instance's newer
+   * login) are still protected: they are never in this set.
+   */
+  private readonly _ownedSessionIds = new Set<string>();
   /** Set by `destroy()`; short-circuits timer re-arming and any post-teardown work. */
   private _destroyed = false;
   private _storageEventHandler: ((e: StorageEvent) => void) | null = null;
@@ -448,21 +460,30 @@ export class PollarClient {
 
     // N4: warn (don't throw — that would break StrictMode double-mounts / HMR)
     // when a second live client exists for this API key.
-    let liveSet = liveClientsByApiKey.get(this.apiKey);
-    if (!liveSet) {
-      liveSet = new Map<PollarClient, () => void>();
-      liveClientsByApiKey.set(this.apiKey, liveSet);
-    }
-    // Register a closure rather than the instance method so the handler stays
-    // private to the class.
-    liveSet.set(this, () => this._onSiblingSessionCleared());
-    if (liveSet.size > 1) {
-      this._log.warn(
-        '[PollarClient] Another PollarClient is already active for this API key. Multiple ' +
-          'instances share one persisted session + DPoP key and run independent refresh loops; ' +
-          'the single-use refresh-token rotation will trip server-side reuse-detection and log ' +
-          'all of them out. Create one client per API key and reuse it (e.g. a module singleton).',
-      );
+    //
+    // Client runtimes only, matching the deregistration in `destroy()` — the
+    // old unconditional registration leaked an entry (and its notify closure)
+    // per server-side client, since those never deregistered. Server-rendered
+    // code also legitimately builds one client per request, so the "multiple
+    // live clients" warning is only meaningful where instances actually share
+    // persisted state and refresh loops: the browser / RN.
+    if (isClientRuntime) {
+      let liveSet = liveClientsByApiKey.get(this.apiKey);
+      if (!liveSet) {
+        liveSet = new Map<PollarClient, () => void>();
+        liveClientsByApiKey.set(this.apiKey, liveSet);
+      }
+      // Register a closure rather than the instance method so the handler stays
+      // private to the class.
+      liveSet.set(this, () => this._onSiblingSessionCleared());
+      if (liveSet.size > 1) {
+        this._log.warn(
+          '[PollarClient] Another PollarClient is already active for this API key. Multiple ' +
+            'instances share one persisted session + DPoP key and run independent refresh loops; ' +
+            'the single-use refresh-token rotation will trip server-side reuse-detection and log ' +
+            'all of them out. Create one client per API key and reuse it (e.g. a module singleton).',
+        );
+      }
     }
 
     // N5: on a non-browser client runtime (React Native) the default visibility
@@ -1517,6 +1538,22 @@ export class PollarClient {
       }
     }
 
+    // A newer session landed while we were awaiting the server revocation (a
+    // login started after this logout, or a cross-tab login this client
+    // adopted). It is not ours to tear down, and the user asked for it more
+    // recently than they asked for this logout - the server-side revocation of
+    // the OLD session already happened, so stop here rather than destroying
+    // state we no longer own. This guard sits BEFORE the adapter disconnect on
+    // purpose: registered adapters are per-type singletons, so the "old"
+    // adapter reference can be the very instance the new login is now using —
+    // disconnecting it would cut the new session's provider connection and
+    // break external signing. When superseded, the old provider session is
+    // left alone: it is either in use by the new login or benign to keep.
+    if (this._destroyed || this._sessionGeneration !== gen) {
+      this._log.info('[PollarClient] Logout superseded by a newer session; leaving it in place');
+      return;
+    }
+
     // Tear down the active wallet adapter's own provider session (e.g. Privy)
     // on an explicit logout. `_clearSession()` only drops the in-memory adapter
     // reference; without this, the provider session persists across a reload and
@@ -1532,16 +1569,13 @@ export class PollarClient {
       } catch (err) {
         this._log.warn('[PollarClient] Wallet adapter disconnect during logout failed', err);
       }
-    }
-
-    // A newer session landed while we were awaiting above (a login started
-    // after this logout, or a cross-tab login this client adopted). It is not
-    // ours to tear down, and the user asked for it more recently than they
-    // asked for this logout - the server-side revocation already happened, so
-    // stop here rather than destroying state we no longer own.
-    if (this._destroyed || this._sessionGeneration !== gen) {
-      this._log.info('[PollarClient] Logout superseded by a newer session; leaving it in place');
-      return;
+      // Re-check after the disconnect await too: a login that completed during
+      // it owns the state from here on (its own storeSession already replaced
+      // the row), so the clear + key rotation below are no longer ours to run.
+      if (this._destroyed || this._sessionGeneration !== gen) {
+        this._log.info('[PollarClient] Logout superseded during adapter disconnect; leaving the new session in place');
+        return;
+      }
     }
 
     let droppedOwnRow = false;
@@ -3657,6 +3691,7 @@ export class PollarClient {
     const prevSession = this._session;
     this._session = await readStorage(this._storage, this.apiKeyHash, this._log);
     if (this._session) {
+      this._recordOwnedSession(this._session.clientSessionId);
       // A DIFFERENT session was restored (e.g. a cross-tab login as another user
       // overwrote storage): invalidate any refresh/resume still in flight against
       // the OLD session, so its rotated token can't be written over the
@@ -3946,6 +3981,7 @@ export class PollarClient {
     this._resetResumeBackoff();
     const gen = this._sessionGeneration;
     this._session = persisted;
+    this._recordOwnedSession(persisted.clientSessionId);
 
     if (session.data) {
       this._profile = {
@@ -4088,6 +4124,16 @@ export class PollarClient {
    *
    * Returns whether the mutation was applied.
    */
+  /** Record a session this instance held; bounded so a long-lived SPA cannot grow it unboundedly. */
+  private _recordOwnedSession(id: string): void {
+    if (this._ownedSessionIds.has(id)) return;
+    this._ownedSessionIds.add(id);
+    if (this._ownedSessionIds.size > 10) {
+      const oldest = this._ownedSessionIds.values().next().value;
+      if (oldest !== undefined) this._ownedSessionIds.delete(oldest);
+    }
+  }
+
   private async _persistSession(
     gen: number,
     session: PollarPersistedSession | null,
@@ -4116,7 +4162,10 @@ export class PollarClient {
       if (current === null) return false;
       let owns: boolean;
       try {
-        owns = (JSON.parse(current) as { clientSessionId?: unknown }).clientSessionId === ownedId;
+        const rowId = (JSON.parse(current) as { clientSessionId?: unknown }).clientSessionId;
+        // Membership in the instance's session history, not equality with the
+        // one being cleared — see `_ownedSessionIds` for the race this covers.
+        owns = typeof rowId === 'string' && (rowId === ownedId || this._ownedSessionIds.has(rowId));
       } catch {
         // Unparseable row inside our own namespace: nobody can use it, so it is
         // ours to clean up.

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -200,8 +200,15 @@ const POLLAR_CLIENT_BRAND = Symbol.for('@pollar/core.PollarClient');
  * Is this a `PollarClient`, including one built by another copy of the module?
  *
  * Prefer this over `instanceof PollarClient` anywhere the value may have crossed
- * a package boundary. Tries `instanceof` first, so it still recognises an
- * instance from a build that predates the brand.
+ * a package boundary. The brand is what does the work here: inside a single copy
+ * the two checks always agree, because this constructor stamps every instance it
+ * builds; across copies - a duplicated install, an iframe, a module swapped by
+ * HMR - `instanceof` is always false and the brand is the only thing that
+ * identifies the value. (An instance from a build older than the brand is, by
+ * definition, from another copy: it fails both checks, and no ordering here
+ * changes that.) `instanceof` stays first because it is the canonical identity
+ * test and keeps this guard's answer identical to the bare `instanceof` it
+ * replaced at every call site.
  */
 export function isPollarClient(value: unknown): value is PollarClient {
   if (value instanceof PollarClient) return true;
@@ -4117,17 +4124,19 @@ export class PollarClient {
     // so the stored one stays usable across page loads and saves the guaranteed
     // `use_dpop_nonce` 401 on the next first proof. See `dpopNonceStorageKey`.
     const droppedOwnRow = await this._persistSession(gen, null, owned);
-    // Same-document siblings never see the `storage` event this removal emits -
-    // browsers fire it only at OTHER documents. Tell them directly, so a second
-    // instance in this document (a React StrictMode double-invoked `useState`
-    // initializer leaves one behind, and it is never destroyed) converges to
-    // logged-out instead of re-persisting its own copy of the session a moment
-    // later. Mirrors exactly what the cross-document handler does.
     this._resetReactiveStores();
     this._setAuthState({ step: 'idle' });
-    // Announce only once this client's own teardown is complete. Telling the
-    // siblings first put their handlers between us and our terminal state, so
-    // anything that went wrong in one of them left this client mid-teardown.
+    // Only now tell the same-document siblings, and only if we actually dropped
+    // the shared row. They never see the `storage` event that removal emits -
+    // browsers fire it at OTHER documents only - so a second instance in this
+    // document would otherwise keep its session and re-persist the row a moment
+    // later. (`PollarProvider` no longer leaves one behind under StrictMode, but
+    // a consumer can still hold two clients, and non-React callers always
+    // could.) This mirrors the cross-document handler.
+    //
+    // It runs AFTER the teardown above on purpose: announcing first put the
+    // siblings' handlers between this client and its own terminal state, so
+    // anything that went wrong inside one of them left this client mid-teardown.
     if (droppedOwnRow) notifySiblingClients(this, this.apiKey, this._log);
     return droppedOwnRow;
   }

--- a/packages/core/src/client/session.ts
+++ b/packages/core/src/client/session.ts
@@ -19,9 +19,26 @@ import type { PollarPersistedSession } from '../types';
 
 const SESSION_SUFFIX = ':session';
 const WALLET_TYPE_SUFFIX = ':walletType';
+const DPOP_NONCE_SUFFIX = ':dpopNonce';
 
 export function sessionStorageKey(apiKeyHash: string): string {
   return `pollar:${apiKeyHash}${SESSION_SUFFIX}`;
+}
+
+/**
+ * Key for the last server-issued `DPoP-Nonce`.
+ *
+ * Deliberately NOT removed by `removeStorage`: the nonce is origin-scoped
+ * server state, not session state. It is a stateless HMAC that sdk-api accepts
+ * for days (24h active + a 3-day rotation overlap, see its lib/dpop-nonce.ts),
+ * carries no user identity and grants nothing on its own, so keeping it across
+ * page loads and logouts is safe - and it spares every cold start the
+ * guaranteed 401 `use_dpop_nonce` challenge it otherwise pays before its first
+ * authenticated request. A stale one costs exactly what having none costs: the
+ * server answers with a fresh nonce and the middleware retries once.
+ */
+export function dpopNonceStorageKey(apiKeyHash: string): string {
+  return `pollar:${apiKeyHash}${DPOP_NONCE_SUFFIX}`;
 }
 
 export function walletTypeStorageKey(apiKeyHash: string): string {
@@ -40,6 +57,8 @@ const MAX_WALLET_PUBLIC_KEY = 128;
 const MAX_WALLET_TYPE = 32;
 // base64url(SHA-256) is exactly 43 chars; bound with headroom.
 const MAX_DPOP_JKT = 64;
+/** Bounds what we accept back from storage as a nonce (sdk-api mints ~70 chars). */
+export const MAX_DPOP_NONCE = 512;
 // One wallet per supported chain, with headroom. Bounds the persisted blob so a
 // hostile or buggy `wallets[]` can't blow up storage or the validation loop.
 const MAX_WALLETS = 16;

--- a/packages/core/src/client/session.ts
+++ b/packages/core/src/client/session.ts
@@ -6,7 +6,7 @@ import type { PollarPersistedSession } from '../types';
  * Persisted session shape (stored via the injected `Storage` adapter).
  *
  * Compared to the full `/auth/login` response:
- *   - `data.{mail,first_name,last_name,avatar,providers}` is dropped — that
+ *   - `data.{mail,first_name,last_name,avatar,providers}` is dropped - that
  *     PII is held in memory only on `PollarClient`, fetched from
  *     `/applications/config` after auth.
  *   - All string fields are length-bounded as defense-in-depth: even though
@@ -68,7 +68,7 @@ const KNOWN_CHAINS = new Set(['STELLAR', 'POLYGON', 'SOLANA']);
 
 /**
  * "Does this build understand the entry at all?" Deliberately NOT the full
- * shape guard — it looks only at the two closed vocabularies a newer server can
+ * shape guard - it looks only at the two closed vocabularies a newer server can
  * extend (`type`, `chain`), so `readStorage` can prune entries from the future
  * instead of failing validation on the whole session.
  */
@@ -126,7 +126,7 @@ export function isValidSession(value: unknown, logger: PollarLogger = console): 
   }
 
   // Optional DPoP key binding (see PollarPersistedSession.dpopJkt). Absent on
-  // sessions persisted by older SDKs — never required.
+  // sessions persisted by older SDKs - never required.
   if (s['dpopJkt'] !== undefined && !isBoundedString(s['dpopJkt'], MAX_DPOP_JKT)) {
     logger.debug('[PollarClient:session] Invalid session — dpopJkt must be a non-empty string if present');
     return false;
@@ -154,12 +154,12 @@ export function isValidSession(value: unknown, logger: PollarLogger = console): 
   // This guard runs against BOTH the persisted shape and the raw `/auth/login`
   // wire response; both speak the same vocabulary (`internal`), so no alias is
   // accepted here. Sessions persisted by older SDKs carry the legacy
-  // `'custodial'` type and a legacy `publicKey` alias — `readStorage` remaps
+  // `'custodial'` type and a legacy `publicKey` alias - `readStorage` remaps
   // the type and backfills `address` before validation, so those upgrade
   // instead of being rejected.
   if (!isValidWallet(s['wallet'], 'wallet', logger)) return false;
 
-  // `wallets` is optional — sessions persisted before the field existed, and
+  // `wallets` is optional - sessions persisted before the field existed, and
   // logins against an sdk-api that predates it, simply have none. When present
   // it must be a bounded array whose entries satisfy the same shape as
   // `wallet`, so a caller reading either field gets the same guarantees.
@@ -233,7 +233,7 @@ export async function readStorage(
 
   try {
     const session = JSON.parse(raw) as unknown;
-    // Migrate sessions persisted by older SDKs (≤0.8.x): they stored the wallet
+    // Migrate sessions persisted by older SDKs (<=0.8.x): they stored the wallet
     // address under the legacy `publicKey` key, and persisted the old wire type
     // `'custodial'` (the wire now emits `'internal'` directly). Backfill
     // `address` and remap the type so they pass validation and survive the
@@ -246,8 +246,8 @@ export async function readStorage(
       if (w && w['type'] === 'custodial') {
         w['type'] = 'internal';
       }
-      // Forward compatibility: a row written by a NEWER SDK — or by a login
-      // against a newer sdk-api — can carry `wallets[]` entries for a chain or
+      // Forward compatibility: a row written by a NEWER SDK - or by a login
+      // against a newer sdk-api - can carry `wallets[]` entries for a chain or
       // wallet type this build does not model. Pruning the unknown entries keeps
       // the session usable; rejecting the whole row would strand the user
       // logged-out on nothing worse than a vocabulary it has never seen.
@@ -265,14 +265,14 @@ export async function readStorage(
     if (!isValidSession(session, logger)) {
       // Deliberately NOT removed. The row is shared by every document on the
       // origin, and in a browser the removal emits a `storage` event that tears
-      // the session down in all of them — so one document running an older
+      // the session down in all of them - so one document running an older
       // build, or hitting a bound, would log everybody out. A row this build
       // cannot read is simply ignored; the next login overwrites it.
       logger.warn('[PollarClient:session] Stored session is invalid — ignoring it (left in storage)');
       return null;
     }
     if (session.token.expiresAt * 1000 < Date.now()) {
-      // AT expired — keep the session row so we can attempt /refresh; the
+      // AT expired - keep the session row so we can attempt /refresh; the
       // caller's refresh path will clear if refresh itself fails.
       return session;
     }

--- a/packages/core/src/client/session.ts
+++ b/packages/core/src/client/session.ts
@@ -57,7 +57,7 @@ const MAX_WALLET_PUBLIC_KEY = 128;
 const MAX_WALLET_TYPE = 32;
 // base64url(SHA-256) is exactly 43 chars; bound with headroom.
 const MAX_DPOP_JKT = 64;
-/** Bounds what we accept back from storage as a nonce (sdk-api mints ~70 chars). */
+/** Bounds what we accept back from storage as a nonce (sdk-api mints ~60 chars). */
 export const MAX_DPOP_NONCE = 512;
 // One wallet per supported chain, with headroom. Bounds the persisted blob so a
 // hostile or buggy `wallets[]` can't blow up storage or the validation loop.

--- a/packages/core/src/client/session.ts
+++ b/packages/core/src/client/session.ts
@@ -35,6 +35,8 @@ const MAX_CLIENT_SESSION_ID = 64;
 const MAX_STATUS = 64;
 const MAX_WALLET_PUBLIC_KEY = 128;
 const MAX_WALLET_TYPE = 32;
+// base64url(SHA-256) is exactly 43 chars; bound with headroom.
+const MAX_DPOP_JKT = 64;
 // One wallet per supported chain, with headroom. Bounds the persisted blob so a
 // hostile or buggy `wallets[]` can't blow up storage or the validation loop.
 const MAX_WALLETS = 16;
@@ -81,6 +83,13 @@ export function isValidSession(value: unknown, logger: PollarLogger = console): 
   }
   if (typeof t['expiresAt'] !== 'number' || !Number.isFinite(t['expiresAt'])) {
     logger.debug('[PollarClient:session] Invalid session — token.expiresAt must be a finite number');
+    return false;
+  }
+
+  // Optional DPoP key binding (see PollarPersistedSession.dpopJkt). Absent on
+  // sessions persisted by older SDKs — never required.
+  if (s['dpopJkt'] !== undefined && !isBoundedString(s['dpopJkt'], MAX_DPOP_JKT)) {
+    logger.debug('[PollarClient:session] Invalid session — dpopJkt must be a non-empty string if present');
     return false;
   }
 

--- a/packages/core/src/client/session.ts
+++ b/packages/core/src/client/session.ts
@@ -28,8 +28,11 @@ export function walletTypeStorageKey(apiKeyHash: string): string {
   return `pollar:${apiKeyHash}${WALLET_TYPE_SUFFIX}`;
 }
 
-const MAX_ACCESS_TOKEN = 4096;
-const MAX_REFRESH_TOKEN = 4096;
+// Bounds are defense-in-depth against a hostile/buggy blob, not a spec limit:
+// exceeding one makes the whole session unreadable, so leave real headroom over
+// the ~1-2 KB a DPoP-bound JWT actually costs.
+const MAX_ACCESS_TOKEN = 8192;
+const MAX_REFRESH_TOKEN = 8192;
 const MAX_USER_ID = 64;
 const MAX_CLIENT_SESSION_ID = 64;
 const MAX_STATUS = 64;
@@ -40,6 +43,23 @@ const MAX_DPOP_JKT = 64;
 // One wallet per supported chain, with headroom. Bounds the persisted blob so a
 // hostile or buggy `wallets[]` can't blow up storage or the validation loop.
 const MAX_WALLETS = 16;
+
+const KNOWN_WALLET_TYPES = new Set(['internal', 'smart', 'external']);
+const KNOWN_CHAINS = new Set(['STELLAR', 'POLYGON', 'SOLANA']);
+
+/**
+ * "Does this build understand the entry at all?" Deliberately NOT the full
+ * shape guard — it looks only at the two closed vocabularies a newer server can
+ * extend (`type`, `chain`), so `readStorage` can prune entries from the future
+ * instead of failing validation on the whole session.
+ */
+function isKnownWalletShape(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const w = value as Record<string, unknown>;
+  if (typeof w['type'] === 'string' && !KNOWN_WALLET_TYPES.has(w['type'])) return false;
+  if (typeof w['chain'] === 'string' && !KNOWN_CHAINS.has(w['chain'])) return false;
+  return true;
+}
 
 function isBoundedString(v: unknown, max: number, allowEmpty = false): v is string {
   if (typeof v !== 'string') return false;
@@ -207,10 +227,29 @@ export async function readStorage(
       if (w && w['type'] === 'custodial') {
         w['type'] = 'internal';
       }
+      // Forward compatibility: a row written by a NEWER SDK — or by a login
+      // against a newer sdk-api — can carry `wallets[]` entries for a chain or
+      // wallet type this build does not model. Pruning the unknown entries keeps
+      // the session usable; rejecting the whole row would strand the user
+      // logged-out on nothing worse than a vocabulary it has never seen.
+      const list = (session as { wallets?: unknown }).wallets;
+      if (Array.isArray(list)) {
+        const known = list.filter((entry) => isKnownWalletShape(entry));
+        if (known.length !== list.length) {
+          logger.warn('[PollarClient:session] Pruned wallets[] entries this SDK does not recognize', {
+            dropped: list.length - known.length,
+          });
+          (session as { wallets?: unknown }).wallets = known;
+        }
+      }
     }
     if (!isValidSession(session, logger)) {
-      await storage.remove(sessionStorageKey(apiKeyHash));
-      logger.warn('[PollarClient:session] Stored session is invalid — clearing storage');
+      // Deliberately NOT removed. The row is shared by every document on the
+      // origin, and in a browser the removal emits a `storage` event that tears
+      // the session down in all of them — so one document running an older
+      // build, or hitting a bound, would log everybody out. A row this build
+      // cannot read is simply ignored; the next login overwrites it.
+      logger.warn('[PollarClient:session] Stored session is invalid — ignoring it (left in storage)');
       return null;
     }
     if (session.token.expiresAt * 1000 < Date.now()) {
@@ -220,8 +259,9 @@ export async function readStorage(
     }
     return session;
   } catch (error) {
+    // Same reasoning as the invalid-session branch: never delete a shared row we
+    // merely failed to read.
     logger.error('[PollarClient:session] Failed to parse session from storage', error);
-    await storage.remove(sessionStorageKey(apiKeyHash));
     return null;
   }
 }

--- a/packages/core/src/client/stream.ts
+++ b/packages/core/src/client/stream.ts
@@ -108,7 +108,7 @@ export async function streamUntilFound(
           try {
             parsed = JSON.parse(dataLine.slice('data:'.length).trim());
           } catch {
-            // partial chunk — keep reading
+            // partial chunk - keep reading
             continue;
           }
           // Terminal `error` event (invalid / expired session): stop and surface.
@@ -134,8 +134,8 @@ export async function streamUntilFound(
 
     // Always wait the computed backoff before reconnecting. A data-bearing
     // close already reset it to the floor (retryDelayMs), so the happy-path
-    // reconnect stays snappy; the failure paths — including a mid-stream read
-    // error caught above — now back off instead of spinning in a tight
+    // reconnect stays snappy; the failure paths - including a mid-stream read
+    // error caught above - now back off instead of spinning in a tight
     // reconnect loop that hammers the server.
     await sleep(backoff);
   }
@@ -192,7 +192,7 @@ export async function pollUntilFound(
     }
 
     // Terminal: the session is gone (404 / INVALID) or expired (410 / EXPIRED).
-    // It can never become ready, so stop and surface — the caller resets the
+    // It can never become ready, so stop and surface - the caller resets the
     // login to an error state. Mirrors the SSE stream's terminal `error` events.
     if (httpStatus === 404 || envelope?.code === 'INVALID_CLIENT_SESSION_ID') {
       throw new SessionStatusError('INVALID_CLIENT_SESSION_ID');

--- a/packages/core/src/dpop.ts
+++ b/packages/core/src/dpop.ts
@@ -12,7 +12,7 @@ import type { KeyManager, PublicEcJwk } from './keys/types';
  * `iat` / `jti` / optional `nonce` / optional `ath` claims, and matches the
  * proof's JWK thumbprint against the access token's `cnf.jkt` claim.
  *
- * Server-issued nonce flow (RFC 9449 §8/§9): the server may respond with
+ * Server-issued nonce flow (RFC 9449 section 8/section 9): the server may respond with
  * `WWW-Authenticate: DPoP ... error="use_dpop_nonce"` plus a `DPoP-Nonce`
  * header. The client should re-build the proof with the new nonce and retry.
  * `buildProof` accepts an optional nonce; the SDK client tracks it across
@@ -20,7 +20,7 @@ import type { KeyManager, PublicEcJwk } from './keys/types';
  *
  * The last seen `DPoP-Nonce` is stored verbatim and embedded in the next
  * proof. The server validates it as an HMAC token, so an attacker who
- * injects an arbitrary nonce cannot escalate — verification fails and the
+ * injects an arbitrary nonce cannot escalate - verification fails and the
  * server replies with a fresh nonce on the next request.
  */
 
@@ -28,7 +28,7 @@ export interface BuildProofArgs {
   /** HTTP method, e.g. `"GET"`. Will be uppercased before signing. */
   htm: string;
   /**
-   * HTTP target URI. Will be normalized per RFC 3986 §6.2 (lowercase scheme
+   * HTTP target URI. Will be normalized per RFC 3986 section 6.2 (lowercase scheme
    * + host, default port elided, query+fragment+userinfo stripped, path
    * dot-segments resolved, trailing slash preserved exactly as provided).
    */
@@ -36,18 +36,18 @@ export interface BuildProofArgs {
   /**
    * Access token to bind the proof to (its base64url(SHA-256) goes in the
    * `ath` claim). Omit for proofs sent to the token endpoint per RFC 9449
-   * §5 / §6.1 (those proofs MUST NOT include `ath`).
+   * section 5 / section 6.1 (those proofs MUST NOT include `ath`).
    */
   accessToken?: string;
   /**
    * Server-issued DPoP nonce, if the server has previously challenged this
    * client with `WWW-Authenticate: DPoP ... error="use_dpop_nonce"`. RFC
-   * 9449 §8.
+   * 9449 section 8.
    */
   nonce?: string;
   /**
    * Seconds to add to the local clock when stamping `iat`, to compensate for a
-   * skewed device clock (`serverTime − localTime`, learned from the `Date`
+   * skewed device clock (`serverTime - localTime`, learned from the `Date`
    * response header). Defaults to 0. Keeps `iat` inside the server's acceptance
    * window even when the device clock is wrong, avoiding proof rejections.
    */
@@ -114,14 +114,14 @@ export async function buildProof(args: BuildProofArgs, keyManager: KeyManager): 
 /**
  * Normalize an HTTP URI for use as the `htu` claim.
  *
- * RFC 9449 §4.3 + RFC 3986 §6.2:
+ * RFC 9449 section 4.3 + RFC 3986 section 6.2:
  *  - lowercase scheme + host
  *  - elide default port (`:443` for https, `:80` for http)
  *  - strip userinfo (never appears in `htu`)
  *  - strip query + fragment
  *  - apply path dot-segment removal (handled by the URL constructor)
- *  - **preserve trailing slash exactly** — `/foo` and `/foo/` are distinct
- *    paths per RFC 3986 §6 and must round-trip identically.
+ *  - **preserve trailing slash exactly** - `/foo` and `/foo/` are distinct
+ *    paths per RFC 3986 section 6 and must round-trip identically.
  *  - preserve IPv6 brackets in host
  *
  * Both client and server must apply the same normalization so the `htu`

--- a/packages/core/src/index.rn.ts
+++ b/packages/core/src/index.rn.ts
@@ -3,15 +3,15 @@
 // SecureStore).
 //
 // Why not WebCrypto, even when `crypto.subtle` is present? A polyfill like
-// react-native-quick-crypto exposes `crypto.subtle.generateKey/sign`, which
-// previously made this factory pick `WebCryptoKeyManager`. But that manager
-// persists the keypair in IndexedDB and generates non-extractable keys — and
-// in React Native there is no IndexedDB AND non-extractable keys can't be
-// serialized to the Storage adapter. The result was a brand-new DPoP keypair
-// on every app launch → the JWK thumbprint changed each start → every
-// sender-constrained access/refresh token was rejected → forced logout loop.
-// Noble persists the 32-byte private scalar through `Storage`, so the key
-// survives restarts. On RN, Noble is the only manager that can persist.
+// react-native-quick-crypto exposes `crypto.subtle.generateKey/sign`, but
+// `WebCryptoKeyManager` persists the keypair in IndexedDB and generates
+// non-extractable keys - and in React Native there is no IndexedDB AND
+// non-extractable keys can't be serialized to the Storage adapter. Picking it
+// here would mean a brand-new DPoP keypair on every app launch: the JWK
+// thumbprint changes each start, so every sender-constrained access/refresh
+// token gets rejected - a forced logout loop. Noble persists the 32-byte
+// private scalar through `Storage`, so the key survives restarts. On RN,
+// Noble is the only manager that can persist.
 //
 // Resolved automatically by Metro and other RN-aware bundlers via the
 // `"react-native"` condition in `package.json#exports`.

--- a/packages/core/src/keys/factory.ts
+++ b/packages/core/src/keys/factory.ts
@@ -28,7 +28,7 @@ export function _setDefaultKeyManagerFactory(factory: KeyManagerFactory): void {
 
 /**
  * Construct the default `KeyManager` for the current runtime. Throws if no
- * factory has been registered — that only happens if `@pollar/core` was
+ * factory has been registered - that only happens if `@pollar/core` was
  * imported in a way that bypassed the entry-point module (a bundler or
  * test setup bug).
  */

--- a/packages/core/src/keys/noble.ts
+++ b/packages/core/src/keys/noble.ts
@@ -122,6 +122,36 @@ export class NobleKeyManager implements KeyManager {
     this._initPromise = null;
   }
 
+  /**
+   * Re-persist the private scalar and verify it actually landed in storage.
+   * Mirrors `WebCryptoKeyManager.ensurePersisted` — see there for rationale.
+   * Returns `false` when the adapter can't durably hold the key, so the login
+   * flow can warn that the session will not survive a relaunch.
+   */
+  async ensurePersisted(): Promise<boolean> {
+    if (!this.privateKey) await this.init();
+    if (!this.privateKey) return false;
+    try {
+      const encoded = base64urlEncode(this.privateKey);
+      await this.storage.set(this.storageKey, encoded);
+      return (await this.storage.get(this.storageKey)) === encoded;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Drop the in-memory cache; the next operation re-runs `init()` and adopts
+   * whatever the storage adapter holds. Never touches persistent storage —
+   * that's `reset()`. Mirrors `WebCryptoKeyManager.resync`.
+   */
+  resync(): void {
+    this.privateKey = null;
+    this.publicJwk = null;
+    this.thumbprint = null;
+    this._initPromise = null;
+  }
+
   async getPublicJwk(): Promise<PublicEcJwk> {
     if (!this.publicJwk) await this.init();
     if (!this.publicJwk) {

--- a/packages/core/src/keys/noble.ts
+++ b/packages/core/src/keys/noble.ts
@@ -25,7 +25,8 @@ import type { KeyManager, PublicEcJwk } from './types';
  * the key inside Secure Enclave / StrongBox (planned for a future minor).
  */
 
-/** Base64url-encoded private scalar (32 bytes → ~43 chars). */
+// Prefix of the storage key; the value stored under it is the base64url-encoded
+// private scalar (32 bytes -> ~43 chars).
 const STORAGE_KEY_PREFIX = 'pollar:dpop-key:';
 
 export class NobleKeyManager implements KeyManager {

--- a/packages/core/src/keys/noble.ts
+++ b/packages/core/src/keys/noble.ts
@@ -11,7 +11,7 @@ import type { KeyManager, PublicEcJwk } from './types';
  * `Storage` adapter. Used in React Native, where `WebCryptoKeyManager` can't
  * be: its non-extractable keys can't be serialized to the `Storage` adapter
  * (and RN has no IndexedDB), so the keypair would be regenerated every launch
- * — see the rationale in `index.rn.ts`. The 32-byte private scalar is
+ * - see the rationale in `index.rn.ts`. The 32-byte private scalar is
  * base64url-encoded and stored through the `Storage` adapter (Keychain /
  * SecureStore in production).
  *
@@ -36,7 +36,7 @@ export class NobleKeyManager implements KeyManager {
   private privateKey: Uint8Array | null = null;
   private publicJwk: PublicEcJwk | null = null;
   private thumbprint: string | null = null;
-  /** Cached in-flight init — see `WebCryptoKeyManager` for the rationale. */
+  /** Cached in-flight init - see `WebCryptoKeyManager` for the rationale. */
   private _initPromise: Promise<void> | null = null;
 
   constructor(storage: Storage, apiKey: string) {
@@ -56,7 +56,7 @@ export class NobleKeyManager implements KeyManager {
    * the manager is self-healing if `init()` was never explicitly invoked.
    */
   async init(): Promise<void> {
-    // All three fields, not just the scalar — see `WebCryptoKeyManager.init`:
+    // All three fields, not just the scalar - see `WebCryptoKeyManager.init`:
     // `_doInit` assigns `privateKey`/`publicJwk` and only then awaits the
     // thumbprint, so a caller in that window must join the in-flight init
     // instead of early-returning into a half-built manager.
@@ -64,7 +64,7 @@ export class NobleKeyManager implements KeyManager {
     if (!this._initPromise) {
       this._initPromise = this._doInit().catch((err) => {
         // Clear the promise so the next call retries. The error propagates to
-        // the caller — `PollarClient` logs it through its configured logger, so
+        // the caller - `PollarClient` logs it through its configured logger, so
         // we don't double-log (raw, ungated) here.
         this._initPromise = null;
         throw err;
@@ -129,7 +129,7 @@ export class NobleKeyManager implements KeyManager {
 
   /**
    * Re-persist the private scalar and verify it actually landed in storage.
-   * Mirrors `WebCryptoKeyManager.ensurePersisted` — see there for rationale.
+   * Mirrors `WebCryptoKeyManager.ensurePersisted` - see there for rationale.
    * Returns `false` when the adapter can't durably hold the key, so the login
    * flow can warn that the session will not survive a relaunch.
    */
@@ -147,7 +147,7 @@ export class NobleKeyManager implements KeyManager {
 
   /**
    * Drop the in-memory cache; the next operation re-runs `init()` and adopts
-   * whatever the storage adapter holds. Never touches persistent storage —
+   * whatever the storage adapter holds. Never touches persistent storage -
    * that's `reset()`. Mirrors `WebCryptoKeyManager.resync`.
    */
   resync(): void {

--- a/packages/core/src/keys/noble.ts
+++ b/packages/core/src/keys/noble.ts
@@ -55,7 +55,11 @@ export class NobleKeyManager implements KeyManager {
    * the manager is self-healing if `init()` was never explicitly invoked.
    */
   async init(): Promise<void> {
-    if (this.privateKey) return;
+    // All three fields, not just the scalar — see `WebCryptoKeyManager.init`:
+    // `_doInit` assigns `privateKey`/`publicJwk` and only then awaits the
+    // thumbprint, so a caller in that window must join the in-flight init
+    // instead of early-returning into a half-built manager.
+    if (this.privateKey && this.publicJwk && this.thumbprint) return;
     if (!this._initPromise) {
       this._initPromise = this._doInit().catch((err) => {
         // Clear the promise so the next call retries. The error propagates to

--- a/packages/core/src/keys/thumbprint.ts
+++ b/packages/core/src/keys/thumbprint.ts
@@ -5,7 +5,7 @@ import type { PublicEcJwk } from './types';
 /**
  * Compute the RFC 7638 JWK thumbprint for an EC P-256 public JWK.
  *
- * Algorithm (RFC 7638 §3):
+ * Algorithm (RFC 7638 section 3):
  *  1. Build a JSON object containing ONLY the required members of the JWK,
  *     ordered lexicographically by member name (Unicode code point).
  *     For EC keys, that's exactly {crv, kty, x, y}.
@@ -17,7 +17,7 @@ import type { PublicEcJwk } from './types';
  * - Including extra fields (`alg`, `use`, `kid`, `ext`, `key_ops`).
  * - Wrong member ordering (must be lex by Unicode code point).
  * - Padded base64 instead of base64url unpadded.
- * - Using `JSON.stringify(jwk)` of an arbitrary-key-order object — we build
+ * - Using `JSON.stringify(jwk)` of an arbitrary-key-order object - we build
  *   a fresh literal in canonical order to make the order explicit and not
  *   rely on V8's insertion-order semantics.
  */
@@ -36,8 +36,8 @@ export async function computeJwkThumbprint(jwk: PublicEcJwk): Promise<string> {
  * Normalize a base64 string to unpadded base64url. Web Crypto's
  * `exportKey('jwk')` is spec'd to return base64url, but some React Native
  * `crypto.subtle` polyfills diverge: standard base64 (`+`/`/`), `=` padding,
- * or — in the case of `react-native-quick-crypto` — a stray `.` in the
- * padding position (observed: `"…dy_c."`). Any of those characters is invalid
+ * or - in the case of `react-native-quick-crypto` - a stray `.` in the
+ * padding position (observed: `"...dy_c."`). Any of those characters is invalid
  * in a JWK member: RFC 7638 thumbprinting and servers that validate `x`/`y`
  * as base64url (`^[A-Za-z0-9_-]+$`) reject them, and the `cnf.jkt` thumbprint
  * silently diverges from the server's. Real browsers already return base64url,
@@ -60,7 +60,7 @@ function toBase64url(value: string): string {
  * coordinates to unpadded base64url. Useful when the input came from
  * `crypto.subtle.exportKey('jwk', publicKey)` which adds `ext` / `key_ops`
  * (and, under some RN polyfills, non-base64url coordinates). Returns a fresh
- * object — never mutates input.
+ * object - never mutates input.
  */
 export function canonicalEcJwk(jwk: { kty?: string; crv?: string; x?: string; y?: string }): PublicEcJwk {
   if (jwk.kty !== 'EC' || jwk.crv !== 'P-256' || typeof jwk.x !== 'string' || typeof jwk.y !== 'string') {

--- a/packages/core/src/keys/types.ts
+++ b/packages/core/src/keys/types.ts
@@ -69,8 +69,8 @@ export interface KeyManager {
    * OPTIONAL. Drop the in-memory cached key WITHOUT touching persistent
    * storage, so the next operation re-loads whatever is persisted. The
    * persisted key is shared per origin/API key across tabs; after another tab
-   * rotates it (logout → fresh login), this instance's cached copy is stale
-   * and would sign proofs the server rejects — and would trip the restore-time
+   * rotates it (logout -> fresh login), this instance's cached copy is stale
+   * and would sign proofs the server rejects - and would trip the restore-time
    * `dpopJkt` binding check against the session the other tab just wrote.
    * `PollarClient` calls this on session teardown and before concluding that
    * a binding mismatch means the key is really lost. Optional so custom

--- a/packages/core/src/keys/types.ts
+++ b/packages/core/src/keys/types.ts
@@ -53,4 +53,28 @@ export interface KeyManager {
    * encoding into the JWS signature segment.
    */
   sign(payload: Uint8Array): Promise<Uint8Array>;
+
+  /**
+   * OPTIONAL. Best-effort check that the current keypair is durably persisted
+   * (re-writing it if needed) and will therefore survive a reload/relaunch.
+   * Returns `false` when persistence is unavailable (e.g. IndexedDB blocked),
+   * meaning any DPoP-bound token minted against this key will stop verifying
+   * on the next cold start. `PollarClient` calls this right before binding a
+   * login to the key so it can warn loudly instead of failing silently later.
+   * Optional so custom `KeyManager` implementations remain source-compatible.
+   */
+  ensurePersisted?(): Promise<boolean>;
+
+  /**
+   * OPTIONAL. Drop the in-memory cached key WITHOUT touching persistent
+   * storage, so the next operation re-loads whatever is persisted. The
+   * persisted key is shared per origin/API key across tabs; after another tab
+   * rotates it (logout → fresh login), this instance's cached copy is stale
+   * and would sign proofs the server rejects — and would trip the restore-time
+   * `dpopJkt` binding check against the session the other tab just wrote.
+   * `PollarClient` calls this on session teardown and before concluding that
+   * a binding mismatch means the key is really lost. Optional so custom
+   * `KeyManager` implementations remain source-compatible.
+   */
+  resync?(): void;
 }

--- a/packages/core/src/keys/web-crypto.ts
+++ b/packages/core/src/keys/web-crypto.ts
@@ -48,6 +48,23 @@ function awaitTx<T>(req: IDBRequest<T>): Promise<T> {
   });
 }
 
+/**
+ * Await a WRITE durably: a put/delete request's `onsuccess` fires before the
+ * transaction actually commits, and a commit-time failure (quota, private-mode
+ * eviction, serialization) aborts the transaction silently after that. Waiting
+ * for the transaction's own `complete` event turns those silent losses into
+ * caught errors — critical here, because a DPoP keypair that only *appeared*
+ * to persist guarantees a thumbprint-mismatch logout on the next page load.
+ */
+function awaitWriteTx(tx: IDBTransaction, req: IDBRequest): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.onerror = (): void => reject(req.error ?? new Error('[PollarClient:keys] IDB write request failed'));
+    tx.oncomplete = (): void => resolve();
+    tx.onerror = (): void => reject(tx.error ?? new Error('[PollarClient:keys] IDB write transaction failed'));
+    tx.onabort = (): void => reject(tx.error ?? new Error('[PollarClient:keys] IDB write transaction aborted'));
+  });
+}
+
 async function dbGet<T>(key: string): Promise<T | undefined> {
   const db = await openDb();
   try {
@@ -63,7 +80,7 @@ async function dbPut(key: string, value: unknown): Promise<void> {
   const db = await openDb();
   try {
     const tx = db.transaction(STORE_NAME, 'readwrite');
-    await awaitTx(tx.objectStore(STORE_NAME).put(value, key));
+    await awaitWriteTx(tx, tx.objectStore(STORE_NAME).put(value, key));
   } finally {
     db.close();
   }
@@ -73,7 +90,7 @@ async function dbDelete(key: string): Promise<void> {
   const db = await openDb();
   try {
     const tx = db.transaction(STORE_NAME, 'readwrite');
-    await awaitTx(tx.objectStore(STORE_NAME).delete(key));
+    await awaitWriteTx(tx, tx.objectStore(STORE_NAME).delete(key));
   } finally {
     db.close();
   }
@@ -202,6 +219,40 @@ export class WebCryptoKeyManager implements KeyManager {
     } catch {
       // Best-effort cleanup; if IDB is unavailable there's nothing persisted to clear.
     }
+    this.keyPair = null;
+    this.publicJwk = null;
+    this.thumbprint = null;
+    this._initPromise = null;
+  }
+
+  /**
+   * Re-persist the in-memory pair and verify it actually landed in IndexedDB.
+   * Idempotent and cheap (one put + one get). Returns `false` when persistence
+   * is unavailable — the caller (the login flow) warns that the session will
+   * not survive a reload, instead of the previous behavior where a silent
+   * `dbPut` failure surfaced only as an unexplained thumbprint-mismatch logout
+   * on the next page load. Re-putting (rather than only probing) also heals
+   * the case where another tab's `reset()` deleted the row this instance still
+   * signs with — the key a new login binds is guaranteed to be the stored one.
+   */
+  async ensurePersisted(): Promise<boolean> {
+    if (!this.keyPair) await this.init();
+    if (!this.keyPair || !this.apiKeyHash) return false;
+    try {
+      await dbPut(this.apiKeyHash, this.keyPair);
+      const readBack = await dbGet<CryptoKeyPair>(this.apiKeyHash);
+      return isCryptoKeyPair(readBack);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Drop the in-memory cache; the next operation re-runs `init()` and adopts
+   * whatever IndexedDB holds (another tab may have rotated the shared key).
+   * Never touches persistent storage — that's `reset()`.
+   */
+  resync(): void {
     this.keyPair = null;
     this.publicJwk = null;
     this.thumbprint = null;

--- a/packages/core/src/keys/web-crypto.ts
+++ b/packages/core/src/keys/web-crypto.ts
@@ -129,7 +129,13 @@ export class WebCryptoKeyManager implements KeyManager {
    * the manager is self-healing if `init()` was never explicitly invoked.
    */
   async init(): Promise<void> {
-    if (this.keyPair) return;
+    // All three fields, not just the pair: `_doInit` assigns `keyPair` and only
+    // THEN awaits the JWK export + thumbprint. A caller landing in that window
+    // would early-return on `keyPair` alone and find `publicJwk`/`thumbprint`
+    // still null — `getThumbprint()` then threw "initialization failed" while
+    // init was, in fact, mid-flight. Requiring all three makes such a caller
+    // fall through and join the in-flight `_initPromise` instead.
+    if (this.keyPair && this.publicJwk && this.thumbprint) return;
     if (!this._initPromise) {
       this._initPromise = this._doInit().catch((err) => {
         // Clear the promise so the next call retries instead of permanently

--- a/packages/core/src/keys/web-crypto.ts
+++ b/packages/core/src/keys/web-crypto.ts
@@ -234,10 +234,10 @@ export class WebCryptoKeyManager implements KeyManager {
   /**
    * Re-persist the in-memory pair and verify it actually landed in IndexedDB.
    * Idempotent and cheap (one put + one get). Returns `false` when persistence
-   * is unavailable — the caller (the login flow) warns that the session will
-   * not survive a reload, instead of the previous behavior where a silent
-   * `dbPut` failure surfaced only as an unexplained thumbprint-mismatch logout
-   * on the next page load. Re-putting (rather than only probing) also heals
+   * is unavailable, so the caller (the login flow) can warn that the session
+   * will not survive a reload rather than letting a silent `dbPut` failure
+   * surface later as an unexplained thumbprint-mismatch logout on the next
+   * page load. Re-putting (rather than only probing) also heals
    * the case where another tab's `reset()` deleted the row this instance still
    * signs with — the key a new login binds is guaranteed to be the stored one.
    */

--- a/packages/core/src/keys/web-crypto.ts
+++ b/packages/core/src/keys/web-crypto.ts
@@ -5,7 +5,7 @@ import type { KeyManager, PublicEcJwk } from './types';
 
 /**
  * `KeyManager` backed by Web Crypto + IndexedDB. The ECDSA P-256 keypair is
- * generated with `extractable: false` for the private key — its bytes never
+ * generated with `extractable: false` for the private key - its bytes never
  * leave the browser's crypto subsystem. The `CryptoKeyPair` is persisted in
  * IndexedDB via structured clone (browsers serialize non-extractable keys
  * without exposing material).
@@ -53,7 +53,7 @@ function awaitTx<T>(req: IDBRequest<T>): Promise<T> {
  * transaction actually commits, and a commit-time failure (quota, private-mode
  * eviction, serialization) aborts the transaction silently after that. Waiting
  * for the transaction's own `complete` event turns those silent losses into
- * caught errors — critical here, because a DPoP keypair that only *appeared*
+ * caught errors - critical here, because a DPoP keypair that only *appeared*
  * to persist guarantees a thumbprint-mismatch logout on the next page load.
  */
 function awaitWriteTx(tx: IDBTransaction, req: IDBRequest): Promise<void> {
@@ -132,14 +132,14 @@ export class WebCryptoKeyManager implements KeyManager {
     // All three fields, not just the pair: `_doInit` assigns `keyPair` and only
     // THEN awaits the JWK export + thumbprint. A caller landing in that window
     // would early-return on `keyPair` alone and find `publicJwk`/`thumbprint`
-    // still null — `getThumbprint()` then threw "initialization failed" while
+    // still null - `getThumbprint()` then threw "initialization failed" while
     // init was, in fact, mid-flight. Requiring all three makes such a caller
     // fall through and join the in-flight `_initPromise` instead.
     if (this.keyPair && this.publicJwk && this.thumbprint) return;
     if (!this._initPromise) {
       this._initPromise = this._doInit().catch((err) => {
         // Clear the promise so the next call retries instead of permanently
-        // returning a rejected promise. The error propagates to the caller —
+        // returning a rejected promise. The error propagates to the caller -
         // `PollarClient` logs it through its configured logger, so we don't
         // double-log (raw, ungated) here.
         this._initPromise = null;
@@ -160,7 +160,7 @@ export class WebCryptoKeyManager implements KeyManager {
       if (pair && !isCryptoKeyPair(pair)) pair = undefined;
     } catch {
       // IDB unavailable (Safari private mode, sandboxed iframe, partitioned
-      // storage in a 3rd-party iframe). Fall through to fresh keygen — we
+      // storage in a 3rd-party iframe). Fall through to fresh keygen - we
       // lose persistence across reloads but the current session can sign.
       pair = undefined;
     }
@@ -168,7 +168,7 @@ export class WebCryptoKeyManager implements KeyManager {
     if (!pair) {
       pair = (await globalThis.crypto.subtle.generateKey(
         { name: 'ECDSA', namedCurve: 'P-256' },
-        // false → private key non-extractable; per W3C ECDSA spec the public
+        // false -> private key non-extractable; per W3C ECDSA spec the public
         // key is always extractable regardless of this flag.
         false,
         ['sign', 'verify'],
@@ -188,9 +188,9 @@ export class WebCryptoKeyManager implements KeyManager {
   /**
    * Derive the public JWK from a `CryptoKey`. Prefers the `'raw'` export (the
    * 65-byte uncompressed point `0x04 || X(32) || Y(32)`) and base64url-encodes
-   * the coordinates ourselves — that sidesteps polyfills whose `exportKey('jwk')`
-   * emits non-base64url `x`/`y` (standard base64, `=` padding, or — as seen with
-   * `react-native-quick-crypto` — a stray `.`). Real browsers and most polyfills
+   * the coordinates ourselves - that sidesteps polyfills whose `exportKey('jwk')`
+   * emits non-base64url `x`/`y` (standard base64, `=` padding, or - as seen with
+   * `react-native-quick-crypto` - a stray `.`). Real browsers and most polyfills
    * support `'raw'` for public EC keys.
    *
    * Falls back to the `'jwk'` export (normalized via `canonicalEcJwk`) if `'raw'`
@@ -212,7 +212,7 @@ export class WebCryptoKeyManager implements KeyManager {
         y: base64urlEncode(raw.slice(33, 65)),
       };
     } catch {
-      // 'raw' unsupported (or odd) on this runtime — fall back to the JWK export
+      // 'raw' unsupported (or odd) on this runtime - fall back to the JWK export
       // and normalize its coordinates to unpadded base64url.
       const jwk = (await globalThis.crypto.subtle.exportKey('jwk', publicKey)) as JsonWebKey;
       return canonicalEcJwk(jwk);
@@ -239,7 +239,7 @@ export class WebCryptoKeyManager implements KeyManager {
    * surface later as an unexplained thumbprint-mismatch logout on the next
    * page load. Re-putting (rather than only probing) also heals
    * the case where another tab's `reset()` deleted the row this instance still
-   * signs with — the key a new login binds is guaranteed to be the stored one.
+   * signs with - the key a new login binds is guaranteed to be the stored one.
    */
   async ensurePersisted(): Promise<boolean> {
     if (!this.keyPair) await this.init();
@@ -256,7 +256,7 @@ export class WebCryptoKeyManager implements KeyManager {
   /**
    * Drop the in-memory cache; the next operation re-runs `init()` and adopts
    * whatever IndexedDB holds (another tab may have rotated the shared key).
-   * Never touches persistent storage — that's `reset()`.
+   * Never touches persistent storage - that's `reset()`.
    */
   resync(): void {
     this.keyPair = null;

--- a/packages/core/src/keys/web-crypto.ts
+++ b/packages/core/src/keys/web-crypto.ts
@@ -232,9 +232,10 @@ export class WebCryptoKeyManager implements KeyManager {
   }
 
   /**
-   * Re-persist the in-memory pair and verify it actually landed in IndexedDB.
-   * Idempotent and cheap (one put + one get). Returns `false` when persistence
-   * is unavailable, so the caller (the login flow) can warn that the session
+   * Re-persist the in-memory pair and verify that the pair IndexedDB holds is
+   * that same key, by thumbprint. Idempotent and cheap (one put + one get).
+   * Returns `false` when persistence is unavailable - or when the stored key is
+   * someone else's - so the caller (the login flow) can warn that the session
    * will not survive a reload rather than letting a silent `dbPut` failure
    * surface later as an unexplained thumbprint-mismatch logout on the next
    * page load. Re-putting (rather than only probing) also heals
@@ -242,12 +243,20 @@ export class WebCryptoKeyManager implements KeyManager {
    * signs with - the key a new login binds is guaranteed to be the stored one.
    */
   async ensurePersisted(): Promise<boolean> {
-    if (!this.keyPair) await this.init();
-    if (!this.keyPair || !this.apiKeyHash) return false;
+    // The thumbprint too, not just the pair: it is what the read-back is checked
+    // against, and `_doInit` publishes it one await after `keyPair`.
+    if (!this.keyPair || !this.thumbprint) await this.init();
+    if (!this.keyPair || !this.thumbprint || !this.apiKeyHash) return false;
     try {
       await dbPut(this.apiKeyHash, this.keyPair);
       const readBack = await dbGet<CryptoKeyPair>(this.apiKeyHash);
-      return isCryptoKeyPair(readBack);
+      if (!isCryptoKeyPair(readBack)) return false;
+      // Compare thumbprints, not shapes: another tab can write its own pair
+      // between the put and the get, and a shape check would accept it. The
+      // login would then bind a key IndexedDB no longer holds, which is exactly
+      // the thumbprint-mismatch logout this call exists to rule out.
+      const storedThumbprint = await computeJwkThumbprint(await this._exportPublicJwk(readBack.publicKey));
+      return storedThumbprint === this.thumbprint;
     } catch {
       return false;
     }

--- a/packages/core/src/lib/abort.ts
+++ b/packages/core/src/lib/abort.ts
@@ -7,7 +7,7 @@
  *     throws `ReferenceError` instead of producing an AbortError.
  *   - `AbortSignal.prototype.throwIfAborted` is absent on older RN AbortSignal
  *     polyfills, so calling it (even via optional chaining, which only guards a
- *     null/undefined signal — not a missing method) throws `TypeError`.
+ *     null/undefined signal - not a missing method) throws `TypeError`.
  *
  * These shims keep the abort path working everywhere while preserving the
  * `error.name === 'AbortError'` contract the rest of the SDK checks against.
@@ -15,7 +15,7 @@
 
 /**
  * Build an AbortError. Uses the native `DOMException` when present (browsers,
- * Node ≥17) and falls back to a plain `Error` tagged `name = 'AbortError'`
+ * Node >=17) and falls back to a plain `Error` tagged `name = 'AbortError'`
  * where `DOMException` is undefined (Hermes).
  */
 export function abortError(): Error {
@@ -57,7 +57,7 @@ export function timeoutController(ms: number): { signal: AbortSignal; clear: () 
 /**
  * Combine several `AbortSignal`s into one that aborts as soon as ANY input does.
  * RN-safe replacement for `AbortSignal.any` (absent on Hermes). Returns the
- * combined signal plus a `cleanup()` that detaches the listeners — call it once
+ * combined signal plus a `cleanup()` that detaches the listeners - call it once
  * the awaited work settles so finished requests don't leak listeners on a
  * long-lived caller signal.
  */

--- a/packages/core/src/lib/api-key-hash.ts
+++ b/packages/core/src/lib/api-key-hash.ts
@@ -2,17 +2,14 @@ import { sha256 } from './sha256';
 
 /**
  * Stable per-API-key namespace tag used to scope persisted storage keys and
- * keypairs. First 32 hex chars (16 bytes / 128 bits) of SHA-256(apiKey) — two
- * distinct keys collide with probability ≈ 1/2^64 (negligible). The pre-0.10
- * width was 8 hex (≈1/2^32), where colliding keys would have shared a session
- * AND a DPoP keypair.
+ * keypairs. First 32 hex chars (16 bytes / 128 bits) of SHA-256(apiKey) - two
+ * distinct keys collide with probability ~1/2^64 (negligible).
  *
- * NOTE: widening this from the old 8-hex value intentionally changes every
- * storage key, so an existing session written by an older SDK is NOT found and
- * the user is asked to re-authenticate ONCE on upgrade. That is by design here —
- * it flushes any stale session state left by earlier buggy versions onto a clean
- * session. There is deliberately NO migration. Do not re-widen without weighing
- * that one-time logout.
+ * NOTE: the tag width is baked into every storage key, so changing it orphans
+ * every persisted session (the row is simply never found) and logs every user
+ * out once on upgrade. There is deliberately NO migration between widths - do
+ * not change it without weighing that one-time logout. (Sessions written by
+ * SDKs older than 0.10 use an 8-hex tag and are intentionally left orphaned.)
  *
  * Async only to match the `sha256` wrapper's signature — the underlying
  * `@noble/hashes` digest is synchronous. Compute once during client

--- a/packages/core/src/lib/api-key-hash.ts
+++ b/packages/core/src/lib/api-key-hash.ts
@@ -11,7 +11,7 @@ import { sha256 } from './sha256';
  * not change it without weighing that one-time logout. (Sessions written by
  * SDKs older than 0.10 use an 8-hex tag and are intentionally left orphaned.)
  *
- * Async only to match the `sha256` wrapper's signature — the underlying
+ * Async only to match the `sha256` wrapper's signature - the underlying
  * `@noble/hashes` digest is synchronous. Compute once during client
  * initialization and cache.
  */

--- a/packages/core/src/lib/base64url.ts
+++ b/packages/core/src/lib/base64url.ts
@@ -1,5 +1,5 @@
 /**
- * Base64url encoder/decoder (RFC 4648 §5), pure JS — no `btoa`, no `Buffer`.
+ * Base64url encoder/decoder (RFC 4648 section 5), pure JS - no `btoa`, no `Buffer`.
  * Used everywhere we need to encode/decode JWS segments, JWK fields, hashes,
  * private scalars, etc. Output is unpadded ("=" stripped).
  */

--- a/packages/core/src/lib/logger.ts
+++ b/packages/core/src/lib/logger.ts
@@ -9,7 +9,7 @@ export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug';
 /**
  * Sink the SDK writes logs to. The global `console` already satisfies this
  * shape, so it's the default. Inject your own (pino, Sentry breadcrumbs, a test
- * spy…) via `PollarClientConfig.logger` to route SDK logs wherever you want.
+ * spy...) via `PollarClientConfig.logger` to route SDK logs wherever you want.
  */
 export interface PollarLogger {
   error(...args: unknown[]): void;
@@ -24,7 +24,7 @@ const RANK: Record<LogLevel, number> = { silent: 0, error: 1, warn: 2, info: 3, 
  * Build a level-gated logger over a sink. The returned object has the same
  * method surface as {@link PollarLogger}; each call is silently dropped when its
  * level is more verbose than the configured `level`. Messages keep their own
- * `[PollarClient…]` prefixes, so this only adds filtering + sink routing.
+ * `[PollarClient...]` prefixes, so this only adds filtering + sink routing.
  *
  * Defaults: `level = 'info'`, `sink = console`.
  */

--- a/packages/core/src/lib/logging.ts
+++ b/packages/core/src/lib/logging.ts
@@ -14,7 +14,7 @@ export const SENSITIVE_BODY_KEYS = new Set([
   'accessToken',
   'token',
   // SEP-10 challenge envelopes: a counter-signed challenge is a live, replayable
-  // auth credential — never log it in the clear.
+  // auth credential - never log it in the clear.
   'signedChallengeXdr',
   'challengeXdr',
   'signedTxXdr',
@@ -46,15 +46,15 @@ export function redactBody(body: unknown): unknown {
 
 /**
  * Sensitive keys for a RESPONSE / error-cause envelope. Same as
- * {@link SENSITIVE_BODY_KEYS} but WITHOUT `code` — in a request body `code` is
+ * {@link SENSITIVE_BODY_KEYS} but WITHOUT `code` - in a request body `code` is
  * the email OTP (a secret), but in a response/cause it's the diagnostic error
- * code (`TX_FEE_LIMIT_EXCEEDED`, `INVALID_EMAIL_CODE`, …) that you need in logs.
+ * code (`TX_FEE_LIMIT_EXCEEDED`, `INVALID_EMAIL_CODE`, ...) that you need in logs.
  * Token/PII/XDR keys stay masked.
  */
 const SENSITIVE_RESPONSE_KEYS = new Set([...SENSITIVE_BODY_KEYS].filter((k) => k !== 'code'));
 
 /**
- * Like {@link redactBody} but RECURSIVE — masks sensitive keys at any depth. Use
+ * Like {@link redactBody} but RECURSIVE - masks sensitive keys at any depth. Use
  * for RESPONSE bodies / error causes, where token material is nested (e.g.
  * `{ content: { token: { accessToken, refreshToken } } }`) and the shallow
  * `redactBody` would leak it. Keeps the diagnostic `code` visible (see

--- a/packages/core/src/lib/random-uuid.ts
+++ b/packages/core/src/lib/random-uuid.ts
@@ -1,9 +1,9 @@
 /**
  * Generate a RFC 4122 v4 UUID. Prefers the secure-context `crypto.randomUUID`
  * when available; falls back to a manual v4 build via `crypto.getRandomValues`
- * for environments where `randomUUID` is missing (older RN/Hermes — where the
+ * for environments where `randomUUID` is missing (older RN/Hermes - where the
  * `react-native-get-random-values` polyfill provides `getRandomValues` but not
- * `randomUUID` — and insecure HTTP origins).
+ * `randomUUID` - and insecure HTTP origins).
  *
  * Throws only when no secure random source exists at all, in which case DPoP
  * (and the SDK) cannot operate anyway.

--- a/packages/core/src/lib/sha256.ts
+++ b/packages/core/src/lib/sha256.ts
@@ -11,9 +11,9 @@ import { sha256 as nobleSha256 } from '@noble/hashes/sha2';
  * (the `NobleKeyManager`). The inputs hashed here are tiny (API keys, access
  * tokens, JWK thumbprints), so the JS implementation is more than fast enough.
  *
- * Kept `async` (the digest itself is synchronous) so existing `await sha256(…)`
- * call sites — DPoP `ath`, API-key hashing, JWK thumbprints, `NobleKeyManager`
- * — need no change.
+ * Kept `async` (the digest itself is synchronous) so existing `await sha256(...)`
+ * call sites - DPoP `ath`, API-key hashing, JWK thumbprints, `NobleKeyManager`
+ * - need no change.
  */
 export async function sha256(data: Uint8Array): Promise<Uint8Array> {
   return nobleSha256(data);

--- a/packages/core/src/lib/units.ts
+++ b/packages/core/src/lib/units.ts
@@ -1,10 +1,10 @@
 /**
- * Decimal ↔ base-unit conversion for on-chain amounts.
+ * Decimal <-> base-unit conversion for on-chain amounts.
  *
  * Chains disagree on what an "amount" is. Stellar's API takes a decimal string
  * ("1.5"); Solana and EVM take integer base units (1500000000 lamports). Balances
  * are always shown to the user as decimals, so a UI that sends to a base-unit
- * chain has to convert — and getting it wrong silently sends the wrong amount.
+ * chain has to convert - and getting it wrong silently sends the wrong amount.
  *
  * The arithmetic is string + BigInt, never float: `parseFloat('0.1') * 1e9` is
  * 100000000.00000001, and at 18 decimals a float cannot represent the value at
@@ -12,10 +12,10 @@
  */
 
 /**
- * "1.5" with 9 decimals → "1500000000".
+ * "1.5" with 9 decimals -> "1500000000".
  *
  * Throws on anything that is not a plain non-negative decimal, and on more
- * fractional digits than the asset has — silently truncating there would send
+ * fractional digits than the asset has - silently truncating there would send
  * less than the user typed.
  */
 export function toBaseUnits(amount: string, decimals: number): string {
@@ -33,12 +33,12 @@ export function toBaseUnits(amount: string, decimals: number): string {
   }
 
   // Right-pad the fraction to exactly `decimals` digits, then the whole thing is
-  // one integer literal — no division, so nothing to round.
+  // one integer literal - no division, so nothing to round.
   const padded = fraction.padEnd(decimals, '0');
   return BigInt(whole + padded).toString();
 }
 
-/** "1500000000" with 9 decimals → "1.5". Inverse of {@link toBaseUnits}. */
+/** "1500000000" with 9 decimals -> "1.5". Inverse of {@link toBaseUnits}. */
 export function fromBaseUnits(base: string, decimals: number): string {
   const trimmed = base.trim();
   if (!/^\d+$/.test(trimmed)) {

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -63,6 +63,9 @@ export {
   submitRampSignature,
   getRampTransaction,
   pollRampTransaction,
+  getRampLiquidity,
+  getRampKycStatus,
+  decodePixQr,
 } from './api/endpoints/ramps';
 
 // ─── Distribution endpoints ───────────────────────────────────────────────────

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -43,7 +43,7 @@ export type {
   ProviderAuthState,
 } from './wallets';
 export type * from './types';
-export { AUTH_ERROR_CODES, PollarNetworkError, isPollarNetworkError } from './types';
+export { AUTH_ERROR_CODES, PollarNetworkError, isPollarNetworkError, PollarApiError, isPollarApiError } from './types';
 export { PollarApiClient } from './api/client';
 export type { paths as pollarPaths } from './api/schema';
 export { isValidSession } from './client/session';

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -3,7 +3,7 @@
 // `KeyManager` factory, exporting `NobleKeyManager`) live in those entry
 // modules so bundlers can tree-shake unused code paths.
 
-export { PollarClient } from './client/client';
+export { PollarClient, isPollarClient } from './client/client';
 export { POLLAR_CORE_VERSION } from './version';
 export { createLogger } from './lib/logger';
 export { toBaseUnits, fromBaseUnits } from './lib/units';

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -9,13 +9,13 @@ export { createLogger } from './lib/logger';
 export { toBaseUnits, fromBaseUnits } from './lib/units';
 export type { LogLevel, PollarLogger } from './lib/logger';
 
-// ─── Storage ──────────────────────────────────────────────────────────────────
+// --- Storage ------------------------------------------------------------------
 export type { Storage, OnStorageDegrade, StorageDegradeReason } from './storage/types';
 export { defaultStorage } from './storage/autodetect';
 export { createLocalStorageAdapter, createMemoryAdapter } from './storage/web';
 export type { LocalStorageAdapterOptions } from './storage/web';
 
-// ─── KeyManager + DPoP ────────────────────────────────────────────────────────
+// --- KeyManager + DPoP --------------------------------------------------------
 export type { KeyManager, PublicEcJwk } from './keys/types';
 export { defaultKeyManager } from './keys/factory';
 export { WebCryptoKeyManager } from './keys/web-crypto';
@@ -50,10 +50,10 @@ export { isValidSession } from './client/session';
 export { StellarClient } from './stellar/StellarClient';
 export type { StellarNetwork, StellarClientConfig, StellarBalance } from './stellar/StellarClient';
 
-// ─── KYC endpoints ────────────────────────────────────────────────────────────
+// --- KYC endpoints ------------------------------------------------------------
 export { getKycStatus, getKycProviders, startKyc, resolveKyc, pollKycStatus } from './api/endpoints/kyc';
 
-// ─── Ramps endpoints ──────────────────────────────────────────────────────────
+// --- Ramps endpoints ----------------------------------------------------------
 export {
   getRampsQuote,
   getRampCountries,
@@ -68,11 +68,11 @@ export {
   decodePixQr,
 } from './api/endpoints/ramps';
 
-// ─── Distribution endpoints ───────────────────────────────────────────────────
+// --- Distribution endpoints ---------------------------------------------------
 export { listDistributionRules, claimDistributionRule } from './api/endpoints/distribution';
 
-// ─── Swap endpoints ───────────────────────────────────────────────────────────
+// --- Swap endpoints -----------------------------------------------------------
 export { quoteSwap, getSwapConfig, getSwapTokens } from './api/endpoints/swap';
 
-// ─── Earn endpoints ───────────────────────────────────────────────────────────
+// --- Earn endpoints -----------------------------------------------------------
 export { getEarnProviders, getEarnOpportunities, getEarnPosition, buildEarnTx } from './api/endpoints/earn';

--- a/packages/core/src/storage/autodetect.ts
+++ b/packages/core/src/storage/autodetect.ts
@@ -8,7 +8,7 @@ const PROBE_KEY = '__pollar_storage_probe__';
  * fallback. The probe writes-reads-removes a sentinel; any throw, value
  * mismatch, or missing `localStorage` (SSR / disabled storage) falls back.
  *
- * Run-time degrade still happens inside `createLocalStorageAdapter` — see its
+ * Run-time degrade still happens inside `createLocalStorageAdapter` - see its
  * docstring for the rationale.
  */
 export function defaultStorage(options: LocalStorageAdapterOptions = {}): Storage {

--- a/packages/core/src/storage/web.ts
+++ b/packages/core/src/storage/web.ts
@@ -46,12 +46,12 @@ export interface LocalStorageAdapterOptions {
  *
  * Why every op (not just the probe): Safari private mode and sandboxed iframes
  * may expose `localStorage` but throw `QuotaExceededError` / `SecurityError`
- * on the first write — a successful probe at construction time isn't enough.
+ * on the first write - a successful probe at construction time isn't enough.
  *
  * Tokens persisted here are DPoP-bound to a non-extractable WebCrypto
  * keypair, so XSS exposure is limited to a signing-oracle attack (the key
  * itself never leaves the browser's crypto subsystem). Consumers who need
- * stricter isolation can inject a custom `Storage` adapter — e.g. one that
+ * stricter isolation can inject a custom `Storage` adapter - e.g. one that
  * proxies to an httpOnly cookie on a host origin.
  */
 export function createLocalStorageAdapter(options: LocalStorageAdapterOptions = {}): Storage {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -934,6 +934,21 @@ export type RampsCountriesResponse =
   pollarPaths['/ramps/countries']['get']['responses'][200]['content']['application/json']['content'];
 export type RampCountry = RampsCountriesResponse['countries'][number];
 
+// Provider utilities: reads that inform a ramp before or during a quote.
+export type RampsLiquidityResponse =
+  pollarPaths['/ramps/liquidity']['get']['responses'][200]['content']['application/json']['content'];
+export type RampRail = RampsLiquidityResponse['rail'];
+/**
+ * Where the user stands with the provider's identity checks. Polled after an
+ * off-ramp answered `kycRequired: true` — that provider (Abroad) publishes no
+ * hosted KYC link, so the client waits for `hasApproved` and re-quotes.
+ */
+export type RampsKycStatusResponse =
+  pollarPaths['/ramps/kyc-status']['get']['responses'][200]['content']['application/json']['content'];
+export type RampsPixDecodeResponse =
+  pollarPaths['/ramps/pix/decode']['get']['responses'][200]['content']['application/json']['content'];
+export type RampsPixDecoded = NonNullable<RampsPixDecodeResponse['decoded']>;
+
 // ─── Distribution types ───────────────────────────────────────────────────────
 
 export type DistributionRule =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -734,6 +734,40 @@ export class PollarNetworkError extends Error {
   }
 }
 
+/**
+ * Thrown when the API answers with an error body. Endpoint helpers used to
+ * collapse that body into `new Error(code)`, which threw away everything the
+ * server said about WHY — so a caller could only ever show the bare code.
+ *
+ * `code` is the stable machine-readable one (e.g. `SDK_RAMPS_AMOUNT_OUT_OF_RANGE`);
+ * `details` is the server's human reason when it sends one; `body` is the whole
+ * payload, for the fields a specific error adds on top (an out-of-range amount
+ * carries `limit` / `limitAmount` / `limitCurrency`, say).
+ */
+export class PollarApiError extends Error {
+  readonly code: string;
+  readonly details?: string;
+  readonly body: Record<string, unknown>;
+  constructor(code: string, body: Record<string, unknown> = {}) {
+    // The message stays the code: existing callers that render `err.message`
+    // keep showing exactly what they showed before this class existed.
+    super(code);
+    this.name = 'PollarApiError';
+    this.code = code;
+    this.body = body;
+    if (typeof body.details === 'string') this.details = body.details;
+  }
+}
+
+/** Type guard for {@link PollarApiError} (instanceof is unreliable across
+ *  bundle/dual-package boundaries, so match the shape too). */
+export function isPollarApiError(err: unknown): err is PollarApiError {
+  return (
+    err instanceof PollarApiError ||
+    (typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'PollarApiError')
+  );
+}
+
 /** Type guard for {@link PollarNetworkError} (instanceof is unreliable across
  *  bundle/dual-package boundaries, so match the stable `code` too). */
 export function isPollarNetworkError(err: unknown): err is PollarNetworkError {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -954,6 +954,23 @@ export type RampsTransactionResponse =
 export type RampTxStatus = RampsTransactionResponse['status'];
 export type RampDirection = RampsTransactionResponse['direction'];
 
+/**
+ * How to pay, in one shape for every provider. Named so a consumer that renders
+ * its own payment screen can type it without reaching into the generated schema.
+ *
+ * `fields` arrive labelled and formatted: iterate and display, no per-provider
+ * knowledge needed. `scannable` carries the code the user points a camera at,
+ * with the image already rendered so no QR encoder is required — Pollar-made
+ * SVGs (`image.inlineSafe`) use `currentColor` and can be injected as markup to
+ * follow the host's theme; a provider's own bitmap must go through
+ * `<img src="data:...">`. `scannable.payload` is the raw string behind the code:
+ * show it as text when `payloadLabel` is set, since a user on the phone that
+ * holds the screen has nothing to scan.
+ */
+export type RampDepositInstructions = NonNullable<RampsTransactionResponse['depositInstructions']>;
+export type RampScannable = NonNullable<RampDepositInstructions['scannable']>;
+export type RampInstructionField = RampDepositInstructions['fields'][number];
+
 // SEP-24 anchor flow (e.g. Anclap): custodial wallets get a `kycUrl` to open;
 // EXTERNAL wallets get a `pendingSignature` to sign and resume.
 export type RampsPendingSignature = NonNullable<RampsOnrampResponse['pendingSignature']>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,7 +8,7 @@ import { WalletAdapter, WalletId } from './wallets';
 
 export type PollarApplicationConfigResponse =
   pollarPaths['/auth/login']['post']['responses'][200]['content']['application/json'];
-/** Full `/auth/login` response shape — used in transit but NOT persisted. */
+/** Full `/auth/login` response shape - used in transit but NOT persisted. */
 export type PollarApplicationConfigContent = PollarApplicationConfigResponse['content'];
 
 /**
@@ -16,23 +16,23 @@ export type PollarApplicationConfigContent = PollarApplicationConfigResponse['co
  * every entry of `wallets`, so the two can never drift apart in shape.
  *
  * `type` discriminates custody:
- *   - 'internal' → platform-managed (custodial) account (G-address, 0x…, …)
- *   - 'smart'    → Soroban smart-account / passkey (C-address)
- *   - 'external' → user-connected wallet (Freighter/Albedo)
+ *   - 'internal' -> platform-managed (custodial) account (G-address, 0x..., ...)
+ *   - 'smart'    -> Soroban smart-account / passkey (C-address)
+ *   - 'external' -> user-connected wallet (Freighter/Albedo)
  * `address` is the on-chain address for every type.
  */
 export interface PollarPersistedWallet {
   type: 'internal' | 'smart' | 'external';
   // The login method, 1:1 with `type` (fixed at account creation server-side):
-  //   internal → 'email' | 'google' | 'github' | 'oidc'
-  //   smart    → 'passkey'
-  //   external → 'wallet'
+  //   internal -> 'email' | 'google' | 'github' | 'oidc'
+  //   smart    -> 'passkey'
+  //   external -> 'wallet'
   // Optional: sessions minted by sdk-api < this change won't carry it. For
   // external wallets the specific on-chain adapter id (freighter/albedo) is
   // exposed separately via `getWallet().provider`, not here.
   provider?: string;
   address: string | null;
-  // The CHAIN this address lives on — NOT testnet-vs-mainnet, which is
+  // The CHAIN this address lives on - NOT testnet-vs-mainnet, which is
   // `network` below. Optional: the back-compat `wallet` field and sessions
   // minted before multi-chain omit it (those are always STELLAR).
   chain?: WalletChain;
@@ -65,14 +65,14 @@ export interface PollarPersistedSession {
    * to (`cnf.jkt`), stamped at store time. On restore the client compares it
    * against the currently loaded keypair: a mismatch means the private key
    * was lost (IndexedDB evicted/unavailable, key reset elsewhere) and every
-   * proof-bound call — resume and refresh included — is guaranteed to fail,
+   * proof-bound call - resume and refresh included - is guaranteed to fail,
    * so the session is cleared locally with a precise diagnostic instead of a
    * burst of opaque 401s. Optional: absent on sessions persisted by older
    * SDKs and on Bearer-fallback sessions, which skip the check.
    */
   dpopJkt?: string;
   /**
-   * BACK-COMPAT — the user's STELLAR wallet (or their smart account). Always
+   * BACK-COMPAT - the user's STELLAR wallet (or their smart account). Always
    * present, always Stellar. Mirrors the entry in `wallets` with
    * `chain: 'STELLAR'` when there is one.
    */
@@ -81,16 +81,16 @@ export interface PollarPersistedSession {
    * Every wallet the user holds, one per chain. Superset of `wallet`.
    *
    * Optional because sessions persisted before this field existed (and logins
-   * against an sdk-api that predates `wallets[]`) have none — treat an absent
+   * against an sdk-api that predates `wallets[]`) have none - treat an absent
    * array as "only `wallet` is known", not as "the user has no wallets".
    */
   wallets?: PollarPersistedWallet[];
 }
 
 /**
- * Custodial login methods — the providers that map to an `internal` wallet.
- * Mirrors the backend `AuthProvider` enum minus passkey (→ smart) and
- * wallet/external (→ external).
+ * Custodial login methods - the providers that map to an `internal` wallet.
+ * Mirrors the backend `AuthProvider` enum minus passkey (-> smart) and
+ * wallet/external (-> external).
  */
 export type PollarAuthMethod = 'email' | 'google' | 'github' | 'oidc';
 
@@ -99,11 +99,11 @@ export type PollarAuthMethod = 'email' | 'google' | 'github' | 'oidc';
  * Every authenticated session has exactly one wallet whose custody is fixed at
  * account creation, so `custody` strictly determines the shape of `provider`:
  *
- *   - `internal` (platform-custodied G-address) → `provider` is the login
+ *   - `internal` (platform-custodied G-address) -> `provider` is the login
  *     method, or `null` if the session predates provider tracking server-side.
- *   - `smart` (passkey Soroban C-address) → `provider` is always `'passkey'`.
- *   - `external` (user-connected wallet) → `provider` is the on-chain adapter
- *     id (`'freighter'`, `'albedo'`, …), or `null` when no adapter is resolved
+ *   - `smart` (passkey Soroban C-address) -> `provider` is always `'passkey'`.
+ *   - `external` (user-connected wallet) -> `provider` is the on-chain adapter
+ *     id (`'freighter'`, `'albedo'`, ...), or `null` when no adapter is resolved
  *     (e.g. a restored session whose adapter could not be re-attached).
  *
  * Obtained via {@link PollarClient.getWallet} (the Stellar wallet) or
@@ -117,9 +117,9 @@ export type WalletInfo =
   // `existsOnStellar` (is the account created on-chain) and `fundingMode` (the
   // app's funding policy) are wallet-status extras carried on every custody so
   // callers can, e.g., offer on-chain account creation for an external wallet
-  // that isn't on Stellar yet. Optional — absent on sessions that predate them.
+  // that isn't on Stellar yet. Optional - absent on sessions that predate them.
   //
-  // `chain` says which chain `address` lives on — NOT testnet-vs-mainnet.
+  // `chain` says which chain `address` lives on - NOT testnet-vs-mainnet.
   // Optional: `getWallet()` omits it (it is always STELLAR by definition), and
   // sessions minted before multi-chain don't carry it either. `getWallets()`
   // sets it whenever the backend reported it.
@@ -178,12 +178,12 @@ export interface PollarClientConfig {
    *
    * `fetch` has no timeout of its own, so without this a transient connection
    * stall (e.g. a dropped TCP SYN on a flaky mobile network at cold start) hangs
-   * the request forever — it neither resolves nor rejects, trapping any caller
+   * the request forever - it neither resolves nor rejects, trapping any caller
    * that `await`s it (a returning user stuck on the splash screen). Bounding it
    * lets the request fail fast so the caller can recover (retry, or fall back to
    * a cached token).
    *
-   * Defaults to `10000` (10s). Set `0` to disable (NOT recommended — restores
+   * Defaults to `10000` (10s). Set `0` to disable (NOT recommended - restores
    * the unbounded-hang behavior).
    */
   requestTimeoutMs?: number;
@@ -220,14 +220,14 @@ export interface PollarClientConfig {
   logLevel?: LogLevel;
   /**
    * Sink the SDK writes logs to. Defaults to the global `console`. Inject your
-   * own (pino, Sentry breadcrumbs, a test spy…) to route SDK logs anywhere.
+   * own (pino, Sentry breadcrumbs, a test spy...) to route SDK logs anywhere.
    * Filtering by `logLevel` still applies on top of whatever you pass.
    */
   logger?: PollarLogger;
   /**
    * Notified when persistent storage silently degrades to in-memory mode
    * (Safari private browsing quota errors, sandboxed iframes, etc.). Useful
-   * for telemetry — the SDK keeps working but sessions won't survive reload.
+   * for telemetry - the SDK keeps working but sessions won't survive reload.
    */
   onStorageDegrade?: OnStorageDegrade;
   /**
@@ -236,13 +236,13 @@ export interface PollarClientConfig {
    * `FreighterAdapter` / `AlbedoAdapter` are auto-registered; entries here are
    * added on top and override a built-in by reusing its `type`. Import extra
    * adapters from their own packages (`@pollar/stellar-wallets-kit-adapter`,
-   * `@pollar/privy-adapter`, …) so their deps stay out of `@pollar/core`'s bundle.
+   * `@pollar/privy-adapter`, ...) so their deps stay out of `@pollar/core`'s bundle.
    */
   walletAdapters?: WalletAdapter[];
   /**
    * Optional human-friendly label sent at /auth/login time and recorded on
    * the server-side refresh-token row so the user can identify it in the
-   * "active sessions" UI (e.g. "iPhone — Safari", "Mac — Chrome 126").
+   * "active sessions" UI (e.g. "iPhone - Safari", "Mac - Chrome 126").
    * If unset, the server-recorded `user_agent` header is the fallback.
    */
   deviceLabel?: string;
@@ -252,7 +252,7 @@ export interface PollarClientConfig {
    * network + sidesteps browser/RN background timer throttling); they run
    * the moment visibility comes back. Defaults to a web provider in the
    * browser (`visibilitychange` + BFCache + focus) and a noop elsewhere.
-   * React Native consumers should inject an `AppState`-backed provider —
+   * React Native consumers should inject an `AppState`-backed provider -
    * use `createAppStateVisibilityProvider` from
    * `@pollar/core/adapters/react-native-appstate`.
    */
@@ -260,8 +260,8 @@ export interface PollarClientConfig {
   /**
    * If set, the silent-refresh scheduler stops issuing proactive refreshes
    * after this many milliseconds of no client-side HTTP activity. The
-   * session is not cleared — the next user action triggers a request that
-   * either reuses a still-valid access token or hits 401 → reactive
+   * session is not cleared - the next user action triggers a request that
+   * either reuses a still-valid access token or hits 401 -> reactive
    * refresh (transparent if the RT is still valid). Defaults to
    * `undefined` = refresh forever as long as the app is visible.
    */
@@ -272,14 +272,14 @@ export interface PollarClientConfig {
    * on web. React Native consumers MUST provide one (typically wrapping
    * `expo-web-browser`'s `openAuthSessionAsync`), since `window.open` does
    * not exist there. The SDK still drives the rest of the flow by polling the
-   * auth-session status, so the opener only needs to surface the URL — it does
+   * auth-session status, so the opener only needs to surface the URL - it does
    * NOT need to capture the redirect payload.
    */
   openAuthUrl?: AuthUrlOpener;
   /**
    * Value sent to the backend as `redirect_uri` for hosted OAuth (where the
    * provider returns the user afterwards). Defaults to `window.location.origin`
-   * on web. On React Native set this to your app's deep link / scheme — the
+   * on web. On React Native set this to your app's deep link / scheme - the
    * same URL you pass to `WebBrowser.openAuthSessionAsync`.
    */
   oauthRedirectUri?: string;
@@ -304,10 +304,10 @@ export interface PollarClientConfig {
  * the result to forward to the backend: a registration response for a new user
  * (`create()`) or an authentication assertion for a returning one (`get()`).
  * `mode` tells the ceremony which to run: `'login'` runs `get()` only (returning
- * user) and `'register'` runs `create()` only (new wallet) — the caller picks via
+ * user) and `'register'` runs `create()` only (new wallet) - the caller picks via
  * the "Log in" / "Create wallet" buttons, so there's no ambiguous autodetect that
  * could create a wallet when the user merely cancelled a login prompt. `response`
- * is the browser's PublicKeyCredential serialized to JSON — forwarded verbatim to
+ * is the browser's PublicKeyCredential serialized to JSON - forwarded verbatim to
  * `/auth/passkey/{register,login}`.
  */
 export type PasskeyMode = 'login' | 'register';
@@ -321,7 +321,7 @@ export type PasskeyCeremony = (ctx: {
  * Signs a smart-account transaction's auth digest with the user's passkey
  * (a WebAuthn `get()` whose challenge is the raw digest). Returns the PUBLIC
  * assertion fields (base64url) for the server to assemble into the Soroban auth
- * entry — no secret leaves the device. Injected by the runtime layer
+ * entry - no secret leaves the device. Injected by the runtime layer
  * (`@pollar/react`); `@pollar/core` never touches `navigator.credentials`.
  */
 export type PasskeySigner = (ctx: {
@@ -335,8 +335,8 @@ export type PasskeySigner = (ctx: {
  * Strategy for opening the hosted OAuth URL. The SDK mints the per-login auth
  * session lazily inside `getUrl()` (call it once; the first call creates the
  * `clientSessionId` and returns the full URL, or `null` if session creation
- * failed). Open the resolved URL however the platform allows — a popup on web,
- * `WebBrowser.openAuthSessionAsync(url, redirectUri)` on React Native — and
+ * failed). Open the resolved URL however the platform allows - a popup on web,
+ * `WebBrowser.openAuthSessionAsync(url, redirectUri)` on React Native - and
  * resolve once the user-facing browser step is done or dismissed. You do NOT
  * need to capture the redirect payload: the SDK polls the auth-session status
  * until the backend marks it READY.
@@ -392,7 +392,7 @@ export type TxSignAndSendBody = NonNullable<
 >['content']['application/json'];
 export type TxSignSendResponse = pollarPaths['/tx/sign-and-send']['post']['responses'][200]['content']['application/json'];
 
-// ─── Split flow (new in v0.7.2) ───────────────────────────────────────────────
+// --- Split flow (new in v0.7.2) -----------------------------------------------
 
 export type TxSignBody = NonNullable<pollarPaths['/tx/sign']['post']['requestBody']>['content']['application/json'];
 export type TxSignResponse = pollarPaths['/tx/sign']['post']['responses'][200]['content']['application/json'];
@@ -419,15 +419,15 @@ export type PollarLoginOptions =
   // Catch-all for any registered wallet adapter (`login({ provider: adapter.type })`,
   // e.g. 'freighter' | 'albedo' | 'privy' | 'xbull'). `string & {}` keeps the
   // built-in literals autocompleting. Trade-off: this also makes a bare
-  // `{ provider: 'email' }` (no `email`) type-check — the email flow still
+  // `{ provider: 'email' }` (no `email`) type-check - the email flow still
   // validates `email` at runtime.
   | ({ provider: string & {} } & Record<string, unknown>);
 
 /**
  * Curated, stable facade handed to every {@link PollarAuthProvider}. It exposes
- * only the primitives a login strategy needs — the shared backbone
- * (`createSession` → drive the session READY → `authenticate`) plus a couple of
- * ready-made legs — and deliberately keeps `PollarClient` internals (storage,
+ * only the primitives a login strategy needs - the shared backbone
+ * (`createSession` -> drive the session READY -> `authenticate`) plus a couple of
+ * ready-made legs - and deliberately keeps `PollarClient` internals (storage,
  * wallet-adapter resolution, DPoP key manager) private. This is the public
  * contract a third-party provider (e.g. Privy) builds against.
  */
@@ -442,12 +442,12 @@ export interface AuthProviderContext {
   readonly logger: PollarLogger;
   /** Drive the SDK's auth state machine (the host's `onAuthStateChange` mirrors it). */
   setAuthState(state: AuthState): void;
-  /** `POST /auth/session` → `clientSessionId` (null on failure; error state already set). */
+  /** `POST /auth/session` -> `clientSessionId` (null on failure; error state already set). */
   createSession(): Promise<string | null>;
   /** Poll the session to READY, then `POST /auth/login` and persist the session. The shared backbone. */
   authenticate(clientSessionId: string): Promise<void>;
   /**
-   * `POST /auth/wallet/challenge` → the server-signed SEP-10 challenge transaction
+   * `POST /auth/wallet/challenge` -> the server-signed SEP-10 challenge transaction
    * (XDR) the wallet must counter-sign to prove key control. Returns `null` on
    * failure. Bind the network you sign on to the app's network.
    */
@@ -479,17 +479,17 @@ export interface PollarAuthProvider {
 export type TxBuildContent = TxBuildResponse['content'];
 
 /**
- * Phases the SDK can be in across the build → sign → submit lifecycle.
+ * Phases the SDK can be in across the build -> sign -> submit lifecycle.
  *
  * **Granular** steps (`building`, `signing`, `submitting`) are emitted when
- * the SDK can directly observe that phase — i.e. when each is a separate
+ * the SDK can directly observe that phase - i.e. when each is a separate
  * client-driven call (`buildTx`, `signTx`, `submitTx`, external-wallet
  * `signAndSubmitTx`).
  *
  * **Compound** steps (`signing-submitting`, `building-signing-submitting`)
  * are emitted when multiple phases collapse into a single opaque backend
- * round-trip (`signAndSubmitTx` custodial → `/tx/sign-and-send`, and `runTx`
- * / `buildAndSignAndSubmitTx` custodial → `/tx/build-sign-submit`). The SDK
+ * round-trip (`signAndSubmitTx` custodial -> `/tx/sign-and-send`, and `runTx`
+ * / `buildAndSignAndSubmitTx` custodial -> `/tx/build-sign-submit`). The SDK
  * can't see when one phase ends and the next begins inside that request, so
  * it honestly reports a single fused state instead of fabricating
  * transitions.
@@ -502,20 +502,20 @@ export type TxBuildContent = TxBuildResponse['content'];
  */
 export type TransactionState =
   | { step: 'idle' }
-  // ─── Granular phases (observable per-call) ────────────────────────────
+  // --- Granular phases (observable per-call) ----------------------------
   | { step: 'building' }
   | { step: 'built'; buildData: TxBuildContent }
   | { step: 'signing'; buildData?: TxBuildContent }
   | { step: 'signed'; buildData?: TxBuildContent; signedXdr: string; submissionToken?: string }
   | { step: 'submitting'; buildData?: TxBuildContent; signedXdr?: string }
-  // ─── Compound phases (custodial-only — backend swallows the boundaries) ──
+  // --- Compound phases (custodial-only - backend swallows the boundaries) --
   | { step: 'signing-submitting'; buildData?: TxBuildContent }
   | { step: 'building-signing-submitting' }
-  // ─── Post-Horizon-ack, pre-ledger-confirm (shared) ────────────────────
+  // --- Post-Horizon-ack, pre-ledger-confirm (shared) --------------------
   | { step: 'submitted'; buildData?: TxBuildContent; hash: string }
-  // ─── Terminal success (shared) ────────────────────────────────────────
+  // --- Terminal success (shared) ----------------------------------------
   | { step: 'success'; buildData?: TxBuildContent; hash: string }
-  // ─── Terminal failure with phase context ──────────────────────────────
+  // --- Terminal failure with phase context ------------------------------
   | {
       step: 'error';
       phase: TxErrorPhase;
@@ -537,7 +537,7 @@ export type TxErrorPhase = 'building' | 'signing' | 'submitting' | 'signing-subm
 /**
  * Per-call outcomes returned by `buildTx`, `signTx`, `submitTx`,
  * `signAndSubmitTx`, and `buildAndSignAndSubmitTx`. These are additive to
- * `TransactionState` — the same operations still drive the state machine for
+ * `TransactionState` - the same operations still drive the state machine for
  * modal-style UIs, but headless callers can `await` the method and inspect
  * the returned outcome directly instead of subscribing to state changes.
  */
@@ -554,10 +554,10 @@ export type SignOutcome =
  */
 export type SignAuthEntryOutcome = { status: 'signed'; signedAuthEntry: string } | { status: 'error'; details?: string };
 
-// ─── Stellar SEP ownership proofs (client.stellar.*) ────────────────────────────
+// --- Stellar SEP ownership proofs (client.stellar.*) ----------------------------
 
 /**
- * Result of {@link StellarSepApi.sep53}.signMessage — a SEP-53 message signature.
+ * Result of {@link StellarSepApi.sep53}.signMessage - a SEP-53 message signature.
  * `signature` is base64 ed25519 over SHA-256("Stellar Signed Message:\n" + message),
  * the same digest external wallets (Freighter/SWK) and the custodial signer both
  * produce, so `scheme` is always `sep53`.
@@ -566,7 +566,7 @@ export type StellarMessageProof =
   | { status: 'signed'; signature: string; signerAddress: string; scheme: 'sep53' }
   | { status: 'error'; details?: string; code?: string };
 
-/** Input to {@link StellarSepApi.sep10}.sign — a verifier-issued SEP-10 challenge. */
+/** Input to {@link StellarSepApi.sep10}.sign - a verifier-issued SEP-10 challenge. */
 export interface Sep10SignParams {
   /** The SEP-10 challenge transaction (unsigned XDR) built by the verifier. */
   challengeXdr: string;
@@ -576,7 +576,7 @@ export interface Sep10SignParams {
   webAuthDomain?: string;
 }
 
-/** Result of {@link StellarSepApi.sep10}.sign — the challenge with the user's signature. */
+/** Result of {@link StellarSepApi.sep10}.sign - the challenge with the user's signature. */
 export type Sep10Proof =
   | { status: 'signed'; signedXdr: string; signerAddress: string }
   | { status: 'error'; details?: string; code?: string };
@@ -598,7 +598,7 @@ export interface StellarSepApi {
  * A payment, addressed per chain.
  *
  * The asset is the one part that cannot be unified: Stellar identifies it by
- * code + issuer, Solana by SPL mint. Amounts differ too — Stellar takes a
+ * code + issuer, Solana by SPL mint. Amounts differ too - Stellar takes a
  * decimal string, Solana integer base units (lamports / mint units), because
  * that is what each chain's signer actually consumes.
  */
@@ -790,7 +790,7 @@ export function isPollarNetworkError(err: unknown): err is PollarNetworkError {
 /**
  * Automatic retry for idempotent, transient-failure SDK HTTP (the token refresh
  * and GETs). Only transport-level failures (timeouts, dropped connections)
- * retry — any HTTP response (including 4xx/5xx) is returned as-is and never
+ * retry - any HTTP response (including 4xx/5xx) is returned as-is and never
  * retried, so a refresh that's genuinely rejected logs out immediately rather
  * than after N pointless attempts.
  */
@@ -808,7 +808,7 @@ export interface PollarRetryConfig {
   baseDelayMs?: number;
 }
 
-// ─── Wallet balance types ─────────────────────────────────────────────────────
+// --- Wallet balance types -----------------------------------------------------
 
 /** A chain a wallet can live on. Mirrors the platform's WalletNetwork enum. */
 export type WalletChain = 'STELLAR' | 'POLYGON' | 'SOLANA';
@@ -825,7 +825,7 @@ export type WalletChain = 'STELLAR' | 'POLYGON' | 'SOLANA';
  * describe trustlines and stay Stellar-only; `decimals` is carried by Polygon and
  * Solana tokens, which need it to format raw amounts.
  *
- * `balance` is null when the chain could not be read — an unreachable RPC, not an
+ * `balance` is null when the chain could not be read - an unreachable RPC, not an
  * empty wallet. Render it as unavailable rather than as zero.
  */
 export interface WalletBalanceRecord {
@@ -865,7 +865,7 @@ export type WalletBalanceState =
   | { step: 'loaded'; data: WalletBalanceContent }
   | { step: 'error'; message: string };
 
-// ─── Enabled-asset types ──────────────────────────────────────────────────────
+// --- Enabled-asset types ------------------------------------------------------
 
 /**
  * One asset the app offers, tagged with the chain it lives on.
@@ -875,12 +875,12 @@ export type WalletBalanceState =
  * chain the app is provisioned on. Mirrors {@link WalletBalanceRecord}, which is
  * hand-written for the same reason.
  *
- * `trustlineEstablished`, `limit` and `sponsored` are Stellar-only — a trustline
+ * `trustlineEstablished`, `limit` and `sponsored` are Stellar-only - a trustline
  * is a Stellar concept, so an ERC-20 or SPL token needs no per-user opt-in to be
  * held and carries none of them. `decimals` is the mirror case: Polygon and
  * Solana tokens carry it, Stellar does not (every Stellar asset is 7-decimal).
  *
- * This is the app's CATALOG, not the user's holdings — amounts come from
+ * This is the app's CATALOG, not the user's holdings - amounts come from
  * {@link WalletBalanceRecord} via `refreshBalance`.
  */
 export interface EnabledAssetRecord {
@@ -901,7 +901,7 @@ export interface EnabledAssetRecord {
 
 /**
  * The app's enabled assets across every chain it is provisioned on, flattened
- * into one list. `multichain` is true when more than one chain answered — the UI
+ * into one list. `multichain` is true when more than one chain answered - the UI
  * uses it to decide whether to show a per-asset network tag.
  */
 export interface WalletAssetsContent {
@@ -918,7 +918,7 @@ export type EnabledAssetsState =
   | { step: 'loaded'; data: WalletAssetsContent }
   | { step: 'error'; message: string };
 
-// ─── Tx history types ─────────────────────────────────────────────────────────
+// --- Tx history types ---------------------------------------------------------
 
 export type TxHistoryRecord =
   pollarPaths['/tx/history']['get']['responses'][200]['content']['application/json']['content']['records'][number];
@@ -933,7 +933,7 @@ export type TxHistoryState =
   | { step: 'loaded'; params: TxHistoryParams; data: TxHistoryContent }
   | { step: 'error'; params: TxHistoryParams; message: string };
 
-// ─── KYC types ────────────────────────────────────────────────────────────────
+// --- KYC types ----------------------------------------------------------------
 
 export type KycLevel = 'basic' | 'intermediate' | 'enhanced';
 export type KycStatus = 'none' | 'pending' | 'approved' | 'rejected';
@@ -944,7 +944,7 @@ export type KycProvider =
 export type KycStartBody = NonNullable<pollarPaths['/kyc/start']['post']['requestBody']>['content']['application/json'];
 export type KycStartResponse = pollarPaths['/kyc/start']['post']['responses'][200]['content']['application/json']['content'];
 
-// ─── Ramps types ──────────────────────────────────────────────────────────────
+// --- Ramps types --------------------------------------------------------------
 
 export type RampsQuoteQuery = NonNullable<pollarPaths['/ramps/quote']['get']['parameters']['query']>;
 export type RampQuote =
@@ -970,7 +970,7 @@ export type RampDirection = RampsTransactionResponse['direction'];
  *
  * `fields` arrive labelled and formatted: iterate and display, no per-provider
  * knowledge needed. `scannable` carries the code the user points a camera at,
- * with the image already rendered so no QR encoder is required — Pollar-made
+ * with the image already rendered so no QR encoder is required - Pollar-made
  * SVGs (`image.inlineSafe`) use `currentColor` and can be injected as markup to
  * follow the host's theme; a provider's own bitmap must go through
  * `<img src="data:...">`. `scannable.payload` is the raw string behind the code:
@@ -1001,7 +1001,7 @@ export type RampsLiquidityResponse =
 export type RampRail = RampsLiquidityResponse['rail'];
 /**
  * Where the user stands with the provider's identity checks. Polled after an
- * off-ramp answered `kycRequired: true` — that provider (Abroad) publishes no
+ * off-ramp answered `kycRequired: true` - that provider (Abroad) publishes no
  * hosted KYC link, so the client waits for `hasApproved` and re-quotes.
  */
 export type RampsKycStatusResponse =
@@ -1010,7 +1010,7 @@ export type RampsPixDecodeResponse =
   pollarPaths['/ramps/pix/decode']['get']['responses'][200]['content']['application/json']['content'];
 export type RampsPixDecoded = NonNullable<RampsPixDecodeResponse['decoded']>;
 
-// ─── Distribution types ───────────────────────────────────────────────────────
+// --- Distribution types -------------------------------------------------------
 
 export type DistributionRule =
   pollarPaths['/distribution/rules']['get']['responses'][200]['content']['application/json']['content']['rules'][number];
@@ -1030,7 +1030,7 @@ export type DistributionRulesState =
   | { step: 'loaded'; rules: DistributionRule[] }
   | { step: 'error'; message: string };
 
-// ─── Swap types (DEX/AMM) ──────────────────────────────────────────────────────
+// --- Swap types (DEX/AMM) ------------------------------------------------------
 
 export type SwapQuoteBody = NonNullable<pollarPaths['/swap/quote']['post']['requestBody']>['content']['application/json'];
 
@@ -1054,7 +1054,7 @@ export type SwapTokensContent = pollarPaths['/swap/tokens']['get']['responses'][
 /** A single curated swap buy token. */
 export type SwapToken = SwapTokensContent['tokens'][number];
 
-/** Input to `client.getSwapQuote` — the request body minus wallet/network, which the client fills. */
+/** Input to `client.getSwapQuote` - the request body minus wallet/network, which the client fills. */
 export type SwapQuoteParams = {
   sellAsset: SwapQuoteBody['sellAsset'];
   buyAsset: SwapQuoteBody['buyAsset'];
@@ -1063,7 +1063,7 @@ export type SwapQuoteParams = {
   slippageBps?: number;
 };
 
-// ─── Earn types (yield vaults / lending) ───────────────────────────────────────
+// --- Earn types (yield vaults / lending) ---------------------------------------
 
 /** Providers this app exposes (from GET /earn/providers). Empty = Earn disabled. */
 export type EarnProvidersContent =
@@ -1091,14 +1091,14 @@ export type EarnBuildContent = pollarPaths['/earn/build']['post']['responses'][2
 /** The ready-to-sign payload a build returns. */
 export type EarnBuild = EarnBuildContent['build'];
 
-/** Input to `client.getEarnPosition` — wallet address is filled by the client. */
+/** Input to `client.getEarnPosition` - wallet address is filled by the client. */
 export type EarnPositionParams = {
   provider: EarnProviderId;
   /** Vault/pool id (an opportunity `id`). */
   opportunity: string;
 };
 
-/** Input to `client.earnDeposit` / `client.earnWithdraw` — address filled by the client. */
+/** Input to `client.earnDeposit` / `client.earnWithdraw` - address filled by the client. */
 export type EarnTxParams = {
   provider: EarnProviderId;
   /** Vault/pool id (an opportunity `id`). */
@@ -1107,7 +1107,7 @@ export type EarnTxParams = {
   amount: string;
 };
 
-// ─── Adapter types ────────────────────────────────────────────────────────────
+// --- Adapter types ------------------------------------------------------------
 
 export type AdapterFn<TParams = unknown> = (params: TParams) => Promise<{ unsignedTransaction: string }>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -746,9 +746,8 @@ export class PollarNetworkError extends Error {
 }
 
 /**
- * Thrown when the API answers with an error body. Endpoint helpers used to
- * collapse that body into `new Error(code)`, which threw away everything the
- * server said about WHY — so a caller could only ever show the bare code.
+ * Thrown when the API answers with an error body, keeping everything the
+ * server said about WHY instead of collapsing it to a bare code string.
  *
  * `code` is the stable machine-readable one (e.g. `SDK_RAMPS_AMOUNT_OUT_OF_RANGE`);
  * `details` is the server's human reason when it sends one; `body` is the whole
@@ -760,8 +759,8 @@ export class PollarApiError extends Error {
   readonly details?: string;
   readonly body: Record<string, unknown>;
   constructor(code: string, body: Record<string, unknown> = {}) {
-    // The message stays the code: existing callers that render `err.message`
-    // keep showing exactly what they showed before this class existed.
+    // The message stays the code, so anything that renders `err.message` shows
+    // the stable machine-readable code.
     super(code);
     this.name = 'PollarApiError';
     this.code = code;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,17 @@ export interface PollarPersistedSession {
   token: { accessToken: string; refreshToken: string; expiresAt: number };
   user: { id?: string; ready: boolean };
   /**
+   * RFC 7638 thumbprint of the DPoP keypair this session's tokens are bound
+   * to (`cnf.jkt`), stamped at store time. On restore the client compares it
+   * against the currently loaded keypair: a mismatch means the private key
+   * was lost (IndexedDB evicted/unavailable, key reset elsewhere) and every
+   * proof-bound call — resume and refresh included — is guaranteed to fail,
+   * so the session is cleared locally with a precise diagnostic instead of a
+   * burst of opaque 401s. Optional: absent on sessions persisted by older
+   * SDKs and on Bearer-fallback sessions, which skip the check.
+   */
+  dpopJkt?: string;
+  /**
    * BACK-COMPAT — the user's STELLAR wallet (or their smart account). Always
    * present, always Stellar. Mirrors the entry in `wallets` with
    * `chain: 'STELLAR'` when there is one.

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,7 +1,7 @@
 // Injected at build time by tsup (`define`) from `package.json#version`.
 // `declare` so TypeScript knows the identifier; at runtime it is either
 // replaced with a string literal (bundled builds) or absent (running the
-// source unbundled — ts-node, vitest), which the `typeof` guard below handles.
+// source unbundled - ts-node, vitest), which the `typeof` guard below handles.
 declare const __POLLAR_SDK_VERSION__: string;
 
 /**

--- a/packages/core/src/visibility/autodetect.ts
+++ b/packages/core/src/visibility/autodetect.ts
@@ -3,8 +3,8 @@ import type { VisibilityProvider } from './types';
 import { createWebVisibilityProvider } from './web';
 
 /**
- * Picks a `VisibilityProvider` based on the runtime: browser → web provider,
- * anything else → noop. React Native consumers should pass an `AppState`-
+ * Picks a `VisibilityProvider` based on the runtime: browser -> web provider,
+ * anything else -> noop. React Native consumers should pass an `AppState`-
  * backed provider explicitly via `PollarClientConfig.visibilityProvider`
  * (use `createAppStateVisibilityProvider` from
  * `@pollar/core/adapters/react-native-appstate`).

--- a/packages/core/src/visibility/types.ts
+++ b/packages/core/src/visibility/types.ts
@@ -2,7 +2,7 @@
  * Pluggable "is the user looking at this app right now?" signal.
  *
  * Used by the silent-refresh scheduler so token renewals are skipped while
- * the tab is hidden / the app is backgrounded — both saves network and
+ * the tab is hidden / the app is backgrounded - both saves network and
  * works around aggressive `setTimeout` throttling that web browsers and RN
  * apply to non-foreground contexts.
  *

--- a/packages/core/src/visibility/web.ts
+++ b/packages/core/src/visibility/web.ts
@@ -8,12 +8,12 @@ import type { VisibilityProvider } from './types';
  *   - `visibilitychange` is the canonical signal but lags on Safari macOS
  *     when switching between windows of the same app.
  *   - `pageshow` / `pagehide` fire when the page enters/leaves BFCache on
- *     iOS Safari — `visibilitychange` does not.
+ *     iOS Safari - `visibilitychange` does not.
  *   - `focus` / `blur` on window catch the macOS Safari multi-window case
  *     and are also the most-likely-to-fire signal on older browsers.
  *
  * Duplicate notifications are filtered by comparing against the last
- * dispatched state — listeners only see real transitions.
+ * dispatched state - listeners only see real transitions.
  */
 export function createWebVisibilityProvider(): VisibilityProvider {
   const isVisibleNow = (): boolean => typeof document === 'undefined' || document.visibilityState === 'visible';

--- a/packages/core/src/wallets/AlbedoAdapter.ts
+++ b/packages/core/src/wallets/AlbedoAdapter.ts
@@ -52,7 +52,7 @@ function waitForAlbedoPopup(): Promise<Record<string, string>> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(
       () => {
-        // Detach before rejecting — otherwise the listener leaks for the page
+        // Detach before rejecting - otherwise the listener leaks for the page
         // lifetime and a late/duplicate ALBEDO_RESULT could resolve an
         // already-timed-out promise (and accumulate across retries).
         window.removeEventListener('message', handler);
@@ -128,7 +128,7 @@ export class AlbedoAdapter implements WalletAdapter {
 
     // Popup + postMessage (same flow as `connect`). A top-level
     // `window.location.href` redirect would unload this document, destroying
-    // the realm the returned promise lives in — it would never resolve.
+    // the realm the returned promise lives in - it would never resolve.
     openAlbedoPopup(url.toString());
     const result = await waitForAlbedoPopup();
 
@@ -147,7 +147,7 @@ export class AlbedoAdapter implements WalletAdapter {
     url.searchParams.set('callback', `${window.location.origin}/albedo-callback`);
     url.searchParams.set('origin', window.location.origin);
 
-    // Popup + postMessage (see `signTransaction` — a redirect would unload the
+    // Popup + postMessage (see `signTransaction` - a redirect would unload the
     // page before the awaited promise could settle).
     openAlbedoPopup(url.toString());
     const result = await waitForAlbedoPopup();

--- a/packages/core/src/wallets/FreighterAdapter.ts
+++ b/packages/core/src/wallets/FreighterAdapter.ts
@@ -59,7 +59,7 @@ export class FreighterAdapter implements WalletAdapter {
     }
 
     // `requestAccess` prompts the user (if not already granted) and returns the
-    // active address — it replaces the v2 `isAllowed`/`setAllowed`/`getUserInfo`
+    // active address - it replaces the v2 `isAllowed`/`setAllowed`/`getUserInfo`
     // dance in a single call.
     const { address } = unwrap(await requestAccess(), 'requestAccess');
     if (!address) {
@@ -123,7 +123,7 @@ export class FreighterAdapter implements WalletAdapter {
   }
 }
 
-/** Standard base64 (padded) via the pure-JS base64url encoder — no `Buffer`, no
+/** Standard base64 (padded) via the pure-JS base64url encoder - no `Buffer`, no
  *  `btoa`, so it works in browser and RN alike. Matches the custodial path's
  *  `signature.toString('base64')` so both proof paths return one format. */
 function bytesToBase64(bytes: Uint8Array): string {

--- a/packages/core/src/wallets/types.ts
+++ b/packages/core/src/wallets/types.ts
@@ -66,7 +66,7 @@ export interface SignMessageResponse {
   signerAddress?: string;
 }
 
-// ─── Solana (SIWS) ────────────────────────────────────────────────────────────
+// --- Solana (SIWS) ------------------------------------------------------------
 // Structural mirror of the Wallet Standard's `solana:signIn` IO, kept here so
 // `@pollar/core` types the Solana adapter contract WITHOUT depending on
 // `@solana/wallet-standard-features`. `@pollar/solana-wallet-standard-adapter`
@@ -111,8 +111,8 @@ export interface WalletAdapterMeta {
   /**
    * Optional gateway grouping for the login UI. Adapters that share the same
    * `group` string collapse behind a single gateway button (labeled with the
-   * `group` value) that opens a sub-picker listing them — this is how the
-   * Stellar Wallets Kit wallets (Freighter, Albedo, xBull, …) stay behind one
+   * `group` value) that opens a sub-picker listing them - this is how the
+   * Stellar Wallets Kit wallets (Freighter, Albedo, xBull, ...) stay behind one
    * "Wallet" button. Adapters with no `group` render as their own button in the
    * root login view (e.g. Privy). Distinct group strings produce distinct
    * gateway buttons.
@@ -122,12 +122,12 @@ export interface WalletAdapterMeta {
 
 /**
  * A client-side wallet integration: it does its own auth/connect (Freighter
- * approve, Privy modal, SWK picker…) and signs. `@pollar/core` treats it as a
- * black box — it wraps the generic SEP-10 login + tx signing around `connect()`
+ * approve, Privy modal, SWK picker...) and signs. `@pollar/core` treats it as a
+ * black box - it wraps the generic SEP-10 login + tx signing around `connect()`
  * and `signTransaction()`. Register instances via `PollarClientConfig.walletAdapters`.
  */
 export interface WalletAdapter {
-  /** Stable id — matches `login({ provider: id })` and the server-side wallet provider. */
+  /** Stable id - matches `login({ provider: id })` and the server-side wallet provider. */
   type: WalletId;
   /** UI metadata for the auto-rendered login button. */
   meta: WalletAdapterMeta;
@@ -143,22 +143,22 @@ export interface WalletAdapter {
   connect(): Promise<ConnectWalletResponse>;
   disconnect(): Promise<void>;
   getPublicKey(): Promise<string | null>;
-  // ─── Stellar signing (SEP-10 login + Soroban) ──────────────────────────────
+  // --- Stellar signing (SEP-10 login + Soroban) ------------------------------
   // Optional because non-Stellar adapters do not implement them. The Stellar
   // flows assert their presence (a STELLAR adapter that omits them is a bug).
   signTransaction?(xdr: string, options?: SignTransactionOptions): Promise<SignTransactionResponse>;
   signAuthEntry?(entryXdr: string, options?: SignAuthEntryOptions): Promise<SignAuthEntryResponse>;
   /**
    * SEP-53: sign an arbitrary message and return the base64 signature + signer
-   * address. Stellar adapters only, and optional even among them — not every
+   * address. Stellar adapters only, and optional even among them - not every
    * wallet exposes message signing (e.g. Albedo does not). Used by the
    * `client.stellar.sep53` ownership-proof flow for external wallets.
    */
   signStellarMessage?(message: string, options?: SignMessageOptions): Promise<SignMessageResponse>;
-  // ─── Solana signing (SIWS login + phase-2 transfers) ───────────────────────
+  // --- Solana signing (SIWS login + phase-2 transfers) -----------------------
   /** SIWS: sign the server-issued Sign In With Solana input. Solana adapters only. */
   signIn?(input: SolanaSignInInput): Promise<SolanaSignInOutput>;
-  /** Raw message signature — the SIWS fallback for wallets without `solana:signIn`. */
+  /** Raw message signature - the SIWS fallback for wallets without `solana:signIn`. */
   signMessage?(message: Uint8Array): Promise<SolanaSignMessageResponse>;
   /** Sign a serialized Solana transaction (phase 2: sponsored external transfers). */
   signSolanaTransaction?(transaction: Uint8Array, chain?: string): Promise<Uint8Array>;
@@ -189,7 +189,7 @@ export interface InteractiveAuthAdapter extends WalletAdapter {
   /**
    * Optional: subscribe to the underlying provider's auth state. The host uses
    * this to auto-trigger `login({ provider })` when the provider authenticates
-   * outside the sub-modal flow — e.g. after an OAuth redirect (the page reloaded,
+   * outside the sub-modal flow - e.g. after an OAuth redirect (the page reloaded,
    * so the sub-modal promise is gone) or a persisted provider session on load.
    * Fires on subscribe with the current state, then on changes. Returns an
    * unsubscribe function.

--- a/packages/privy-adapter/package.json
+++ b/packages/privy-adapter/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/pollar-xyz/pollar.git",
     "directory": "packages/privy-adapter"
   },
-  "description": "Privy client-side wallet adapter for @pollar/core — sign Stellar transactions with a user's Privy embedded Stellar wallet via raw-hash signing.",
+  "description": "Privy client-side wallet adapter for @pollar/core - sign Stellar transactions with a user's Privy embedded Stellar wallet via raw-hash signing.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/privy-adapter/package.json
+++ b/packages/privy-adapter/package.json
@@ -71,11 +71,9 @@
       "optional": true
     }
   },
-  "dependencies": {
-    "@pollar/core": "^0.11.2"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@pollar/core": "^0.11.2",
     "@privy-io/expo": "^0.69.4",
     "@privy-io/react-auth": "^3.32.2",
     "@stellar/stellar-sdk": "^15.1.0",

--- a/packages/privy-adapter/src/config.ts
+++ b/packages/privy-adapter/src/config.ts
@@ -26,7 +26,7 @@ export interface PollarPrivyAppearance {
  * install `@privy-io/react-auth` just for the types.
  */
 export interface PollarPrivyConfig {
-  /** Your Privy app id (Privy dashboard → app settings). */
+  /** Your Privy app id (Privy dashboard -> app settings). */
   appId: string;
   /** Optional Privy app client id, for apps scoped to a specific client key. */
   clientId?: string;

--- a/packages/privy-adapter/src/environment.ts
+++ b/packages/privy-adapter/src/environment.ts
@@ -6,12 +6,12 @@
  * There is **no** Privy SDK for Angular, Vue, Svelte or vanilla JS. So this
  * adapter supports exactly two hosts: React (web) and Expo / React Native.
  *
- * We can't reliably fingerprint the host framework at build time — Angular, Vue
+ * We can't reliably fingerprint the host framework at build time - Angular, Vue
  * and React web all resolve the same "web" bundle (only the `react-native`
  * export condition is distinguishable). The support boundary is therefore
  * enforced at runtime: the adapter only works once a platform bridge
  * (`<PrivyAdapterProvider>` on web, the Expo provider on RN) mounts and attaches
- * its runtime. If none ever does — the typical Angular/Vue case — the first use
+ * its runtime. If none ever does - the typical Angular/Vue case - the first use
  * fails with {@link PrivyAdapterUnsupportedError} instead of hanging or throwing
  * a cryptic "react-auth not found".
  */

--- a/packages/privy-adapter/src/index.tsx
+++ b/packages/privy-adapter/src/index.tsx
@@ -50,7 +50,7 @@ function toPrivyClientConfig(config: PollarPrivyConfig): PrivyClientConfig {
       solana: { createOnLogin: 'off' },
     },
   };
-  // Build appearance only from defined fields — `exactOptionalPropertyTypes`
+  // Build appearance only from defined fields - `exactOptionalPropertyTypes`
   // forbids assigning `undefined` to optional props.
   const a = config.appearance;
   if (a) {
@@ -97,7 +97,7 @@ function PrivyRuntimeBridge({ adapter }: BridgeProps) {
   api.current = { privy, sendCode, loginWithCode, initOAuth, createWallet, signRawHash };
 
   // Trace Privy's auth state. If this logs `authenticated: true` but Pollar still
-  // shows logged-out, the handoff (login({ provider:'privy' })) never ran — e.g.
+  // shows logged-out, the handoff (login({ provider:'privy' })) never ran - e.g.
   // an OAuth redirect that lost the in-page promise.
   useEffect(() => {
     const address = findStellarAddress(privy.user);
@@ -113,7 +113,7 @@ function PrivyRuntimeBridge({ adapter }: BridgeProps) {
 
   // Keep the host app's URL clean: once authenticated, strip Privy's OAuth
   // redirect params. react-auth usually does this, but skips it when the user
-  // was already logged in — so we always do it ourselves. `replaceState` does
+  // was already logged in - so we always do it ourselves. `replaceState` does
   // not reload or add a history entry.
   useEffect(() => {
     if (!privy.authenticated || typeof window === 'undefined') return;
@@ -141,7 +141,7 @@ function PrivyRuntimeBridge({ adapter }: BridgeProps) {
         new Promise<void>((resolve, reject) => {
           oauthPending.current = { resolve, reject };
           // On web, `initOAuth` redirects (or opens a popup); completion arrives
-          // via the onComplete callback above — after the redirect round-trip,
+          // via the onComplete callback above - after the redirect round-trip,
           // which the Pollar sub-modal resumes once Privy reports authenticated.
           log('web: initOAuth invoked (web uses a redirect/popup)', { provider });
           api.current.initOAuth({ provider }).catch((error) => {

--- a/packages/privy-adapter/src/log.ts
+++ b/packages/privy-adapter/src/log.ts
@@ -9,7 +9,7 @@ export function setPrivyAdapterDebug(on: boolean): void {
   DEBUG = on;
 }
 
-/** Verbose trace log — a no-op unless debug is enabled. */
+/** Verbose trace log - a no-op unless debug is enabled. */
 export function log(message: string, data?: unknown): void {
   if (!DEBUG) return;
   if (data !== undefined) {

--- a/packages/privy-adapter/src/runtime.ts
+++ b/packages/privy-adapter/src/runtime.ts
@@ -17,7 +17,7 @@ import { log, setPrivyAdapterDebug } from './log.ts';
 export const PRIVY_ID = 'privy';
 
 /**
- * Platform-agnostic contract a Privy "bridge" fulfils — `@privy-io/react-auth`
+ * Platform-agnostic contract a Privy "bridge" fulfils - `@privy-io/react-auth`
  * on web, `@privy-io/expo` on React Native. Both SDKs are hook-based and must
  * run inside a React tree, so the bridge captures those hooks and exposes them
  * imperatively here, letting the {@link WalletAdapter} drive login + signing
@@ -43,7 +43,7 @@ export interface PrivyRuntime {
   ensureStellarWallet(): Promise<string>;
   /**
    * Raw-hash sign (ed25519) over the 32-byte transaction hash. Hex in, hex out
-   * — mirrors Privy's `signRawHash` for `chainType: 'stellar'`.
+   * - mirrors Privy's `signRawHash` for `chainType: 'stellar'`.
    */
   signRawHash(address: string, hashHex: string): Promise<string>;
   /** The authenticated Stellar address, or null if not logged in / no wallet. */
@@ -77,7 +77,7 @@ const LOGIN_METHOD_TO_OPTION: Record<PrivyLoginMethod, AuthOption> = {
  * Build the platform-agnostic Privy {@link WalletAdapter}. The returned handle
  * is inert until a platform bridge calls `_attachRuntime`; any method invoked
  * before that waits briefly and then throws {@link PrivyAdapterUnsupportedError}
- * — the signal that there is no React/Expo host (e.g. Angular/Vue) or the bridge
+ * - the signal that there is no React/Expo host (e.g. Angular/Vue) or the bridge
  * was never mounted.
  */
 export function buildPrivyAdapter(config: PollarPrivyConfig): PrivyAdapterHandle {

--- a/packages/privy-adapter/test/runtime.test.ts
+++ b/packages/privy-adapter/test/runtime.test.ts
@@ -6,7 +6,7 @@ import { buildPrivyAdapter, type PrivyRuntime } from '../src/runtime.ts';
 import { PrivyAdapterUnsupportedError } from '../src/environment.ts';
 
 // These tests exercise the framework-agnostic core (`buildPrivyAdapter`) with a
-// MOCK PrivyRuntime — no Privy SDK, no app id, no browser. The mock stands in for
+// MOCK PrivyRuntime - no Privy SDK, no app id, no browser. The mock stands in for
 // what the web/RN bridge would attach; a real Stellar keypair plays the role of
 // Privy's `signRawHash`, so we can prove the adapter emits a cryptographically
 // valid Stellar signature without any Privy infrastructure.
@@ -61,7 +61,7 @@ test('signTransaction produces a valid Stellar signature via the runtime', async
   assert.equal(signed.signatures.length, 1);
   const sig = signed.signatures[0]!;
   // The decorated signature must verify against the original tx hash + keypair,
-  // and carry the keypair's hint — i.e. it is exactly what `tx.sign(kp)` yields.
+  // and carry the keypair's hint - i.e. it is exactly what `tx.sign(kp)` yields.
   assert.ok(kp.verify(signed.hash(), sig.signature()), 'signature verifies against the tx hash');
   assert.deepEqual(sig.hint(), kp.signatureHint(), 'decorated signature carries the keypair hint');
 });
@@ -123,7 +123,7 @@ test('getPublicKey is null before a runtime attaches', async () => {
 
 test('throws PrivyAdapterUnsupportedError when no runtime ever attaches', async () => {
   // No bridge mounts (e.g. Angular/Vue). The method waits for the attach timeout
-  // and then fails clearly. ~5s by design — the only slow test here.
+  // and then fails clearly. ~5s by design - the only slow test here.
   const adapter = buildPrivyAdapter({ appId: 'app', loginMethods: ['email'] });
   await assert.rejects(
     () => adapter.signTransaction(buildTxXdr(), { networkPassphrase: PASSPHRASE }),

--- a/packages/privy-adapter/tsup.config.ts
+++ b/packages/privy-adapter/tsup.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   ],
   // The web entry renders React hooks, so it must be a client module under
   // Next.js app-router. tsup/esbuild strip a module-level "use client" (and the
-  // `banner` option too), so prepend it to the built files post-build — same
+  // `banner` option too), so prepend it to the built files post-build - same
   // approach as `@pollar/react`. Web entry only (the directive is meaningless in
   // React Native).
   async onSuccess() {

--- a/packages/privy-server-adapter/src/index.ts
+++ b/packages/privy-server-adapter/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @pollar/privy-server-adapter — SERVER-SIDE ONLY.
+ * @pollar/privy-server-adapter - SERVER-SIDE ONLY.
  *
  * This package binds an HTTP listener via `@hono/node-server` and consumes
  * `PRIVY_APP_SECRET` + `POLLAR_API_SECRET` from the host environment. Do not
  * import it in a browser bundle, a React Native app, or any other client-side
- * runtime — credentials would leak and `node:*` imports would fail to bundle.
+ * runtime - credentials would leak and `node:*` imports would fail to bundle.
  */
 import { serve } from '@hono/node-server';
 import { LRUCache } from 'lru-cache';

--- a/packages/privy-server-adapter/src/lib/user-mapping.ts
+++ b/packages/privy-server-adapter/src/lib/user-mapping.ts
@@ -6,7 +6,7 @@ export interface PrivyUserResolution {
   created: boolean;
 }
 
-// Privy stores the Pollar-userId → did:privy:... mapping natively in
+// Privy stores the Pollar-userId -> did:privy:... mapping natively in
 // linked_accounts[type=custom_auth]. We never persist it on the adapter side:
 // every resolution round-trips to Privy. On miss, we create the Privy user
 // atomically with a stellar embedded wallet so the next call already has
@@ -33,7 +33,7 @@ export const getOrCreatePrivyUser = async (
     );
     return { user, created: true };
   } catch (err) {
-    // Lost a race against a concurrent create — the user exists now.
+    // Lost a race against a concurrent create - the user exists now.
     if (err instanceof ConflictError) {
       const user = await withTimeout(privy.users().getByCustomAuthID({ custom_user_id: customUserId }), options.timeoutMs);
       return { user, created: false };

--- a/packages/privy-server-adapter/src/middleware/bearer.ts
+++ b/packages/privy-server-adapter/src/middleware/bearer.ts
@@ -16,7 +16,7 @@ export const createBearerMiddleware = (pollarApiSecret: string) => {
     }
 
     const provided = Buffer.from(auth.slice(7), 'utf8');
-    // timingSafeEqual throws on length mismatch — guard first.
+    // timingSafeEqual throws on length mismatch - guard first.
     if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
       c.header('WWW-Authenticate', WWW_AUTH_INVALID);
       return c.var.error(ErrorCode.FORBIDDEN, 401);

--- a/packages/privy-server-adapter/src/privy.ts
+++ b/packages/privy-server-adapter/src/privy.ts
@@ -13,7 +13,7 @@ export const createPrivyClientFactory = (config: ResolvedAdapterConfig) => {
   // Coalesce concurrent expired-cache calls. Without this, two requests
   // arriving while `entry` is null/expired would each call
   // `config.getCredentials()` and `new PrivyClient(...)`, with the second
-  // overwriting the first — wasted creds fetch + an orphaned client.
+  // overwriting the first - wasted creds fetch + an orphaned client.
   let pending: Promise<PrivyClient> | null = null;
 
   return async (): Promise<PrivyClient> => {
@@ -31,7 +31,7 @@ export const createPrivyClientFactory = (config: ResolvedAdapterConfig) => {
         const fingerprint = createHash('sha256').update(`${appId}:${appSecret}`).digest('hex');
 
         if (entry && entry.fingerprint === fingerprint) {
-          // Credentials unchanged — extend TTL, keep client to avoid reconnect overhead.
+          // Credentials unchanged - extend TTL, keep client to avoid reconnect overhead.
           entry.expiresAt = Date.now() + config.cacheTtlMs;
           return entry.client;
         }

--- a/packages/privy-server-adapter/src/routes/wallets-create.ts
+++ b/packages/privy-server-adapter/src/routes/wallets-create.ts
@@ -17,13 +17,13 @@ export const createWalletsCreateRoute = (deps: AdapterDeps) => {
    * `getOrCreatePrivyUser` already handles the user-creation race (Privy
    * returns `ConflictError` on the second `users.create`, we fall back to
    * fetch). But for an EXISTING user without a stellar wallet, both
-   * requests fall through `findStellarWalletInUser → null` and both call
-   * `wallets().create(...)` — Privy doesn't dedupe by user, so you get two
+   * requests fall through `findStellarWalletInUser -> null` and both call
+   * `wallets().create(...)` - Privy doesn't dedupe by user, so you get two
    * stellar wallets attached to the same Privy user, with the second
    * overwriting the first in `walletCache`.
    *
    * The mutex is per-process: scaling the adapter to N replicas reintroduces
-   * the race across instances. That's an accepted trade-off — the adapter is
+   * the race across instances. That's an accepted trade-off - the adapter is
    * documented as stateless beyond in-memory caches.
    */
   const inflight = new Map<string, Promise<{ address: string; walletCreated: boolean }>>();

--- a/packages/privy-server-adapter/src/routes/wallets-sign.ts
+++ b/packages/privy-server-adapter/src/routes/wallets-sign.ts
@@ -50,7 +50,7 @@ export const createWalletsSignRoute = (deps: AdapterDeps) => {
       let walletId = deps.walletCache.get(walletAddress);
 
       if (!walletId) {
-        // Cache miss: resolve userId → did:privy: and inspect linked_accounts
+        // Cache miss: resolve userId -> did:privy: and inspect linked_accounts
         // to find the matching wallet. We do NOT auto-create here; sign without
         // a pre-existing wallet must surface as WALLET_NOT_FOUND so the caller
         // can route through the create flow first.
@@ -86,7 +86,7 @@ export const createWalletsSignRoute = (deps: AdapterDeps) => {
       } catch (err) {
         // Cache may have a stale walletId (wallet detached / deleted on
         // Privy side between resolution and now). Evict so the next request
-        // re-resolves from Privy — this request still fails, but we don't
+        // re-resolves from Privy - this request still fails, but we don't
         // keep returning errors for the same stale entry until TTL expires.
         if (err instanceof NotFoundError) {
           deps.walletCache.delete(walletAddress);
@@ -107,7 +107,7 @@ export const createWalletsSignRoute = (deps: AdapterDeps) => {
       const err = error instanceof Error ? error : new Error(String(error));
       // Raw error goes to the host's `onError` callback for server-side logging
       // (Privy SDK errors can include user IDs, rate-limit context, internal
-      // identifiers — none of which the caller should see). The HTTP response
+      // identifiers - none of which the caller should see). The HTTP response
       // is intentionally code-only.
       deps.config.onError?.(err, { endpoint: 'POST /wallets/sign', body: parsed });
       return c.var.error(ErrorCode.TX_SIGN_FAILED, 502);

--- a/packages/privy-server-adapter/src/stellar.ts
+++ b/packages/privy-server-adapter/src/stellar.ts
@@ -35,12 +35,12 @@ export interface OperationValidation {
  * Enforces the configured operation allowlist on a parsed transaction.
  *
  * Precedence:
- *  - If neither field is set → no restriction (legacy behavior): `{ ok: true }`.
+ *  - If neither field is set -> no restriction (legacy behavior): `{ ok: true }`.
  *  - `allowedOperations` (when set) is the base allowlist of stellar-sdk
  *    operation type names.
  *  - `restrictToTrustlines: true` adds the trustline preset
- *    (`TRUSTLINE_OPERATION_ALLOWLIST`) to the allowlist — so the effective set is
- *    the UNION of `allowedOperations` and the preset — and additionally requires
+ *    (`TRUSTLINE_OPERATION_ALLOWLIST`) to the allowlist - so the effective set is
+ *    the UNION of `allowedOperations` and the preset - and additionally requires
  *    the transaction to contain at least one `changeTrust` operation.
  *
  * Returns `{ ok: false, reason }` on the first violation; `reason` is safe to
@@ -49,7 +49,7 @@ export interface OperationValidation {
 export const validateTxOperations = (tx: Transaction, policy: OperationPolicy): OperationValidation => {
   const restrict = policy.restrictToTrustlines === true;
 
-  // No allowlist configured at all → legacy: sign any (non-fee-bump) tx.
+  // No allowlist configured at all -> legacy: sign any (non-fee-bump) tx.
   if (!restrict && !policy.allowedOperations) {
     return { ok: true };
   }

--- a/packages/privy-server-adapter/src/types.ts
+++ b/packages/privy-server-adapter/src/types.ts
@@ -45,7 +45,7 @@ export interface PollarPrivyAdapterConfig {
   // rules between the two fields below.
   //
   // `allowedOperations`: explicit list of stellar-sdk operation type names
-  // (e.g. ['changeTrust', 'payment']). `undefined` → no restriction (legacy).
+  // (e.g. ['changeTrust', 'payment']). `undefined` -> no restriction (legacy).
   allowedOperations?: string[];
   // `restrictToTrustlines`: shortcut that allows the trustline preset
   // (changeTrust + the sponsorship sandwich) AND additionally requires at least

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,8 +8,17 @@ Stellar and Solana applications.
 > browser passkey ceremony on every path (via core's new `setPasskeyDefaults()`), and an
 > explicit `passkey: undefined` no longer wipes the default. `browserPasskeyCeremony` and
 > `browserPasskeySigner` are now exported for consumers who build their own client or want
-> to wrap the ceremony. If you pin exact versions, bump `@pollar/react` and `@pollar/core`
-> together.
+> to wrap the ceremony. Also, **StrictMode no longer leaves an orphaned `PollarClient`
+> running**: the provider keys the client it builds on the config object, so StrictMode's
+> second render pass reuses the first pass's instance instead of constructing a second
+> client whose refresh loop could clear the session the real login just wrote (dev only,
+> no API change). Packaging: **`@pollar/core` moved from `dependencies` to
+> `peerDependencies`**, so npm no longer installs a package-local duplicate of core (the
+> configuration that broke `instanceof` and split the live-client registry); the provider
+> now discriminates with core's new `isPollarClient()` guard, which works across copies.
+> npm 7+ installs peers automatically; on npm 6, Yarn 1 or `--legacy-peer-deps`, add
+> `@pollar/core` to your own dependencies. If you pin exact versions, keep both packages
+> on the same version.
 >
 > Earlier: **0.11.2** required `@pollar/core@^0.11.2`. The **Transaction History modal
 > goes multichain**: the same network picker and address chip as the Balance /

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,7 +3,15 @@
 React bindings for [Pollar](https://pollar.xyz) — drop-in authentication UI, transaction modals, and hooks for
 Stellar and Solana applications.
 
-> **0.11.2** requires `@pollar/core@^0.11.2`. The **Transaction History modal
+> **0.11.3** requires `@pollar/core@^0.11.3`. Non-breaking. A **pre-built `PollarClient`
+> passed to `PollarProvider` no longer loses passkey support**: the provider installs the
+> browser passkey ceremony on every path (via core's new `setPasskeyDefaults()`), and an
+> explicit `passkey: undefined` no longer wipes the default. `browserPasskeyCeremony` and
+> `browserPasskeySigner` are now exported for consumers who build their own client or want
+> to wrap the ceremony. If you pin exact versions, bump `@pollar/react` and `@pollar/core`
+> together.
+>
+> Earlier: **0.11.2** required `@pollar/core@^0.11.2`. The **Transaction History modal
 > goes multichain**: the same network picker and address chip as the Balance /
 > Send modals, a server-side chain filter (pagination is server-side, so
 > switching networks refetches and resets to page 1), per-chain explorer links

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/react",
-  "version": "0.11.2",
+  "version": "0.11.3-rc.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -40,12 +40,12 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@pollar/core": "^0.11.2",
+    "@pollar/core": "^0.11.3-rc.1",
     "react": ">=18",
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.2",
+    "@pollar/core": "^0.11.3-rc.1",
     "@simplewebauthn/browser": "^13.3.0",
     "qr.js": "^0.0.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollar/react",
-  "version": "0.11.3-rc.1",
+  "version": "0.11.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -40,12 +40,12 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@pollar/core": "^0.11.3-rc.1",
+    "@pollar/core": "^0.11.3",
     "react": ">=18",
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.3-rc.1",
+    "@pollar/core": "^0.11.3",
     "@simplewebauthn/browser": "^13.3.0",
     "qr.js": "^0.0.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,12 +45,12 @@
     "react-dom": ">=18"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.3",
     "@simplewebauthn/browser": "^13.3.0",
     "qr.js": "^0.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@pollar/core": "^0.11.3",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "eslint": "^10.5.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,6 +55,7 @@
     "@types/react-dom": "^18.0.0",
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "jsdom": "^29.1.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "tsup": "^8.5.1",

--- a/packages/react/src/components/AssetSelect.tsx
+++ b/packages/react/src/components/AssetSelect.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-// ─── Shared asset picker ──────────────────────────────────────────────────────
+// --- Shared asset picker ------------------------------------------------------
 // One asset <select> used by both the Send and Swap modals: groups options into
 // "App assets" (enabled by the app) and "Other assets" (everything else, incl.
-// native XLM), shows a "— X available" suffix, and renders a skeleton shimmer
+// native XLM), shows a "- X available" suffix, and renders a skeleton shimmer
 // while loading. The parent auto-selects the first option, so there is no
 // "Select asset" placeholder in the normal flow.
-// ─────────────────────────────────────────────────────────────────────────────
+// -----------------------------------------------------------------------------
 
 import type { ReactNode } from 'react';
 import './send-modal/SendModal.css';
@@ -17,7 +17,7 @@ export interface AssetSelectOption {
   /** Stable unique key: `code:issuer` or `code:native`. */
   key: string;
   code: string;
-  /** Spendable amount shown as "— X available"; omit to hide the suffix. */
+  /** Spendable amount shown as "- X available"; omit to hide the suffix. */
   available?: string | undefined;
   /** App-enabled asset? Drives the App / Other grouping. */
   enabledInApp?: boolean | undefined;

--- a/packages/react/src/components/ChainSelect.tsx
+++ b/packages/react/src/components/ChainSelect.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-// ─── Shared network picker ────────────────────────────────────────────────────
+// --- Shared network picker ----------------------------------------------------
 // One chain <select> used by the Send, Wallet Balance and Assets modals. The
 // options are the chains the user actually holds a wallet on (`getWallets()`),
 // so every option always resolves to an address; the parent defaults to the
-// first one. Everything else in those modals — address, assets, balances — is
+// first one. Everything else in those modals - address, assets, balances - is
 // filtered by whatever is picked here.
-// ─────────────────────────────────────────────────────────────────────────────
+// -----------------------------------------------------------------------------
 
 import type { WalletChain, WalletInfo } from '@pollar/core';
 import './send-modal/SendModal.css';
@@ -28,7 +28,7 @@ export function resolveChain(chain: WalletChain | undefined): WalletChain {
 }
 
 /**
- * The selectable chains — the first is the default everywhere (network picker,
+ * The selectable chains - the first is the default everywhere (network picker,
  * the address the wallet button shows). De-duplicated because two wallets on one
  * chain (e.g. a custodial and a linked external Stellar wallet) are still one
  * network choice.

--- a/packages/react/src/components/commons.tsx
+++ b/packages/react/src/components/commons.tsx
@@ -169,7 +169,7 @@ export function ModalStatusBanner({ message, status, onCancel, onRetry }: ModalS
  *
  * Shared by the balance and asset lists: both render per-chain rows and must
  * agree on the label and colour, so the palette lives in one place. Callers show
- * it only when the app spans more than one chain — a Stellar-only app would just
+ * it only when the app spans more than one chain - a Stellar-only app would just
  * see the same tag on every row.
  */
 const CHAIN_TAG: Record<string, { label: string; color: string }> = {
@@ -199,7 +199,7 @@ export function cropAddress(address: string): string {
  * The balance/assets state machines drop their payload while a refresh is in
  * flight (`step` leaves `'loaded'`), which would blank the list on every
  * refresh. Holding the previous data lets the modal keep rendering it under a
- * {@link BusyOverlay} instead — the list never collapses and then reflows.
+ * {@link BusyOverlay} instead - the list never collapses and then reflows.
  */
 export function useStickyData<T>(data: T | null): T | null {
   const lastRef = useRef<T | null>(null);

--- a/packages/react/src/components/distribution-rules-modal/DistributionRulesModal.tsx
+++ b/packages/react/src/components/distribution-rules-modal/DistributionRulesModal.tsx
@@ -6,6 +6,7 @@ import { usePollar } from '../../context';
 import '../shared.css';
 import './DistributionRulesModal.css';
 import { DistributionRulesModalTemplate } from './DistributionRulesModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface DistributionRulesModalProps {
   onClose: () => void;
@@ -13,7 +14,7 @@ interface DistributionRulesModalProps {
 
 export function DistributionRulesModal({ onClose }: DistributionRulesModalProps) {
   const { getClient, styles } = usePollar();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const [state, setState] = useState<DistributionRulesState>({ step: 'idle' });
   const [claimingId, setClaimingId] = useState<string | null>(null);
@@ -62,10 +63,11 @@ export function DistributionRulesModal({ onClose }: DistributionRulesModalProps)
   );
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <DistributionRulesModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         state={state}
         claimingId={claimingId}
         claimErrors={claimErrors}

--- a/packages/react/src/components/distribution-rules-modal/DistributionRulesModalTemplate.tsx
+++ b/packages/react/src/components/distribution-rules-modal/DistributionRulesModalTemplate.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { DistributionRule, DistributionRulesState } from '@pollar/core';
-import { type CSSProperties } from 'react';
 import { PollarModalFooter } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 interface DistributionRulesModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   state: DistributionRulesState;
   claimingId: string | null;
   claimErrors: Record<string, string>;
@@ -116,6 +118,7 @@ function RuleCard({
 export function DistributionRulesModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   state,
   claimingId,
   claimErrors,
@@ -124,25 +127,7 @@ export function DistributionRulesModalTemplate({
   onClaim,
   onClose,
 }: DistributionRulesModalTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const isLoading = state.step === 'loading';
   const rules = state.step === 'loaded' ? state.rules : [];

--- a/packages/react/src/components/distribution-rules-modal/DistributionRulesModalTemplate.tsx
+++ b/packages/react/src/components/distribution-rules-modal/DistributionRulesModalTemplate.tsx
@@ -35,7 +35,7 @@ const REASON_LABEL: Record<string, string> = {
   DISTRIBUTION_RULE_NOT_STARTED: 'Not started yet',
   DISTRIBUTION_RULE_EXPIRED: 'Expired',
   DISTRIBUTION_RULE_EXHAUSTED: 'Fully claimed',
-  // Per-user, per-window claim limit (resets next period) — not permanent.
+  // Per-user, per-window claim limit (resets next period) - not permanent.
   DISTRIBUTION_RATE_LIMIT_EXCEEDED: 'Claimed for this period',
 };
 

--- a/packages/react/src/components/earn-modal/EarnModal.tsx
+++ b/packages/react/src/components/earn-modal/EarnModal.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { EarnOpportunity, EarnPosition, EarnProviderId } from '@pollar/core';
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePollar } from '../../context';
 import { PollarModalFooter } from '../commons';
+import { buildModalCssVars, modalChrome } from '../modal-theme';
 import { TxStatusView } from '../transaction-modal/TxStatusView';
 import '../shared.css';
 import '../transaction-modal/TransactionModal.css';
@@ -57,8 +58,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
 
   const walletType = wallet?.custody === 'external' ? wallet.provider : null;
   const smartUnsupported = wallet?.custody === 'smart';
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
-  const isDark = theme === 'dark';
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const [step, setStep] = useState<'form' | 'tx'>('form');
   const [tab, setTab] = useState<'deposit' | 'withdraw'>('deposit');
@@ -229,23 +229,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
     !providersLoading &&
     !loadingOpps;
 
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   // ─── Actions ────────────────────────────────────────────────────────────────
   async function handleSubmit() {
@@ -343,7 +327,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
   const title = step === 'form' ? 'Earn' : txTitle;
 
   return (
-    <div className="pollar-overlay" onClick={!isInProgress ? onClose : undefined}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={!isInProgress ? onClose : undefined}>
       <div
         className="pollar-modal-card pollar-send-modal"
         data-theme={theme}

--- a/packages/react/src/components/earn-modal/EarnModal.tsx
+++ b/packages/react/src/components/earn-modal/EarnModal.tsx
@@ -75,7 +75,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // ─── Providers ────────────────────────────────────────────────────────────
+  // --- Providers ------------------------------------------------------------
   const loadProviders = useCallback(() => {
     setProviders(null);
     return getEarnProviders()
@@ -97,7 +97,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
     void refreshAssets();
   }, [refreshWalletBalance, refreshAssets]);
 
-  // ─── Opportunities (per provider) ───────────────────────────────────────────
+  // --- Opportunities (per provider) -------------------------------------------
   useEffect(() => {
     if (!provider) return;
     let cancelled = false;
@@ -121,7 +121,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
 
   const selectedOpportunity = opportunities.find((o) => o.id === opportunityId) ?? null;
 
-  // ─── Position (live, polled) ────────────────────────────────────────────────
+  // --- Position (live, polled) ------------------------------------------------
   const refreshPosition = useCallback(() => {
     if (!provider || !opportunityId || !wallet) return;
     getEarnPosition({ provider, opportunity: opportunityId })
@@ -149,7 +149,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
     [],
   );
 
-  // ─── Derived ────────────────────────────────────────────────────────────────
+  // --- Derived ----------------------------------------------------------------
   const providersLoading = providers === null;
   const earnUnavailable = providers !== null && providers.length === 0;
   const withdrawUnit = position?.withdrawUnit ?? 'asset';
@@ -231,7 +231,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
 
   const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
-  // ─── Actions ────────────────────────────────────────────────────────────────
+  // --- Actions ----------------------------------------------------------------
   async function handleSubmit() {
     setFormError('');
     if (smartUnsupported) {
@@ -258,9 +258,9 @@ export function EarnModal({ onClose }: EarnModalProps) {
     setStep('tx');
 
     // Deposit of an issued asset needs its trustline first (native never does).
-    // Establish it, then deposit — two signatures, like swap.
+    // Establish it, then deposit - two signatures, like swap.
     if (tab === 'deposit' && depositNeedsTrustline && selectedOpportunity?.asset.issuer) {
-      // Sponsorship is derived automatically from the app config now — no flag.
+      // Sponsorship is derived automatically from the app config now - no flag.
       const tl = await setTrustline({ code: assetCode, issuer: selectedOpportunity.asset.issuer });
       if (tl.status === 'error') {
         setFormError(`Trustline for ${assetCode} failed: ${tl.details ?? 'unknown error'}`);
@@ -318,7 +318,7 @@ export function EarnModal({ onClose }: EarnModalProps) {
       setOpportunityId((cur) => (opps.some((o) => o.id === cur) ? cur : (opps[0]?.id ?? '')));
       refreshPosition();
     } catch {
-      /* transient — keep the current snapshot */
+      /* transient - keep the current snapshot */
     } finally {
       setRefreshing(false);
     }

--- a/packages/react/src/components/enabled-assets-modal/EnabledAssetsModal.tsx
+++ b/packages/react/src/components/enabled-assets-modal/EnabledAssetsModal.tsx
@@ -8,6 +8,7 @@ import { addressForChain } from '../ChainSelect';
 import '../shared.css';
 import './EnabledAssetsModal.css';
 import { CustomTrustlineModalTemplate, EnabledAssetsModalTemplate } from './EnabledAssetsModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface EnabledAssetsModalProps {
   onClose: () => void;
@@ -19,7 +20,7 @@ function assetKey(record: { code: string; issuer?: string }): string {
 
 export function EnabledAssetsModal({ onClose }: EnabledAssetsModalProps) {
   const { enabledAssets, refreshAssets, setTrustline, wallets, styles } = usePollar();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const { chains } = useChains();
   const [selectedChain, setSelectedChain] = useState<WalletChain | null>(null);
@@ -88,11 +89,12 @@ export function EnabledAssetsModal({ onClose }: EnabledAssetsModalProps) {
   );
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       {view === 'list' ? (
         <EnabledAssetsModalTemplate
           theme={theme}
           accentColor={accentColor}
+          styleOverrides={styleOverrides}
           enabledAssets={enabledAssets}
           walletAddress={walletAddress}
           chains={chains}
@@ -112,6 +114,7 @@ export function EnabledAssetsModal({ onClose }: EnabledAssetsModalProps) {
         <CustomTrustlineModalTemplate
           theme={theme}
           accentColor={accentColor}
+          styleOverrides={styleOverrides}
           busy={busyKey === 'custom'}
           actionError={actionError}
           onBack={() => {

--- a/packages/react/src/components/enabled-assets-modal/EnabledAssetsModal.tsx
+++ b/packages/react/src/components/enabled-assets-modal/EnabledAssetsModal.tsx
@@ -65,7 +65,7 @@ export function EnabledAssetsModal({ onClose }: EnabledAssetsModalProps) {
   const handleToggle = useCallback(
     (record: EnabledAssetRecord) => {
       const removing = record.trustlineEstablished;
-      // Sponsorship is derived automatically from the app config now — no flag.
+      // Sponsorship is derived automatically from the app config now - no flag.
       void runAction(
         assetKey(record),
         { code: record.code, issuer: record.issuer ?? '' },
@@ -77,7 +77,7 @@ export function EnabledAssetsModal({ onClose }: EnabledAssetsModalProps) {
 
   const handleCustomSubmit = useCallback(
     async (input: { code: string; issuer: string; limit?: string }) => {
-      // Custom (non-configured) assets are never app-sponsored — the user pays.
+      // Custom (non-configured) assets are never app-sponsored - the user pays.
       const ok = await runAction(
         'custom',
         { code: input.code, issuer: input.issuer },

--- a/packages/react/src/components/enabled-assets-modal/EnabledAssetsModalTemplate.tsx
+++ b/packages/react/src/components/enabled-assets-modal/EnabledAssetsModalTemplate.tsx
@@ -1,30 +1,10 @@
 'use client';
 
 import { EnabledAssetRecord, EnabledAssetsState, WalletChain } from '@pollar/core';
-import { useState, type CSSProperties } from 'react';
+import { useState } from 'react';
 import { ChainSelect, resolveChain } from '../ChainSelect';
 import { BusyOverlay, CopyButton, cropAddress, PollarModalFooter, Toggle, useStickyData } from '../commons';
-
-function cssVarsFor(theme: string, accentColor: string): CSSProperties {
-  const isDark = theme === 'dark';
-  return {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
-}
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 function assetKey(record: { code: string; issuer?: string }): string {
   return record.code + (record.issuer ?? '');
@@ -95,6 +75,8 @@ function AssetItem({
 export interface EnabledAssetsModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   enabledAssets: EnabledAssetsState;
   /** Address of the wallet on {@link selectedChain}. */
   walletAddress: string;
@@ -114,6 +96,7 @@ export interface EnabledAssetsModalTemplateProps {
 export function EnabledAssetsModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   enabledAssets,
   walletAddress,
   chains,
@@ -126,7 +109,7 @@ export function EnabledAssetsModalTemplate({
   onToggleTrustline,
   onAddCustom,
 }: EnabledAssetsModalTemplateProps) {
-  const cssVars = cssVarsFor(theme, accentColor);
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const isLoading = enabledAssets.step === 'loading';
   // Keep the previous payload on screen while refreshing; the overlay below
@@ -238,6 +221,8 @@ export function EnabledAssetsModalTemplate({
 export interface CustomTrustlineModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   busy: boolean;
   actionError: string | null;
   onBack: () => void;
@@ -252,13 +237,14 @@ function isValidIssuer(issuer: string): boolean {
 export function CustomTrustlineModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   busy,
   actionError,
   onBack,
   onClose,
   onSubmit,
 }: CustomTrustlineModalTemplateProps) {
-  const cssVars = cssVarsFor(theme, accentColor);
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const [code, setCode] = useState('');
   const [issuer, setIssuer] = useState('');

--- a/packages/react/src/components/enabled-assets-modal/EnabledAssetsModalTemplate.tsx
+++ b/packages/react/src/components/enabled-assets-modal/EnabledAssetsModalTemplate.tsx
@@ -57,7 +57,7 @@ function AssetItem({
       {isStellar && (
         <div className="pollar-asset-actions">
           <span className="pollar-asset-trustline-label">Trustline</span>
-          {/* Native XLM needs no trustline — it is implicit and can't be removed,
+          {/* Native XLM needs no trustline - it is implicit and can't be removed,
               so the switch shows the state but stays locked on. */}
           <Toggle
             checked={established}
@@ -117,7 +117,7 @@ export function EnabledAssetsModalTemplate({
   const data = useStickyData(enabledAssets.step === 'loaded' ? enabledAssets.data : null);
   const busy = busyKey !== null;
   // Only the picked network's assets. The backend returns every chain in one
-  // payload, so this is a local filter — switching networks costs no request.
+  // payload, so this is a local filter - switching networks costs no request.
   const assets = (data?.assets ?? []).filter((a) => resolveChain(a.chain) === selectedChain);
   // Trustlines are Stellar-only, so the custom-trustline form is offered only
   // while Stellar is the selected network.
@@ -177,7 +177,7 @@ export function EnabledAssetsModalTemplate({
         </div>
       )}
 
-      {/* First load only — a refresh keeps the old list under the overlay. */}
+      {/* First load only - a refresh keeps the old list under the overlay. */}
       {isLoading && !data && (
         <div className="pollar-loading-block">
           <div className="pollar-spinner" />

--- a/packages/react/src/components/kyc-modal/KycModal.css
+++ b/packages/react/src/components/kyc-modal/KycModal.css
@@ -56,7 +56,7 @@
   padding: 0.875rem 1rem;
   border-radius: var(--pollar-card-border-radius, 10px);
   border: 1px solid var(--pollar-border);
-  background-color: var(--pollar-input-bg);
+  background-color: var(--pollar-btn-secondary-bg, var(--pollar-input-bg));
   cursor: pointer;
   transition: all 0.15s;
   box-sizing: border-box;
@@ -75,7 +75,7 @@
 .pollar-kyc-provider-name {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: var(--pollar-text);
+  color: var(--pollar-btn-secondary-fg, var(--pollar-text));
 }
 
 .pollar-kyc-provider-flow {

--- a/packages/react/src/components/kyc-modal/KycModal.css
+++ b/packages/react/src/components/kyc-modal/KycModal.css
@@ -1,4 +1,4 @@
-/* ─── KYC Badge ─────────────────────────────────────────────────────────────── */
+/* --- KYC Badge --------------------------------------------------------------- */
 .pollar-kyc-badge {
   display: inline-flex;
   align-items: center;
@@ -20,7 +20,7 @@
   animation: pollar-pulse 1.5s ease-in-out infinite;
 }
 
-/* ─── KYC Modal ─────────────────────────────────────────────────────────────── */
+/* --- KYC Modal --------------------------------------------------------------- */
 .pollar-kyc-modal {
   max-width: 500px;
 }
@@ -40,7 +40,7 @@
   color: var(--pollar-muted);
 }
 
-/* ─── Provider list ─────────────────────────────────────────────────────────── */
+/* --- Provider list ----------------------------------------------------------- */
 .pollar-kyc-providers {
   display: flex;
   flex-direction: column;
@@ -85,7 +85,7 @@
   letter-spacing: 0.04em;
 }
 
-/* ─── KYC iframe ────────────────────────────────────────────────────────────── */
+/* --- KYC iframe -------------------------------------------------------------- */
 .pollar-kyc-iframe-wrap {
   width: 100%;
   height: 400px;
@@ -117,7 +117,7 @@
   box-sizing: border-box;
 }
 
-/* ─── Polling state ─────────────────────────────────────────────────────────── */
+/* --- Polling state ----------------------------------------------------------- */
 .pollar-kyc-polling {
   display: flex;
   flex-direction: column;
@@ -132,7 +132,7 @@
   color: var(--pollar-muted);
 }
 
-/* ─── Result ────────────────────────────────────────────────────────────────── */
+/* --- Result ------------------------------------------------------------------ */
 .pollar-kyc-result {
   display: flex;
   flex-direction: column;

--- a/packages/react/src/components/kyc-modal/KycModal.tsx
+++ b/packages/react/src/components/kyc-modal/KycModal.tsx
@@ -7,6 +7,7 @@ import type { KycStep } from './KycModalTemplate';
 import { KycModalTemplate } from './KycModalTemplate';
 import '../shared.css';
 import './KycModal.css';
+import { modalChrome } from '../modal-theme';
 
 interface KycModalProps {
   onClose: () => void;
@@ -29,7 +30,7 @@ export function KycModal({ onClose, country = 'MX', level = 'basic', onApproved 
   const [isLoading, setIsLoading] = useState(false);
 
   const client = getClient();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const loadProviders = useCallback(() => {
     setIsLoading(true);
@@ -79,10 +80,11 @@ export function KycModal({ onClose, country = 'MX', level = 'basic', onApproved 
   }
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <KycModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         step={step}
         providers={providers}
         selectedProvider={selectedProvider}

--- a/packages/react/src/components/kyc-modal/KycModalTemplate.tsx
+++ b/packages/react/src/components/kyc-modal/KycModalTemplate.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { KycProvider, KycStartResponse, KycStatus as KycStatusValue } from '@pollar/core';
-import type { CSSProperties } from 'react';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 import { KycStatus as KycStatusBadge } from './KycStatus';
 
 export type KycStep = 'select_provider' | 'verifying' | 'polling' | 'done';
@@ -9,6 +9,8 @@ export type KycStep = 'select_provider' | 'verifying' | 'polling' | 'done';
 interface KycModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   step: KycStep;
   providers: KycProvider[];
   selectedProvider: KycProvider | null;
@@ -24,6 +26,7 @@ interface KycModalTemplateProps {
 export function KycModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   step,
   providers,
   selectedProvider,
@@ -35,28 +38,7 @@ export function KycModalTemplate({
   onRefresh,
   onClose,
 }: KycModalTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-    '--pollar-modal-padding': '2rem',
-    '--pollar-modal-heading-size': '1.375rem',
-    '--pollar-modal-subtitle-size': '0.9rem',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides, 'hero');
 
   return (
     <div className="pollar-modal-card pollar-kyc-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>

--- a/packages/react/src/components/login-modal/LoginModal.css
+++ b/packages/react/src/components/login-modal/LoginModal.css
@@ -105,7 +105,7 @@
   gap: 0.75rem;
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
   border: 1px solid var(--pollar-border);
-  background-color: var(--pollar-input-bg);
+  background-color: var(--pollar-btn-secondary-bg, var(--pollar-input-bg));
   padding: 0 1rem;
   cursor: pointer;
   transition: all 0.15s;
@@ -129,7 +129,7 @@
 .pollar-social-btn-text {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--pollar-text);
+  color: var(--pollar-btn-secondary-fg, var(--pollar-text));
 }
 
 /* ---- Wallets ---- */
@@ -158,8 +158,8 @@
   padding: 0 1rem;
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
   border: 1px solid var(--pollar-border);
-  background-color: var(--pollar-input-bg);
-  color: var(--pollar-text);
+  background-color: var(--pollar-btn-secondary-bg, var(--pollar-input-bg));
+  color: var(--pollar-btn-secondary-fg, var(--pollar-text));
   font-size: 1rem;
   font-weight: 500;
   cursor: pointer;
@@ -215,8 +215,8 @@
   gap: 0.75rem;
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
   border: 1px solid var(--pollar-border);
-  background-color: var(--pollar-input-bg);
-  color: var(--pollar-text);
+  background-color: var(--pollar-btn-secondary-bg, var(--pollar-input-bg));
+  color: var(--pollar-btn-secondary-fg, var(--pollar-text));
   padding: 0 1rem;
   font-size: 1rem;
   font-weight: 500;
@@ -248,8 +248,8 @@
   gap: 0.75rem;
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
   border: 1px solid var(--pollar-border);
-  background-color: var(--pollar-input-bg);
-  color: var(--pollar-text);
+  background-color: var(--pollar-btn-secondary-bg, var(--pollar-input-bg));
+  color: var(--pollar-btn-secondary-fg, var(--pollar-text));
   padding: 0 1rem;
   font-size: 1rem;
   font-weight: 500;

--- a/packages/react/src/components/login-modal/LoginModal.tsx
+++ b/packages/react/src/components/login-modal/LoginModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@pollar/core';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { usePollar } from '../../context';
+import { modalChrome } from '../modal-theme';
 import { LoginModalStatus, LoginModalTemplate } from './LoginModalTemplate';
 import { PrivyLoginSubmodal } from './PrivyLoginSubmodal';
 import '../shared.css';
@@ -69,10 +70,14 @@ export function LoginModal({ onClose }: LoginModalProps) {
     };
   }, [getClient]);
 
-  const { theme = 'light', accentColor = '#005DB4', logoUrl, emailEnabled, embeddedWallets, smartWallet, providers } = styles;
+  const { logoUrl, emailEnabled, embeddedWallets, smartWallet, providers } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
   // Opt-in: the Smart Wallet (passkey) option only shows when the dashboard
   // explicitly enables it. Absent → hidden.
   const smartWalletEnabled = smartWallet ?? false;
+  // The heading is the app's name unless Branding set a custom one. Blank counts
+  // as unset, which is what the dashboard sends when the field is cleared.
+  const modalTitle = styles.modalTitle?.trim() || config.application?.name || 'Pollar';
 
   function handleClose() {
     setEmail('');
@@ -138,14 +143,15 @@ export function LoginModal({ onClose }: LoginModalProps) {
   }
 
   return (
-    <div className="pollar-overlay" onClick={handleClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={handleClose}>
       {configStatus !== 'ready' ? (
         <LoginModalStatus
           status={configStatus === 'error' ? 'error' : 'loading'}
           theme={theme}
           accentColor={accentColor}
+          styleOverrides={styleOverrides}
           logoUrl={logoUrl ?? null}
-          appName={config.application?.name ?? 'Pollar'}
+          appName={modalTitle}
           onRetry={retryConfig}
           onCancel={handleClose}
         />
@@ -154,8 +160,9 @@ export function LoginModal({ onClose }: LoginModalProps) {
           adapter={interactiveAdapter}
           theme={theme}
           accentColor={accentColor}
+          styleOverrides={styleOverrides}
           logoUrl={logoUrl ?? null}
-          appName={config.application?.name ?? 'Pollar'}
+          appName={modalTitle}
           onBack={() => setInteractiveAdapter(null)}
           onCancel={handleClose}
           onAuthenticated={handleInteractiveAuthenticated}
@@ -164,6 +171,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
         <LoginModalTemplate
           theme={theme}
           accentColor={accentColor}
+          styleOverrides={styleOverrides}
           logoUrl={logoUrl ?? null}
           emailEnabled={!!emailEnabled}
           embeddedWallets={!!embeddedWallets}
@@ -176,7 +184,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
             apple: !!providers?.apple,
           }}
           walletAdapters={walletAdapters}
-          appName={config.application?.name ?? 'Pollar'}
+          appName={modalTitle}
           email={email}
           onEmailChange={setEmail}
           onEmailSubmit={handleEmailSubmit}

--- a/packages/react/src/components/login-modal/LoginModal.tsx
+++ b/packages/react/src/components/login-modal/LoginModal.tsx
@@ -26,7 +26,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
   const [email, setEmail] = useState('');
   const { getClient, styles, appConfig: config, configStatus, retryConfig } = usePollar();
   const [authState, setAuthState] = useState<AuthState>(() => getClient().getAuthState());
-  // Registered wallet adapters (built-ins + config) → one login button each.
+  // Registered wallet adapters (built-ins + config) -> one login button each.
   const walletAdapters = useMemo(() => getClient().listWalletAdapters(), [getClient]);
   const [codeInputKey, setCodeInputKey] = useState(0);
   const pendingEmail = useRef<string | null>(null);
@@ -49,7 +49,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
         setCodeInputKey((k) => k + 1);
       }
       if (next.step === 'authenticated') {
-        // Clear any timer already pending — if `authenticated` fires more than
+        // Clear any timer already pending - if `authenticated` fires more than
         // once, overwriting the handle would orphan the previous timeout
         // (cleanup only tracks the latest).
         if (autoCloseTimer.current !== null) {
@@ -73,7 +73,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
   const { logoUrl, emailEnabled, embeddedWallets, smartWallet, providers } = styles;
   const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
   // Opt-in: the Smart Wallet (passkey) option only shows when the dashboard
-  // explicitly enables it. Absent → hidden.
+  // explicitly enables it. Absent -> hidden.
   const smartWalletEnabled = smartWallet ?? false;
   // The heading is the app's name unless Branding set a custom one. Blank counts
   // as unset, which is what the dashboard sends when the field is cleared.
@@ -103,7 +103,7 @@ export function LoginModal({ onClose }: LoginModalProps) {
       setInteractiveAdapter(adapter);
       return;
     }
-    // Any other registered wallet adapter (freighter/albedo/swk…). The adapter
+    // Any other registered wallet adapter (freighter/albedo/swk...). The adapter
     // opens its own connect/auth UI; the SDK wraps the generic SEP-10 flow.
     getClient().login({ provider: type } as PollarLoginOptions);
   }

--- a/packages/react/src/components/login-modal/LoginModalTemplate.tsx
+++ b/packages/react/src/components/login-modal/LoginModalTemplate.tsx
@@ -3,12 +3,18 @@
 import { AUTH_ERROR_CODES, AuthState, WalletId } from '@pollar/core';
 
 type StateStatus = 'NONE' | 'LOADING' | 'SUCCESS' | 'ERROR';
-import { type CSSProperties, useState } from 'react';
+import { useState } from 'react';
 import { LOGO_POLLAR } from '../../constants';
 import { ModalStatusBanner, PollarModalFooter } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 import { EmailCodeInput } from './EmailCodeInput';
 import { GithubButton } from './GithubButton';
 import { GoogleButton } from './GoogleButton';
+
+// Re-exported from its old home so consumers that imported it from this module
+// (the dashboard's branding preview, among others) keep working.
+export { buildModalCssVars } from '../modal-theme';
+export type { ModalStyleOverrides } from '../modal-theme';
 
 type WalletAdapterEntry = { id: WalletId; meta: { label: string; iconUrl?: string; group?: string } };
 
@@ -106,6 +112,8 @@ function authStateToStatus(step: AuthState['step']): StateStatus {
 interface LoginModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   logoUrl: string | null;
   emailEnabled: boolean;
   embeddedWallets: boolean;
@@ -139,36 +147,10 @@ interface LoginModalTemplateProps {
   onRetry: () => void;
 }
 
-/** Theme-derived CSS custom properties shared by the login modal and its
- *  loading/error status card. Kept as a standalone helper so both render paths
- *  stay visually in lockstep. */
-export function buildModalCssVars(theme: string, accentColor: string): CSSProperties {
-  const isDark = theme === 'dark';
-  return {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-    '--pollar-modal-padding': '2rem',
-    '--pollar-modal-heading-size': '1.375rem',
-    '--pollar-modal-subtitle-size': '0.9rem',
-  } as CSSProperties;
-}
-
 export function LoginModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   logoUrl,
   emailEnabled,
   embeddedWallets,
@@ -211,7 +193,7 @@ export function LoginModalTemplate({
     }, []);
   const activeGroupAdapters = walletGroups.find((g) => g.label === activeGroup)?.adapters ?? [];
 
-  const cssVars = buildModalCssVars(theme, accentColor);
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides, 'hero');
 
   const status = authStateToStatus(authState.step);
   const isLoading = status === 'LOADING';
@@ -419,6 +401,7 @@ export function LoginModalStatus({
   status,
   theme,
   accentColor,
+  styleOverrides,
   logoUrl,
   appName,
   onRetry,
@@ -427,12 +410,13 @@ export function LoginModalStatus({
   status: 'loading' | 'error';
   theme: string;
   accentColor: string;
+  styleOverrides?: ModalStyleOverrides;
   logoUrl: string | null;
   appName: string;
   onRetry: () => void;
   onCancel: () => void;
 }) {
-  const cssVars = buildModalCssVars(theme, accentColor);
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides, 'hero');
   return (
     <div className="pollar-modal-card pollar-modal" style={cssVars} onClick={(e) => e.stopPropagation()}>
       <button type="button" className="pollar-close-btn" onClick={onCancel} aria-label="Close">

--- a/packages/react/src/components/login-modal/LoginModalTemplate.tsx
+++ b/packages/react/src/components/login-modal/LoginModalTemplate.tsx
@@ -27,8 +27,8 @@ function WalletAdapterButtons({
   walletAdapters: WalletAdapterEntry[];
   onConnect: (id: WalletId) => void;
   isLoading: boolean;
-  // 'list'  → borderless rows for inside a group sub-picker (large icon + name).
-  // 'entry' → bordered buttons that match the root-level entries (Google, Wallet,
+  // 'list'  -> borderless rows for inside a group sub-picker (large icon + name).
+  // 'entry' -> bordered buttons that match the root-level entries (Google, Wallet,
   //           Smart Wallet) so a root adapter like Privy doesn't read as bare text.
   variant?: 'list' | 'entry';
 }) {
@@ -127,7 +127,7 @@ interface LoginModalTemplateProps {
     github: boolean;
     apple: boolean;
   };
-  /** Registered wallet adapters to render as buttons (Freighter, Albedo, Privy, …). */
+  /** Registered wallet adapters to render as buttons (Freighter, Albedo, Privy, ...). */
   walletAdapters: WalletAdapterEntry[];
   appName: string;
   email?: string;
@@ -180,7 +180,7 @@ export function LoginModalTemplate({
 
   // Split registered adapters into root-level buttons (no `meta.group`, e.g. Privy)
   // and gateway groups (adapters sharing a `meta.group` collapse behind one button
-  // that opens a sub-picker — e.g. the Stellar Wallets Kit wallets under "Wallet").
+  // that opens a sub-picker - e.g. the Stellar Wallets Kit wallets under "Wallet").
   const rootAdapters = walletAdapters.filter((a) => !a.meta.group);
   const walletGroups = walletAdapters
     .filter((a) => a.meta.group)
@@ -394,7 +394,7 @@ export function LoginModalTemplate({
 }
 
 /** Placeholder shown inside the login modal while the app config is loading, or
- *  when its remote fetch failed — instead of the empty shell that renders when
+ *  when its remote fetch failed - instead of the empty shell that renders when
  *  `styles` is still the default `{}`. Mirrors the template's card chrome (logo,
  *  title, footer) so the swap to the real form isn't jarring. */
 export function LoginModalStatus({

--- a/packages/react/src/components/login-modal/PrivyLoginSubmodal.tsx
+++ b/packages/react/src/components/login-modal/PrivyLoginSubmodal.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { type CSSProperties, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { InteractiveAuthAdapter } from '@pollar/core';
 import { LOGO_POLLAR } from '../../constants';
 import { ModalStatusBanner, PollarModalFooter } from '../commons';
 import { EmailCodeInput } from './EmailCodeInput';
 import { GithubButton } from './GithubButton';
 import { GoogleButton } from './GoogleButton';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 type StateStatus = 'NONE' | 'LOADING' | 'SUCCESS' | 'ERROR';
 
@@ -15,6 +16,8 @@ interface PrivyLoginSubmodalProps {
   adapter: InteractiveAuthAdapter;
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   logoUrl: string | null;
   appName: string;
   /** Return to the root login view. */
@@ -38,6 +41,7 @@ export function PrivyLoginSubmodal({
   adapter,
   theme,
   accentColor,
+  styleOverrides,
   logoUrl,
   appName,
   onBack,
@@ -50,29 +54,9 @@ export function PrivyLoginSubmodal({
   const [status, setStatus] = useState<StateStatus>('NONE');
   const [message, setMessage] = useState('');
 
-  const isDark = theme === 'dark';
   const isLoading = status === 'LOADING';
 
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-    '--pollar-modal-padding': '2rem',
-    '--pollar-modal-heading-size': '1.375rem',
-    '--pollar-modal-subtitle-size': '0.9rem',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides, 'hero');
 
   function fail(error: unknown) {
     setStatus('ERROR');

--- a/packages/react/src/components/login-modal/PrivyLoginSubmodal.tsx
+++ b/packages/react/src/components/login-modal/PrivyLoginSubmodal.tsx
@@ -24,7 +24,7 @@ interface PrivyLoginSubmodalProps {
   onBack: () => void;
   /** Close the whole login modal. */
   onCancel: () => void;
-  /** The provider login finished — hand off to `login({ provider })`. */
+  /** The provider login finished - hand off to `login({ provider })`. */
   onAuthenticated: () => void;
 }
 

--- a/packages/react/src/components/modal-theme.ts
+++ b/packages/react/src/components/modal-theme.ts
@@ -1,0 +1,152 @@
+import type { CSSProperties } from 'react';
+import type { PollarStyles } from '../types';
+
+/** Per-app overrides for the modal chrome, configured in the dashboard's
+ *  Branding screen. Every field is optional: absent means "use the value the
+ *  theme derives", which is what every modal rendered before these existed. */
+export interface ModalStyleOverrides {
+  /** Card background. Overrides the theme's white / #1a1a1a. */
+  backgroundColor?: string | null | undefined;
+  /** Body text. Overrides the theme's #111827 / white. Secondary ("muted") text
+   *  keeps its theme color, so the two stay distinguishable. */
+  textColor?: string | null | undefined;
+  /** Fill of the SECONDARY buttons (the wallet / social / provider entries, the
+   *  retry button). The primary button is the accent's job. Unset ⇒ the theme's
+   *  own surface color, which is what these buttons always used. */
+  buttonColor?: string | null | undefined;
+  /** Radius of the modal card itself, in px. */
+  modalBorderRadius?: number | null | undefined;
+  /** Radius of the buttons inside the modal, in px. Independent of the card's. */
+  buttonBorderRadius?: number | null | undefined;
+}
+
+/** The card radius the modals used before it was configurable (1rem). */
+const DEFAULT_MODAL_BORDER_RADIUS = 16;
+/** Same, for the buttons. */
+const DEFAULT_BUTTON_BORDER_RADIUS = 6;
+/** Stacking order of the fixed overlay, before it was configurable. */
+const DEFAULT_OVERLAY_Z_INDEX = 50;
+
+/** A configured length, as a CSS px string. Anything that isn't a finite,
+ *  non-negative number falls back to `fallback` — a malformed stored value must
+ *  not collapse the card's chrome. */
+function px(value: number | null | undefined, fallback: number): string {
+  return `${typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback}px`;
+}
+
+/** A configured color, or the theme's own when unset. Empty string counts as
+ *  unset: that's what the dashboard sends when the field is cleared. */
+function color(value: string | null | undefined, fallback: string): string {
+  return typeof value === 'string' && value.trim() !== '' ? value : fallback;
+}
+
+/** `#rgb` / `#rrggbb` as 0-255 channels, or null for anything else (a named
+ *  color, a `color-mix()`, a typo). */
+function parseHex(value: string): [number, number, number] | null {
+  const hex = value.trim().replace(/^#/, '');
+  const full = hex.length === 3 ? [...hex].map((c) => c + c).join('') : hex;
+  if (!/^[0-9a-f]{6}$/i.test(full)) return null;
+  return [Number.parseInt(full.slice(0, 2), 16), Number.parseInt(full.slice(2, 4), 16), Number.parseInt(full.slice(4, 6), 16)];
+}
+
+/** Text color that stays legible on `background`. The primary button's label was
+ *  hardcoded white, which a light fill (the Amber accent preset, say) turns
+ *  invisible — so it follows the fill's luminance instead. Unparseable colors
+ *  keep white, the pre-existing behavior. */
+export function readableTextOn(background: string): string {
+  const rgb = parseHex(background);
+  if (!rgb) return '#ffffff';
+  // Relative luminance, sRGB coefficients (WCAG). The 0.6 cut lands white on
+  // Pollar blue (#005DB4) exactly as before, and dark on a pale fill.
+  const [r, g, b] = rgb;
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255 > 0.6 ? '#111827' : '#ffffff';
+}
+
+/** How much room a modal gives its header. 'hero' is the identity-forward set
+ *  (login, KYC, ramp, the Privy sub-modal): roomier padding and a larger
+ *  centered heading. 'compact' is every utility modal (send, balance, history,
+ *  …), which keeps the card's own 1.75rem padding. */
+export type ModalVariant = 'hero' | 'compact';
+
+/** Theme-derived CSS custom properties shared by every Pollar modal, plus the
+ *  per-app overrides on top. One definition so the whole modal family stays
+ *  visually in lockstep — a var added here reaches all of them at once. */
+export function buildModalCssVars(
+  theme: string,
+  accentColor: string,
+  overrides: ModalStyleOverrides = {},
+  variant: ModalVariant = 'compact',
+): CSSProperties {
+  const isDark = theme === 'dark';
+  const textColor = color(overrides.textColor, isDark ? '#ffffff' : '#111827');
+  // Only emitted when actually configured. Left out, the secondary buttons fall
+  // back inside the CSS to whatever each already used — the theme surface for
+  // the filled ones, `transparent` for the ghost one — so an unset field can't
+  // flatten those two into the same look.
+  const secondaryBg = color(overrides.buttonColor, '');
+  return {
+    '--pollar-accent': accentColor,
+    '--pollar-bg': color(overrides.backgroundColor, isDark ? '#1a1a1a' : '#ffffff'),
+    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
+    '--pollar-text': textColor,
+    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
+    // The primary button is the accent's, straight up; its label follows the
+    // accent's luminance so a pale accent doesn't render white-on-white.
+    '--pollar-btn-primary-fg': readableTextOn(accentColor),
+    ...(secondaryBg
+      ? {
+          '--pollar-btn-secondary-bg': secondaryBg,
+          '--pollar-btn-secondary-fg': readableTextOn(secondaryBg),
+        }
+      : {}),
+    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
+    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
+    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
+    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
+    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
+    '--pollar-modal-border-radius': px(overrides.modalBorderRadius, DEFAULT_MODAL_BORDER_RADIUS),
+    '--pollar-buttons-border-radius': px(overrides.buttonBorderRadius, DEFAULT_BUTTON_BORDER_RADIUS),
+    '--pollar-buttons-height': '44px',
+    '--pollar-input-height': '44px',
+    '--pollar-input-border-radius': '0.5rem',
+    '--pollar-card-border-radius': '10px',
+    ...(variant === 'hero'
+      ? {
+          '--pollar-modal-padding': '2rem',
+          '--pollar-modal-heading-size': '1.375rem',
+          '--pollar-modal-subtitle-size': '0.9rem',
+        }
+      : {}),
+  } as CSSProperties;
+}
+
+/** Everything a modal wrapper needs to dress itself from the app's branding:
+ *  the theme pair its template already took, the overrides to forward to that
+ *  template, and the inline style for the fixed overlay behind it. */
+export interface ModalChrome {
+  theme: string;
+  accentColor: string;
+  styleOverrides: ModalStyleOverrides;
+  overlayStyle: CSSProperties;
+}
+
+/** Resolve the branding config into the props/styles a modal wrapper applies.
+ *  Called by every `.pollar-overlay` renderer so the z-index and the card
+ *  overrides can't drift apart between modals. */
+export function modalChrome(styles: PollarStyles): ModalChrome {
+  const zIndex = styles.modalZIndex;
+  return {
+    theme: styles.theme ?? 'light',
+    accentColor: styles.accentColor ?? '#005DB4',
+    styleOverrides: {
+      backgroundColor: styles.backgroundColor,
+      textColor: styles.textColor,
+      buttonColor: styles.buttonColor,
+      modalBorderRadius: styles.modalBorderRadius,
+      buttonBorderRadius: styles.buttonBorderRadius,
+    },
+    overlayStyle: {
+      '--pollar-overlay-z-index': typeof zIndex === 'number' && Number.isFinite(zIndex) ? zIndex : DEFAULT_OVERLAY_Z_INDEX,
+    } as CSSProperties,
+  };
+}

--- a/packages/react/src/components/modal-theme.ts
+++ b/packages/react/src/components/modal-theme.ts
@@ -11,7 +11,7 @@ export interface ModalStyleOverrides {
    *  keeps its theme color, so the two stay distinguishable. */
   textColor?: string | null | undefined;
   /** Fill of the SECONDARY buttons (the wallet / social / provider entries, the
-   *  retry button). The primary button is the accent's job. Unset ⇒ the theme's
+   *  retry button). The primary button is the accent's job. Unset => the theme's
    *  own surface color, which is what these buttons always used. */
   buttonColor?: string | null | undefined;
   /** Radius of the modal card itself, in px. */
@@ -28,7 +28,7 @@ const DEFAULT_BUTTON_BORDER_RADIUS = 6;
 const DEFAULT_OVERLAY_Z_INDEX = 50;
 
 /** A configured length, as a CSS px string. Anything that isn't a finite,
- *  non-negative number falls back to `fallback` — a malformed stored value must
+ *  non-negative number falls back to `fallback` - a malformed stored value must
  *  not collapse the card's chrome. */
 function px(value: number | null | undefined, fallback: number): string {
   return `${typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback}px`;
@@ -51,7 +51,7 @@ function parseHex(value: string): [number, number, number] | null {
 
 /** Text color that stays legible on `background`. The primary button's label was
  *  hardcoded white, which a light fill (the Amber accent preset, say) turns
- *  invisible — so it follows the fill's luminance instead. Unparseable colors
+ *  invisible - so it follows the fill's luminance instead. Unparseable colors
  *  keep white, the pre-existing behavior. */
 export function readableTextOn(background: string): string {
   const rgb = parseHex(background);
@@ -65,12 +65,12 @@ export function readableTextOn(background: string): string {
 /** How much room a modal gives its header. 'hero' is the identity-forward set
  *  (login, KYC, ramp, the Privy sub-modal): roomier padding and a larger
  *  centered heading. 'compact' is every utility modal (send, balance, history,
- *  …), which keeps the card's own 1.75rem padding. */
+ *  ...), which keeps the card's own 1.75rem padding. */
 export type ModalVariant = 'hero' | 'compact';
 
 /** Theme-derived CSS custom properties shared by every Pollar modal, plus the
  *  per-app overrides on top. One definition so the whole modal family stays
- *  visually in lockstep — a var added here reaches all of them at once. */
+ *  visually in lockstep - a var added here reaches all of them at once. */
 export function buildModalCssVars(
   theme: string,
   accentColor: string,
@@ -80,8 +80,8 @@ export function buildModalCssVars(
   const isDark = theme === 'dark';
   const textColor = color(overrides.textColor, isDark ? '#ffffff' : '#111827');
   // Only emitted when actually configured. Left out, the secondary buttons fall
-  // back inside the CSS to whatever each already used — the theme surface for
-  // the filled ones, `transparent` for the ghost one — so an unset field can't
+  // back inside the CSS to whatever each already used - the theme surface for
+  // the filled ones, `transparent` for the ghost one - so an unset field can't
   // flatten those two into the same look.
   const secondaryBg = color(overrides.buttonColor, '');
   return {

--- a/packages/react/src/components/ramp-widget/RampWidget.css
+++ b/packages/react/src/components/ramp-widget/RampWidget.css
@@ -17,6 +17,41 @@
   color: var(--pollar-muted);
 }
 
+/* ─── Step indicator ────────────────────────────────────────────────────────
+   One segment per step of THIS run — the count varies by route, so the track is
+   a flex row of equal shares rather than a percentage-filled bar. */
+.pollar-ramp-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.pollar-ramp-steps-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--pollar-muted);
+}
+
+.pollar-ramp-steps-track {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.pollar-ramp-steps-segment {
+  flex: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--pollar-border);
+  transition: background-color 0.2s;
+}
+
+.pollar-ramp-steps-segment[data-done] {
+  background: var(--pollar-accent);
+}
+
 /* The country <select> loading placeholder uses the shared .pollar-select-loading
    (spinner + label inside a select-shaped box), consistent with all the modals. */
 
@@ -141,12 +176,26 @@
   box-sizing: border-box;
 }
 
+/* The route being started: keep it prominent (it's the one acting) but make it
+   clear it no longer responds to clicks. */
+.pollar-ramp-route-card[data-busy] {
+  cursor: wait;
+  border-color: var(--pollar-accent);
+}
+
+/* The other routes while one is starting — dimmed and inert, so a second click
+   can't fire a competing request. */
+.pollar-ramp-route-card[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .pollar-ramp-route-card[data-recommended='true'] {
   border-color: var(--pollar-accent);
   background-color: color-mix(in srgb, var(--pollar-accent) 5%, var(--pollar-input-bg));
 }
 
-.pollar-ramp-route-card:hover {
+.pollar-ramp-route-card:not([data-disabled]):hover {
   border-color: var(--pollar-accent);
 }
 

--- a/packages/react/src/components/ramp-widget/RampWidget.css
+++ b/packages/react/src/components/ramp-widget/RampWidget.css
@@ -97,6 +97,21 @@
   color: var(--pollar-error-text, #dc2626);
 }
 
+.pollar-ramp-field-hint {
+  display: block;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--pollar-muted);
+}
+
+/* Rides inside the label, so it reads as part of the field name rather than as
+   another line competing with the hint below. */
+.pollar-ramp-field-optional {
+  font-weight: 400;
+  text-transform: none;
+  color: var(--pollar-muted);
+}
+
 .pollar-ramp-input-row {
   display: flex;
   gap: 0.625rem;

--- a/packages/react/src/components/ramp-widget/RampWidget.css
+++ b/packages/react/src/components/ramp-widget/RampWidget.css
@@ -297,6 +297,22 @@
   font-family: monospace;
 }
 
+/* Pollar-rendered QR. The SVG paints with `currentColor`, so setting the text
+   colour here is what makes it legible in both themes without a second asset. */
+.pollar-ramp-qr {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  color: var(--pollar-text);
+}
+
+.pollar-ramp-qr svg {
+  width: 100%;
+  max-width: 220px;
+  height: auto;
+  display: block;
+}
+
 .pollar-ramp-copy-btn {
   padding: 0.25rem 0.625rem;
   border-radius: var(--pollar-buttons-border-radius, 6px);

--- a/packages/react/src/components/ramp-widget/RampWidget.css
+++ b/packages/react/src/components/ramp-widget/RampWidget.css
@@ -1,9 +1,9 @@
-/* ─── Widget container ──────────────────────────────────────────────────────── */
+/* --- Widget container -------------------------------------------------------- */
 .pollar-ramp-modal {
   max-width: 480px;
 }
 
-/* ─── Header ────────────────────────────────────────────────────────────────── */
+/* --- Header ------------------------------------------------------------------ */
 .pollar-ramp-header-text {
   display: flex;
   flex-direction: column;
@@ -17,8 +17,8 @@
   color: var(--pollar-muted);
 }
 
-/* ─── Step indicator ────────────────────────────────────────────────────────
-   One segment per step of THIS run — the count varies by route, so the track is
+/* --- Step indicator --------------------------------------------------------
+   One segment per step of THIS run - the count varies by route, so the track is
    a flex row of equal shares rather than a percentage-filled bar. */
 .pollar-ramp-steps {
   display: flex;
@@ -57,7 +57,7 @@
 
 /* Direction tabs use the shared segmented control (.pollar-tabs / .pollar-tab). */
 
-/* ─── Input group ───────────────────────────────────────────────────────────── */
+/* --- Input group ------------------------------------------------------------- */
 .pollar-ramp-field {
   margin-bottom: 1rem;
 }
@@ -121,7 +121,7 @@
   flex: 1;
 }
 
-/* ─── Loading quote ─────────────────────────────────────────────────────────── */
+/* --- Loading quote ----------------------------------------------------------- */
 .pollar-ramp-loading {
   display: flex;
   flex-direction: column;
@@ -170,7 +170,7 @@
   flex-shrink: 0;
 }
 
-/* ─── Route card ────────────────────────────────────────────────────────────── */
+/* --- Route card -------------------------------------------------------------- */
 .pollar-ramp-route-list {
   display: flex;
   flex-direction: column;
@@ -198,7 +198,7 @@
   border-color: var(--pollar-accent);
 }
 
-/* The other routes while one is starting — dimmed and inert, so a second click
+/* The other routes while one is starting - dimmed and inert, so a second click
    can't fire a competing request. */
 .pollar-ramp-route-card[data-disabled] {
   opacity: 0.5;
@@ -252,7 +252,7 @@
   letter-spacing: 0.04em;
 }
 
-/* ─── Payment instructions ──────────────────────────────────────────────────── */
+/* --- Payment instructions ---------------------------------------------------- */
 .pollar-ramp-payment {
   display: flex;
   flex-direction: column;

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -7,6 +7,7 @@ import type { RampFieldSpec, RampStep } from './RampWidgetTemplate';
 import { RampWidgetTemplate } from './RampWidgetTemplate';
 import '../shared.css';
 import './RampWidget.css';
+import { modalChrome } from '../modal-theme';
 
 interface RampWidgetProps {
   onClose: () => void;
@@ -39,7 +40,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   const { getClient, signTx, wallet, styles, network } = usePollar();
   const walletAddress = wallet?.address ?? '';
   const client = getClient();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const [step, setStep] = useState<RampStep>('input');
   const [direction, setDirection] = useState<RampDirection>('onramp');
@@ -317,10 +318,11 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   const canComplete = direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash;
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <RampWidgetTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         step={step}
         direction={direction}
         amount={amount}

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -20,6 +20,31 @@ function requiredFieldsOf(quote: RampQuote): RampFieldSpec[] {
   return (quote as { requiredFields?: RampFieldSpec[] }).requiredFields ?? [];
 }
 
+/**
+ * The steps a run actually goes through. Not fixed: 'Details' only exists when
+ * the chosen route asks for fields (Bridge wants a name and email; SEP-24
+ * anchors collect everything on their own hosted page), so a progress bar that
+ * always said "of 4" would lie to half the providers.
+ *
+ * Before a route is picked the total is a forecast: if any offered route would
+ * ask for details, the step is shown, and choosing one settles it.
+ */
+function flowStepsOf(quotes: RampQuote[], selected: RampQuote | null): string[] {
+  const needsDetails =
+    selected != null ? requiredFieldsOf(selected).length > 0 : quotes.some((q) => requiredFieldsOf(q).length > 0);
+  return needsDetails ? ['Amount', 'Provider', 'Details', 'Complete'] : ['Amount', 'Provider', 'Complete'];
+}
+
+/** Which of those steps the current widget step sits on. `error` belongs to no
+ *  step — the flow stopped rather than advanced — so the bar hides there. */
+const STEP_LABEL: Partial<Record<RampStep, string>> = {
+  input: 'Amount',
+  loading_quote: 'Amount',
+  select_route: 'Provider',
+  contact: 'Details',
+  status: 'Complete',
+};
+
 /** A bound the amount broke, or null when it fits. Providers declare their
  *  limits on the quote (`minAmount` / `maxAmount`); the ones that don't simply
  *  never trip this, and the backend stays the last word either way. */
@@ -236,7 +261,10 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     }
   }
 
-  function resetToInput() {
+  /** Back to the amount step. `keepMessage` carries the reason forward: when the
+   *  user steps back because the amount missed a route's minimum, dropping the
+   *  figure would leave them correcting it blind. A plain retry clears it. */
+  function resetToInput({ keepMessage = false }: { keepMessage?: boolean } = {}) {
     setStep('input');
     setQuotes([]);
     setSelectedQuote(null);
@@ -252,7 +280,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     setTxStatus(null);
     setStellarTxHash(null);
     setDepositInstructions(null);
-    setErrorMsg(null);
+    if (!keepMessage) setErrorMsg(null);
   }
 
   /**
@@ -410,6 +438,9 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   const canComplete =
     direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash && !kycBlocking;
 
+  const flowSteps = flowStepsOf(quotes, selectedQuote);
+  const flowStepIndex = flowSteps.indexOf(STEP_LABEL[step] ?? '');
+
   return (
     <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <RampWidgetTemplate
@@ -417,6 +448,9 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         accentColor={accentColor}
         styleOverrides={styleOverrides}
         step={step}
+        flowSteps={flowSteps}
+        flowStepIndex={flowStepIndex}
+        startingQuoteId={isLoading && selectedQuote ? selectedQuote.quoteId : null}
         direction={direction}
         amount={amount}
         currency={currency}
@@ -445,7 +479,12 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         completing={completing}
         errorMsg={errorMsg}
         onDirectionChange={setDirection}
-        onAmountChange={setAmount}
+        onAmountChange={(next) => {
+          // Editing the amount is the user acting on the limit message, so it
+          // stops applying the moment they type.
+          setAmount(next);
+          setErrorMsg(null);
+        }}
         onFieldChange={setFieldValue}
         onCountryChange={handleCountryChange}
         onFindRoute={handleFindRoute}
@@ -454,7 +493,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         onOpenKyc={handleOpenKyc}
         onOpenTos={handleOpenTos}
         onCompleteWithdraw={handleCompleteWithdraw}
-        onRetry={resetToInput}
+        onBack={() => resetToInput({ keepMessage: true })}
+        onRetry={() => resetToInput()}
         onRefresh={handleRefresh}
         onClose={onClose}
       />

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -355,7 +355,9 @@ export function RampWidget({ onClose }: RampWidgetProps) {
       return;
     }
     const fields = requiredFieldsOf(quote);
-    const missing = fields.some((f) => !(fieldValues[f.key] ?? '').trim());
+    // An `optional` field left blank is not missing (Abroad's tax id) — it must
+    // not drag the user into the details step on its own.
+    const missing = fields.some((f) => !f.optional && !(fieldValues[f.key] ?? '').trim());
     if (fields.length > 0 && missing) {
       setStep('contact');
       return;

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -29,6 +29,10 @@ interface RampResult {
   // Bridge splits onboarding into two hosted steps: KYC (identity) and ToS
   // acceptance. Both must be completed before the customer activates.
   tosUrl?: string;
+  // The provider gated the flow on identity verification and offers no hosted
+  // URL (Abroad). Nothing was built or signed — the user clears KYC with the
+  // provider directly, and we poll `getRampKycStatus` until they do.
+  kycRequired?: boolean;
   stellarTxHash?: string;
   pendingSignature?: { unsignedXdr: string; action: 'sep10' | 'withdraw_payment' };
   // REST providers (Bridge) return deposit instructions as data (e.g. a Pix
@@ -64,6 +68,10 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   const [provider, setProvider] = useState('');
   const [kycUrl, setKycUrl] = useState<string | null>(null);
   const [tosUrl, setTosUrl] = useState<string | null>(null);
+  // Link-less KYC gate (Abroad): `kycPending` is what the provider told us on
+  // start; `kycApproved` is what polling has since learned.
+  const [kycPending, setKycPending] = useState(false);
+  const [kycApproved, setKycApproved] = useState(false);
   const [txStatus, setTxStatus] = useState<RampTxStatus | null>(null);
   const [stellarTxHash, setStellarTxHash] = useState<string | null>(null);
   const [depositInstructions, setDepositInstructions] = useState<Record<string, unknown> | null>(null);
@@ -98,6 +106,27 @@ export function RampWidget({ onClose }: RampWidgetProps) {
       clearInterval(id);
     };
   }, [step, txId, txStatus, client]);
+
+  // A link-less KYC gate has nothing to open, so poll the provider until the user
+  // clears it elsewhere. Stops as soon as it's approved.
+  useEffect(() => {
+    if (step !== 'status' || !kycPending || kycApproved) return;
+    let active = true;
+    const check = async () => {
+      try {
+        const { hasApproved } = await client.getRampKycStatus();
+        if (active && hasApproved) setKycApproved(true);
+      } catch {
+        /* transient — keep polling */
+      }
+    };
+    void check();
+    const id = setInterval(check, 10000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [step, kycPending, kycApproved, client]);
 
   /**
    * Fetch the ramp countries supported on the app's network. When `resetSelection`
@@ -205,6 +234,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     }
     setKycUrl(result.kycUrl ?? null);
     setTosUrl(result.tosUrl ?? null);
+    setKycPending(result.kycRequired === true);
+    if (result.kycRequired) setKycApproved(false);
     setTxStatus(result.status);
     setStellarTxHash(result.stellarTxHash ?? null);
     setDepositInstructions(result.depositInstructions ?? null);
@@ -315,7 +346,12 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     }
   }
 
-  const canComplete = direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash;
+  // A pending link-less KYC gate blocks the withdraw: the provider has no payment
+  // context to pay into yet, so completing would either fail or — worse — move
+  // real funds into a deposit it cannot pay out.
+  const kycBlocking = kycPending && !kycApproved;
+  const canComplete =
+    direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash && !kycBlocking;
 
   return (
     <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
@@ -339,6 +375,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         txStatus={txStatus}
         kycUrl={kycUrl}
         tosUrl={tosUrl}
+        kycBlocking={kycBlocking}
+        kycJustApproved={kycPending && kycApproved}
         stellarTxHash={stellarTxHash}
         explorerUrl={
           stellarTxHash

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import type { RampCountry, RampDirection, RampQuote, RampsOfframpBody, RampsOnrampBody, RampTxStatus } from '@pollar/core';
+import type {
+  RampCountry,
+  RampDepositInstructions,
+  RampDirection,
+  RampQuote,
+  RampsOfframpBody,
+  RampsOnrampBody,
+  RampTxStatus,
+} from '@pollar/core';
 import { useEffect, useRef, useState } from 'react';
 import { usePollar } from '../../context';
 import type { RampFieldSpec, RampStep } from './RampWidgetTemplate';
@@ -111,7 +119,7 @@ interface RampResult {
   pendingSignature?: { unsignedXdr: string; action: 'sep10' | 'withdraw_payment' };
   // REST providers (Bridge) return deposit instructions as data (e.g. a Pix
   // `br_code` / bank details for on-ramp) instead of an interactive URL.
-  depositInstructions?: Record<string, unknown>;
+  depositInstructions?: RampDepositInstructions;
 }
 
 export function RampWidget({ onClose }: RampWidgetProps) {
@@ -148,7 +156,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   const [kycApproved, setKycApproved] = useState(false);
   const [txStatus, setTxStatus] = useState<RampTxStatus | null>(null);
   const [stellarTxHash, setStellarTxHash] = useState<string | null>(null);
-  const [depositInstructions, setDepositInstructions] = useState<Record<string, unknown> | null>(null);
+  const [depositInstructions, setDepositInstructions] = useState<RampDepositInstructions | null>(null);
   const [completing, setCompleting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -20,6 +20,55 @@ function requiredFieldsOf(quote: RampQuote): RampFieldSpec[] {
   return (quote as { requiredFields?: RampFieldSpec[] }).requiredFields ?? [];
 }
 
+/** A bound the amount broke, or null when it fits. Providers declare their
+ *  limits on the quote (`minAmount` / `maxAmount`); the ones that don't simply
+ *  never trip this, and the backend stays the last word either way. */
+function brokenLimitOf(amount: number, quote: RampQuote): { limit: 'min' | 'max'; value: number } | null {
+  const { minAmount, maxAmount } = quote as { minAmount?: number; maxAmount?: number };
+  if (!Number.isFinite(amount)) return null;
+  if (minAmount != null && amount < minAmount) return { limit: 'min', value: minAmount };
+  if (maxAmount != null && amount > maxAmount) return { limit: 'max', value: maxAmount };
+  return null;
+}
+
+/** "The minimum amount is 11 ARS" — one phrasing, used both when we catch the
+ *  limit before submitting and when the backend is the one to report it. */
+function limitMessage(limit: 'min' | 'max', value: number, currency: string): string {
+  return `The ${limit === 'min' ? 'minimum' : 'maximum'} amount for this route is ${value} ${currency}.`;
+}
+
+/** Ramp failures a user can act on. Anything unlisted keeps the raw code, which
+ *  is still the most useful thing to show for a cause we can't phrase. */
+const RAMP_ERROR_MESSAGES: Record<string, string> = {
+  SDK_RAMPS_QUOTE_EXPIRED: 'This quote expired. Request a new one and try again.',
+  SDK_RAMPS_ASSET_NOT_ENABLED: 'This currency is not available for that route right now.',
+  SDK_RAMPS_KYC_REQUIRED: 'The provider needs to verify your identity before continuing.',
+  SDK_RAMPS_WALLET_UNSUPPORTED: 'This wallet type cannot be used for this ramp.',
+  SDK_RAMPS_PROVIDER_NOT_CONFIGURED: 'This ramp provider is not configured for this app yet.',
+  SDK_RAMPS_ANCHOR_ERROR: 'The provider rejected the request. Please try again in a moment.',
+  SDK_RAMPS_BRIDGE_ERROR: 'The provider rejected the request. Please try again in a moment.',
+};
+
+/**
+ * Turn a thrown ramp error into something worth reading. An out-of-range amount
+ * arrives with the bound as fields (`limit` / `limitAmount` / `limitCurrency`),
+ * so the exact figure gets stated rather than the bare code the modal used to
+ * show. Every provider that reports the range gets this for free.
+ */
+function rampErrorMessage(e: unknown, fallback: string): string {
+  const body = (e as { body?: Record<string, unknown> } | undefined)?.body;
+  const code = (e as { code?: unknown } | undefined)?.code;
+  if (typeof code !== 'string') return e instanceof Error ? e.message : fallback;
+
+  const limit = body?.limit;
+  const value = body?.limitAmount;
+  const currency = body?.limitCurrency;
+  if ((limit === 'min' || limit === 'max') && typeof value === 'number' && typeof currency === 'string') {
+    return limitMessage(limit, value, currency);
+  }
+  return RAMP_ERROR_MESSAGES[code] ?? (e instanceof Error ? e.message : fallback);
+}
+
 // Common shape of the on/off-ramp, complete and signature responses.
 interface RampResult {
   txId: string;
@@ -257,7 +306,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
       setQuotes(list);
       setStep('select_route');
     } catch (e) {
-      setErrorMsg(e instanceof Error ? e.message : 'Failed to fetch quotes.');
+      setErrorMsg(rampErrorMessage(e, 'Failed to fetch quotes.'));
       setStep('error');
     } finally {
       setIsLoading(false);
@@ -269,6 +318,14 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   function handleSelectQuote(quote: RampQuote) {
     setSelectedQuote(quote);
     setErrorMsg(null);
+    // The limits are per route, and the amount was typed before the routes were
+    // known — so this is the first moment we can check it. Catching it here
+    // states the figure without spending a round trip on a certain rejection.
+    const broken = brokenLimitOf(Number(amount), quote);
+    if (broken) {
+      setErrorMsg(limitMessage(broken.limit, broken.value, currency));
+      return;
+    }
     const fields = requiredFieldsOf(quote);
     const missing = fields.some((f) => !(fieldValues[f.key] ?? '').trim());
     if (fields.length > 0 && missing) {
@@ -309,7 +366,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
       ) as RampResult;
       await applyResult(result);
     } catch (e) {
-      setErrorMsg(e instanceof Error ? e.message : 'Failed to start the ramp.');
+      setErrorMsg(rampErrorMessage(e, 'Failed to start the ramp.'));
       setStep('error');
     } finally {
       setIsLoading(false);

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -288,6 +288,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     setTxStatus(null);
     setStellarTxHash(null);
     setDepositInstructions(null);
+    setKycPending(false);
+    setKycApproved(false);
     if (!keepMessage) setErrorMsg(null);
   }
 
@@ -441,12 +443,13 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     }
   }
 
-  // A pending link-less KYC gate blocks the withdraw: the provider has no payment
-  // context to pay into yet, so completing would either fail or - worse - move
-  // real funds into a deposit it cannot pay out.
+  // A link-less KYC gate blocks the withdraw for good: the provider consumed the
+  // quote when it answered `kycRequired`, so completing would either fail or -
+  // worse - move real funds into a deposit it cannot pay out. Approval clears the
+  // gate for the NEXT quote, not for this transaction, so `kycPending` (not
+  // `kycBlocking`) is what keeps the button away.
   const kycBlocking = kycPending && !kycApproved;
-  const canComplete =
-    direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash && !kycBlocking;
+  const canComplete = direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash && !kycPending;
 
   const flowSteps = flowStepsOf(quotes, selectedQuote);
   const flowStepIndex = flowSteps.indexOf(STEP_LABEL[step] ?? '');

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -44,7 +44,7 @@ function flowStepsOf(quotes: RampQuote[], selected: RampQuote | null): string[] 
 }
 
 /** Which of those steps the current widget step sits on. `error` belongs to no
- *  step — the flow stopped rather than advanced — so the bar hides there. */
+ *  step - the flow stopped rather than advanced - so the bar hides there. */
 const STEP_LABEL: Partial<Record<RampStep, string>> = {
   input: 'Amount',
   loading_quote: 'Amount',
@@ -64,7 +64,7 @@ function brokenLimitOf(amount: number, quote: RampQuote): { limit: 'min' | 'max'
   return null;
 }
 
-/** "The minimum amount is 11 ARS" — one phrasing, used both when we catch the
+/** "The minimum amount is 11 ARS" - one phrasing, used both when we catch the
  *  limit before submitting and when the backend is the one to report it. */
 function limitMessage(limit: 'min' | 'max', value: number, currency: string): string {
   return `The ${limit === 'min' ? 'minimum' : 'maximum'} amount for this route is ${value} ${currency}.`;
@@ -112,7 +112,7 @@ interface RampResult {
   // acceptance. Both must be completed before the customer activates.
   tosUrl?: string;
   // The provider gated the flow on identity verification and offers no hosted
-  // URL (Abroad). Nothing was built or signed — the user clears KYC with the
+  // URL (Abroad). Nothing was built or signed - the user clears KYC with the
   // provider directly, and we poll `getRampKycStatus` until they do.
   kycRequired?: boolean;
   stellarTxHash?: string;
@@ -175,12 +175,12 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         setTxStatus(tx.status);
         if (tx.stellarTxHash) setStellarTxHash(tx.stellarTxHash);
         if (tx.kycUrl) setKycUrl(tx.kycUrl);
-        // depositInstructions is returned by REST providers (Bridge) — e.g. a Pix
+        // depositInstructions is returned by REST providers (Bridge) - e.g. a Pix
         // `br_code` / bank details for on-ramp.
         if (tx.depositInstructions) setDepositInstructions(tx.depositInstructions);
         if (TERMINAL.includes(tx.status)) clearInterval(id);
       } catch {
-        /* transient — keep polling */
+        /* transient - keep polling */
       }
     }, 5000);
     return () => {
@@ -199,7 +199,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         const { hasApproved } = await client.getRampKycStatus();
         if (active && hasApproved) setKycApproved(true);
       } catch {
-        /* transient — keep polling */
+        /* transient - keep polling */
       }
     };
     void check();
@@ -212,7 +212,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
 
   /**
    * Fetch the ramp countries supported on the app's network. When `resetSelection`
-   * is set (initial load) — or the current selection is no longer offered — pick
+   * is set (initial load) - or the current selection is no longer offered - pick
    * the first country and adopt its primary currency.
    */
   async function loadCountries(resetSelection: boolean) {
@@ -263,7 +263,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         if (tx.depositInstructions) setDepositInstructions(tx.depositInstructions);
       }
     } catch {
-      /* transient — leave the current data in place */
+      /* transient - leave the current data in place */
     } finally {
       setRefreshing(false);
     }
@@ -355,7 +355,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     setSelectedQuote(quote);
     setErrorMsg(null);
     // The limits are per route, and the amount was typed before the routes were
-    // known — so this is the first moment we can check it. Catching it here
+    // known - so this is the first moment we can check it. Catching it here
     // states the figure without spending a round trip on a certain rejection.
     const broken = brokenLimitOf(Number(amount), quote);
     if (broken) {
@@ -363,7 +363,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
       return;
     }
     const fields = requiredFieldsOf(quote);
-    // An `optional` field left blank is not missing (Abroad's tax id) — it must
+    // An `optional` field left blank is not missing (Abroad's tax id) - it must
     // not drag the user into the details step on its own.
     const missing = fields.some((f) => !f.optional && !(fieldValues[f.key] ?? '').trim());
     if (fields.length > 0 && missing) {
@@ -442,7 +442,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   }
 
   // A pending link-less KYC gate blocks the withdraw: the provider has no payment
-  // context to pay into yet, so completing would either fail or — worse — move
+  // context to pay into yet, so completing would either fail or - worse - move
   // real funds into a deposit it cannot pay out.
   const kycBlocking = kycPending && !kycApproved;
   const canComplete =

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -35,6 +35,14 @@ interface RampWidgetTemplateProps {
   /** Per-app modal chrome overrides (background, card + button radius). */
   styleOverrides?: ModalStyleOverrides;
   step: RampStep;
+  /** Labels of the steps this run goes through. Length varies by route: only
+   *  providers that collect fields add a 'Details' step. */
+  flowSteps: string[];
+  /** Index into `flowSteps`, or -1 when the current step is outside the flow
+   *  (the error step) and the progress bar should be hidden. */
+  flowStepIndex: number;
+  /** Quote whose start request is in flight, so its row can show it. */
+  startingQuoteId: string | null;
   direction: RampDirection;
   amount: string;
   currency: string;
@@ -72,6 +80,9 @@ interface RampWidgetTemplateProps {
   onOpenKyc: () => void;
   onOpenTos: () => void;
   onCompleteWithdraw: () => void;
+  /** Step back to the amount, keeping what was entered. Distinct from `onRetry`
+   *  (which restarts a failed flow) so a "Back" button reads as navigation. */
+  onBack: () => void;
   onRetry: () => void;
   onRefresh: () => void;
   onClose: () => void;
@@ -151,6 +162,9 @@ export function RampWidgetTemplate({
   accentColor,
   styleOverrides,
   step,
+  flowSteps,
+  flowStepIndex,
+  startingQuoteId,
   direction,
   amount,
   currency,
@@ -184,6 +198,7 @@ export function RampWidgetTemplate({
   onOpenKyc,
   onOpenTos,
   onCompleteWithdraw,
+  onBack,
   onRetry,
   onRefresh,
   onClose,
@@ -242,6 +257,29 @@ export function RampWidgetTemplate({
         </div>
       </div>
 
+      {/* How far along the run is. The segment count comes from the route, not
+          from a constant: a provider that collects no fields genuinely has one
+          step fewer. Hidden on the error step, which is not part of the flow. */}
+      {flowStepIndex >= 0 && flowSteps.length > 0 && (
+        <div className="pollar-ramp-steps">
+          <span className="pollar-ramp-steps-label">
+            Step {flowStepIndex + 1} of {flowSteps.length}
+          </span>
+          <div
+            className="pollar-ramp-steps-track"
+            role="progressbar"
+            aria-valuenow={flowStepIndex + 1}
+            aria-valuemin={1}
+            aria-valuemax={flowSteps.length}
+            aria-label={flowSteps[flowStepIndex]}
+          >
+            {flowSteps.map((label, i) => (
+              <span key={label} className="pollar-ramp-steps-segment" data-done={i <= flowStepIndex || undefined} />
+            ))}
+          </div>
+        </div>
+      )}
+
       {step === 'input' && (
         <>
           <div className="pollar-tabs">
@@ -294,6 +332,9 @@ export function RampWidgetTemplate({
               min="0"
               onChange={(e) => onAmountChange(e.target.value)}
             />
+            {/* Why the user was sent back here (e.g. the route's minimum), kept
+                under the field they came to fix. Clears as soon as they type. */}
+            {errorMsg && <span className="pollar-ramp-field-error">{errorMsg}</span>}
           </div>
 
           <div className="pollar-modal-actions">
@@ -328,7 +369,13 @@ export function RampWidgetTemplate({
         <>
           <div className="pollar-ramp-route-list">
             {quotes.map((q, i) => (
-              <RouteDisplay key={i} quote={q} onSelect={onSelectQuote} />
+              <RouteDisplay
+                key={i}
+                quote={q}
+                busy={startingQuoteId != null && q.quoteId === startingQuoteId}
+                disabled={startingQuoteId != null && q.quoteId !== startingQuoteId}
+                onSelect={onSelectQuote}
+              />
             ))}
           </div>
           {/* A route whose limits the amount breaks reports it here, so the user
@@ -339,8 +386,11 @@ export function RampWidgetTemplate({
               {errorMsg}
             </p>
           )}
-          <button type="button" className="pollar-btn-secondary" onClick={onClose}>
-            Cancel
+          {/* Back returns to the amount, which is the only way out of a route
+              whose minimum the amount misses — so it takes the primary weight
+              while that message is up. The header's ✕ still closes the modal. */}
+          <button type="button" className={errorMsg ? 'pollar-btn-primary' : 'pollar-btn-secondary'} onClick={onBack}>
+            Back
           </button>
         </>
       )}
@@ -381,7 +431,7 @@ export function RampWidgetTemplate({
           ))}
 
           <div className="pollar-modal-actions">
-            <button type="button" className="pollar-btn-secondary" onClick={onRetry}>
+            <button type="button" className="pollar-btn-secondary" onClick={onBack}>
               Back
             </button>
             <button

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import type { RampCountry, RampDirection, RampQuote, RampTxStatus } from '@pollar/core';
+import type {
+  RampCountry,
+  RampDepositInstructions,
+  RampDirection,
+  RampInstructionField,
+  RampQuote,
+  RampTxStatus,
+} from '@pollar/core';
 import { RouteDisplay } from './RouteDisplay';
 import { CopyButton } from '../commons';
 import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
@@ -100,7 +107,7 @@ interface RampWidgetTemplateProps {
   stellarTxHash: string | null;
   /** Stellar Expert URL for `stellarTxHash` (network-aware); null when unknown. */
   explorerUrl: string | null;
-  depositInstructions: Record<string, unknown> | null;
+  depositInstructions: RampDepositInstructions | null;
   canComplete: boolean;
   completing: boolean;
   errorMsg: string | null;
@@ -143,52 +150,15 @@ const STATUS_LABEL: Record<RampTxStatus, string> = {
   failed: 'Failed',
 };
 
-// Human labels for the deposit-instruction fields REST providers (Bridge) return
-// (e.g. a Pix `br_code`, or bank details for ACH/SEPA). Unknown keys fall back to
-// the raw key so nothing is silently dropped.
-const INSTRUCTION_LABELS: Record<string, string> = {
-  br_code: 'Pix code',
-  account_holder_name: 'Account holder',
-  bank_name: 'Bank',
-  bank_address: 'Bank address',
-  bank_account_number: 'Account number',
-  bank_routing_number: 'Routing number',
-  iban: 'IBAN',
-  bic: 'BIC',
-  clabe: 'CLABE',
-  amount: 'Amount',
-  currency: 'Currency',
-  payment_rails: 'Rails',
-};
-
-type InstructionKind = 'text' | 'qr' | 'datetime';
-type InstructionField = { key: string; label: string; value: string; kind: InstructionKind };
-
-function flattenInstructions(instr: Record<string, unknown>): InstructionField[] {
-  const out: InstructionField[] = [];
-  for (const [k, v] of Object.entries(instr)) {
-    // A base64 QR image (e.g. Stereum's Bolivian bank QR) — render as an <img>,
-    // not raw text.
-    if (k === 'qrBase64') {
-      if (typeof v === 'string' && v) out.push({ key: k, label: INSTRUCTION_LABELS[k] ?? 'Payment QR', value: v, kind: 'qr' });
-      continue;
-    }
-    // Expiry timestamps come as epoch milliseconds — render as a local date/time.
-    if ((k === 'expiresAt' || k === 'expires_at') && (typeof v === 'number' || typeof v === 'string')) {
-      const ms = Number(v);
-      if (Number.isFinite(ms) && ms > 0) {
-        out.push({ key: k, label: INSTRUCTION_LABELS[k] ?? 'Expires', value: new Date(ms).toLocaleString(), kind: 'datetime' });
-      }
-      continue;
-    }
-    let value: string;
-    if (typeof v === 'string' || typeof v === 'number') value = String(v);
-    else if (Array.isArray(v)) value = v.filter((x) => typeof x === 'string' || typeof x === 'number').join(', ');
-    else continue;
-    if (!value) continue;
-    out.push({ key: k, label: INSTRUCTION_LABELS[k] ?? k, value, kind: 'text' });
-  }
-  return out;
+/**
+ * A timestamp field arrives as ISO-8601 (the server no longer guesses at epoch
+ * milliseconds); render it in the viewer's locale. Anything unparseable falls
+ * back to the raw string rather than showing "Invalid Date".
+ */
+function displayValue(field: RampInstructionField): string {
+  if (field.type !== 'datetime') return field.value;
+  const at = new Date(field.value);
+  return Number.isNaN(at.getTime()) ? field.value : at.toLocaleString();
 }
 
 export function RampWidgetTemplate({
@@ -556,25 +526,70 @@ export function RampWidgetTemplate({
             </div>
           )}
 
+          {/* The code to scan. The server sends it rendered, so there is no QR
+              library here and no per-provider branch: a Pollar-made SVG is
+              inlined (it uses `currentColor`, so it follows the modal's theme),
+              and a provider's own bitmap goes through an <img>. */}
+          {depositInstructions?.scannable && txStatus !== 'completed' && (
+            <div className="pollar-ramp-payment-field">
+              <span className="pollar-ramp-payment-label">Payment QR</span>
+              <div className="pollar-ramp-payment-value">
+                {depositInstructions.scannable.image.inlineSafe ? (
+                  <div
+                    className="pollar-ramp-qr"
+                    aria-label="Payment QR"
+                    dangerouslySetInnerHTML={{ __html: depositInstructions.scannable.image.data }}
+                  />
+                ) : (
+                  <img
+                    src={`data:${depositInstructions.scannable.image.mediaType};base64,${depositInstructions.scannable.image.data}`}
+                    alt="Payment QR"
+                    style={{ width: '100%', maxWidth: 220, height: 'auto', display: 'block', margin: '0 auto' }}
+                  />
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* The payload as text, when it is worth pasting. On the phone holding
+              the screen there is nothing to scan, and a Pix code is designed to
+              be pasted. The server decides by setting `payloadLabel`. */}
+          {depositInstructions?.scannable?.payload &&
+            depositInstructions.scannable.payloadLabel &&
+            txStatus !== 'completed' && (
+              <div className="pollar-ramp-payment-field">
+                <span className="pollar-ramp-payment-label">{depositInstructions.scannable.payloadLabel}</span>
+                <div className="pollar-ramp-payment-value">
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <code style={{ flex: 1, wordBreak: 'break-all' }}>{depositInstructions.scannable.payload}</code>
+                    <CopyButton
+                      value={depositInstructions.scannable.payload}
+                      label={`Copy ${depositInstructions.scannable.payloadLabel}`}
+                    />
+                  </span>
+                </div>
+              </div>
+            )}
+
+          {/* Everything else. Labelled and formatted server-side, so this only
+              iterates — it knows nothing about which provider served the route. */}
           {depositInstructions &&
             txStatus !== 'completed' &&
-            flattenInstructions(depositInstructions).map(({ key, label, value, kind }) => (
-              <div key={key} className="pollar-ramp-payment-field">
-                <span className="pollar-ramp-payment-label">{label}</span>
+            depositInstructions.fields.map((f) => (
+              <div key={f.key} className="pollar-ramp-payment-field">
+                <span className="pollar-ramp-payment-label">{f.label}</span>
                 <div className="pollar-ramp-payment-value">
-                  {kind === 'qr' ? (
-                    <img
-                      src={value.startsWith('data:') ? value : `data:image/png;base64,${value}`}
-                      alt={label}
-                      style={{ width: '100%', maxWidth: 220, height: 'auto', display: 'block', margin: '0 auto' }}
-                    />
-                  ) : kind === 'datetime' ? (
-                    <span>{value}</span>
-                  ) : (
+                  {f.copyable ? (
                     <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                      <code style={{ flex: 1, wordBreak: 'break-all' }}>{value}</code>
-                      <CopyButton value={value} label={`Copy ${label}`} />
+                      <code style={{ flex: 1, wordBreak: 'break-all' }}>{f.value}</code>
+                      <CopyButton value={f.value} label={`Copy ${f.label}`} />
                     </span>
+                  ) : f.type === 'url' ? (
+                    <a href={f.value} target="_blank" rel="noopener noreferrer">
+                      {f.value}
+                    </a>
+                  ) : (
+                    <span>{displayValue(f)}</span>
                   )}
                 </div>
               </div>

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -11,10 +11,14 @@ export type RampStep = 'input' | 'loading_quote' | 'select_route' | 'contact' | 
 // provider (which rejects it with a generic VALIDATION_ERROR).
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-/** A collected field is complete when it's non-empty and (for email) well-formed. */
+/**
+ * A collected field is complete when it's non-empty and (for email) well-formed.
+ * An `optional` field is complete while blank, but still has to be well-formed
+ * once something is typed into it.
+ */
 function isFieldValid(spec: RampFieldSpec, raw: string | undefined): boolean {
   const value = (raw ?? '').trim();
-  if (!value) return false;
+  if (!value) return spec.optional === true;
   if (spec.type === 'email') return EMAIL_RE.test(value);
   return true;
 }
@@ -26,7 +30,37 @@ export interface RampFieldSpec {
   type: 'text' | 'email' | 'tel' | 'select';
   bankType?: 'CLABE' | 'PIX' | 'PSE' | 'ACH' | 'BREB';
   /** For `type: 'select'` — dropdown choices (e.g. Stereum's Bolivian banks). */
-  options?: { value: string; label: string }[];
+  options?: { value: string; label: string; placeholder?: string }[];
+  /** Declared but not mandatory (Abroad's tax id). Blank must not block Continue. */
+  optional?: boolean;
+  /** Example of the expected shape, for formats a user cannot guess. */
+  placeholder?: string;
+  /**
+   * Key of a sibling `select` whose chosen option supplies the placeholder. One
+   * Pix field can then show a CPF mask, an email or a +55 number as the user
+   * switches kind, without this component knowing what a Pix key is.
+   */
+  placeholderFrom?: string;
+  /** Secondary line under the field, for a rule the label has no room for. */
+  hint?: string;
+}
+
+/** "a", "a and b", "a, b and c" — for naming what a step is asking for. */
+function listOf(items: string[]): string {
+  const last = items[items.length - 1];
+  if (last === undefined) return 'a few details';
+  if (items.length === 1) return last;
+  return `${items.slice(0, -1).join(', ')} and ${last}`;
+}
+
+/** The placeholder to show: the one a sibling select dictates, else the static one. */
+function placeholderFor(field: RampFieldSpec, fields: RampFieldSpec[], values: Record<string, string>): string | undefined {
+  if (field.placeholderFrom) {
+    const source = fields.find((f) => f.key === field.placeholderFrom);
+    const chosen = source?.options?.find((o) => o.value === values[field.placeholderFrom as string]);
+    if (chosen?.placeholder) return chosen.placeholder;
+  }
+  return field.placeholder;
 }
 
 interface RampWidgetTemplateProps {
@@ -218,7 +252,11 @@ export function RampWidgetTemplate({
     input: direction === 'onramp' ? 'Enter the amount you want to deposit' : 'Enter the amount you want to withdraw',
     loading_quote: 'Comparing providers in real time…',
     select_route: 'All prices include fees',
-    contact: `${provider || 'This provider'} needs your name and email to verify you`,
+    // What this step actually asks for is whatever the route declared, and that
+    // is rarely a name and an email: an Abroad off-ramp asks where to send the
+    // money, not who you are. Say which, rather than asserting the Bridge case
+    // over every provider.
+    contact: `${provider || 'This provider'} needs ${listOf(requiredFields.filter((f) => !f.optional).map((f) => f.label.toLowerCase()))} to continue`,
     status: `Finish the flow at ${provider || 'the provider'} to continue`,
     error: 'Please try again',
   };
@@ -399,7 +437,10 @@ export function RampWidgetTemplate({
         <>
           {requiredFields.map((f) => (
             <div key={f.key} className="pollar-ramp-field">
-              <label className="pollar-ramp-label">{f.label}</label>
+              <label className="pollar-ramp-label">
+                {f.label}
+                {f.optional && <span className="pollar-ramp-field-optional"> (optional)</span>}
+              </label>
               {f.type === 'select' ? (
                 <select
                   className="pollar-ramp-input"
@@ -420,10 +461,12 @@ export function RampWidgetTemplate({
                   type={f.type}
                   className="pollar-ramp-input"
                   value={fieldValues[f.key] ?? ''}
+                  placeholder={placeholderFor(f, requiredFields, fieldValues)}
                   autoComplete={f.type === 'email' ? 'email' : 'off'}
                   onChange={(e) => onFieldChange(f.key, e.target.value)}
                 />
               )}
+              {f.hint && <span className="pollar-ramp-field-hint">{f.hint}</span>}
               {f.type === 'email' && (fieldValues[f.key] ?? '').trim() !== '' && !isFieldValid(f, fieldValues[f.key]) && (
                 <span className="pollar-ramp-field-error">Enter a valid email address.</span>
               )}

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -51,6 +51,10 @@ interface RampWidgetTemplateProps {
   txStatus: RampTxStatus | null;
   kycUrl: string | null;
   tosUrl: string | null;
+  /** Provider gated the flow on KYC and published no link; nothing was signed. */
+  kycBlocking: boolean;
+  /** The gate has since cleared — the user needs a fresh quote to continue. */
+  kycJustApproved: boolean;
   stellarTxHash: string | null;
   /** Stellar Expert URL for `stellarTxHash` (network-aware); null when unknown. */
   explorerUrl: string | null;
@@ -162,6 +166,8 @@ export function RampWidgetTemplate({
   txStatus,
   kycUrl,
   tosUrl,
+  kycBlocking,
+  kycJustApproved,
   stellarTxHash,
   explorerUrl,
   depositInstructions,
@@ -486,6 +492,22 @@ export function RampWidgetTemplate({
             <button type="button" className="pollar-btn-primary" onClick={onOpenKyc}>
               Continue at {provider}
             </button>
+          )}
+
+          {/* Link-less KYC gate: there is nowhere to send the user, so say what
+              is blocking and keep the withdraw button out of reach. No funds
+              have moved and nothing was signed. */}
+          {kycBlocking && (
+            <p className="pollar-ramp-payment-note">
+              {provider} needs to verify your identity before this payout. Nothing has been sent yet — complete verification
+              with {provider}, and this will update on its own.
+            </p>
+          )}
+
+          {kycJustApproved && (
+            <p className="pollar-ramp-payment-note">
+              {provider} approved your verification. Request a new quote to continue — the previous one was consumed.
+            </p>
           )}
 
           {canComplete && (

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { RampCountry, RampDirection, RampQuote, RampTxStatus } from '@pollar/core';
-import type { CSSProperties } from 'react';
 import { RouteDisplay } from './RouteDisplay';
 import { CopyButton } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 export type RampStep = 'input' | 'loading_quote' | 'select_route' | 'contact' | 'status' | 'error';
 
@@ -32,6 +32,8 @@ export interface RampFieldSpec {
 interface RampWidgetTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   step: RampStep;
   direction: RampDirection;
   amount: string;
@@ -143,6 +145,7 @@ function flattenInstructions(instr: Record<string, unknown>): InstructionField[]
 export function RampWidgetTemplate({
   theme,
   accentColor,
+  styleOverrides,
   step,
   direction,
   amount,
@@ -179,28 +182,7 @@ export function RampWidgetTemplate({
   onRefresh,
   onClose,
 }: RampWidgetTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-    '--pollar-modal-padding': '2rem',
-    '--pollar-modal-heading-size': '1.375rem',
-    '--pollar-modal-subtitle-size': '0.9rem',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides, 'hero');
 
   const stepTitle: Record<RampStep, string> = {
     input: direction === 'onramp' ? 'Buy crypto' : 'Sell crypto',

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -331,6 +331,14 @@ export function RampWidgetTemplate({
               <RouteDisplay key={i} quote={q} onSelect={onSelectQuote} />
             ))}
           </div>
+          {/* A route whose limits the amount breaks reports it here, so the user
+              can pick another route or go back and edit — without leaving the
+              list for the error step. */}
+          {errorMsg && (
+            <p className="pollar-ramp-payment-note" style={{ color: 'var(--pollar-error-text)' }}>
+              {errorMsg}
+            </p>
+          )}
           <button type="button" className="pollar-btn-secondary" onClick={onClose}>
             Cancel
           </button>

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -6,6 +6,7 @@ import type {
   RampDirection,
   RampInstructionField,
   RampQuote,
+  RampScannable,
   RampTxStatus,
 } from '@pollar/core';
 import { RouteDisplay } from './RouteDisplay';
@@ -28,6 +29,18 @@ function isFieldValid(spec: RampFieldSpec, raw: string | undefined): boolean {
   if (!value) return spec.optional === true;
   if (spec.type === 'email') return EMAIL_RE.test(value);
   return true;
+}
+
+/**
+ * The `src` for a scannable that is not inline-safe. `encoding` and `inlineSafe`
+ * are independent in the contract: an SVG a provider sent (so not inline-safe)
+ * still arrives as `utf8`, and base64-wrapping that text yields a data URL the
+ * browser cannot decode - a blank QR on the payment screen.
+ */
+function scannableImageSrc(image: RampScannable['image']): string {
+  return image.encoding === 'base64'
+    ? `data:${image.mediaType};base64,${image.data}`
+    : `data:${image.mediaType};charset=utf-8,${encodeURIComponent(image.data)}`;
 }
 
 /** A field a provider declares (via the quote) that the client must collect. */
@@ -542,7 +555,7 @@ export function RampWidgetTemplate({
                   />
                 ) : (
                   <img
-                    src={`data:${depositInstructions.scannable.image.mediaType};base64,${depositInstructions.scannable.image.data}`}
+                    src={scannableImageSrc(depositInstructions.scannable.image)}
                     alt="Payment QR"
                     style={{ width: '100%', maxWidth: 220, height: 'auto', display: 'block', margin: '0 auto' }}
                   />
@@ -620,10 +633,18 @@ export function RampWidgetTemplate({
             </p>
           )}
 
+          {/* Approval unblocks the next quote, not this one: the provider consumed
+              this transaction's quote when it asked for KYC. So the withdraw stays
+              out of reach and the only way forward is a fresh quote. */}
           {kycJustApproved && (
-            <p className="pollar-ramp-payment-note">
-              {provider} approved your verification. Request a new quote to continue — the previous one was consumed.
-            </p>
+            <>
+              <p className="pollar-ramp-payment-note">
+                {provider} approved your verification. Request a new quote to continue — the previous one was consumed.
+              </p>
+              <button type="button" className="pollar-btn-primary" onClick={onRetry}>
+                Request a new quote
+              </button>
+            </>
           )}
 
           {canComplete && (

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -36,7 +36,7 @@ export interface RampFieldSpec {
   label: string;
   type: 'text' | 'email' | 'tel' | 'select';
   bankType?: 'CLABE' | 'PIX' | 'PSE' | 'ACH' | 'BREB';
-  /** For `type: 'select'` — dropdown choices (e.g. Stereum's Bolivian banks). */
+  /** For `type: 'select'` - dropdown choices (e.g. Stereum's Bolivian banks). */
   options?: { value: string; label: string; placeholder?: string }[];
   /** Declared but not mandatory (Abroad's tax id). Blank must not block Continue. */
   optional?: boolean;
@@ -52,7 +52,7 @@ export interface RampFieldSpec {
   hint?: string;
 }
 
-/** "a", "a and b", "a, b and c" — for naming what a step is asking for. */
+/** "a", "a and b", "a, b and c" - for naming what a step is asking for. */
 function listOf(items: string[]): string {
   const last = items[items.length - 1];
   if (last === undefined) return 'a few details';
@@ -102,7 +102,7 @@ interface RampWidgetTemplateProps {
   tosUrl: string | null;
   /** Provider gated the flow on KYC and published no link; nothing was signed. */
   kycBlocking: boolean;
-  /** The gate has since cleared — the user needs a fresh quote to continue. */
+  /** The gate has since cleared - the user needs a fresh quote to continue. */
   kycJustApproved: boolean;
   stellarTxHash: string | null;
   /** Stellar Expert URL for `stellarTxHash` (network-aware); null when unknown. */
@@ -387,7 +387,7 @@ export function RampWidgetTemplate({
             ))}
           </div>
           {/* A route whose limits the amount breaks reports it here, so the user
-              can pick another route or go back and edit — without leaving the
+              can pick another route or go back and edit - without leaving the
               list for the error step. */}
           {errorMsg && (
             <p className="pollar-ramp-payment-note" style={{ color: 'var(--pollar-error-text)' }}>
@@ -395,8 +395,8 @@ export function RampWidgetTemplate({
             </p>
           )}
           {/* Back returns to the amount, which is the only way out of a route
-              whose minimum the amount misses — so it takes the primary weight
-              while that message is up. The header's ✕ still closes the modal. */}
+              whose minimum the amount misses - so it takes the primary weight
+              while that message is up. The header's X still closes the modal. */}
           <button type="button" className={errorMsg ? 'pollar-btn-primary' : 'pollar-btn-secondary'} onClick={onBack}>
             Back
           </button>
@@ -572,7 +572,7 @@ export function RampWidgetTemplate({
             )}
 
           {/* Everything else. Labelled and formatted server-side, so this only
-              iterates — it knows nothing about which provider served the route. */}
+              iterates - it knows nothing about which provider served the route. */}
           {depositInstructions &&
             txStatus !== 'completed' &&
             depositInstructions.fields.map((f) => (
@@ -596,7 +596,7 @@ export function RampWidgetTemplate({
             ))}
 
           {/* KYC / ToS onboarding steps at the provider. Hidden once deposit
-              instructions exist — by then onboarding is done and the only
+              instructions exist - by then onboarding is done and the only
               remaining action is to pay using the instructions above. */}
           {tosUrl && !depositInstructions && txStatus !== 'completed' && (
             <button type="button" className="pollar-btn-primary" onClick={onOpenTos}>

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -151,9 +151,9 @@ const STATUS_LABEL: Record<RampTxStatus, string> = {
 };
 
 /**
- * A timestamp field arrives as ISO-8601 (the server no longer guesses at epoch
- * milliseconds); render it in the viewer's locale. Anything unparseable falls
- * back to the raw string rather than showing "Invalid Date".
+ * A timestamp field arrives as ISO-8601; render it in the viewer's locale.
+ * Anything unparseable falls back to the raw string rather than showing
+ * "Invalid Date".
  */
 function displayValue(field: RampInstructionField): string {
   if (field.type !== 'datetime') return field.value;

--- a/packages/react/src/components/ramp-widget/RouteDisplay.tsx
+++ b/packages/react/src/components/ramp-widget/RouteDisplay.tsx
@@ -4,6 +4,10 @@ import type { RampQuote } from '@pollar/core';
 
 interface RouteDisplayProps {
   quote: RampQuote;
+  /** This route is the one being started — it owns the in-flight request. */
+  busy?: boolean;
+  /** Another route is starting, so this one is not selectable meanwhile. */
+  disabled?: boolean;
   onSelect: (quote: RampQuote) => void;
 }
 
@@ -14,25 +18,42 @@ const RAIL_LABELS: Record<string, string> = {
   ACH: 'ACH (US)',
 };
 
-export function RouteDisplay({ quote, onSelect }: RouteDisplayProps) {
+export function RouteDisplay({ quote, busy = false, disabled = false, onSelect }: RouteDisplayProps) {
+  // Picking a route fires a request that can take seconds (the provider is
+  // contacted server-side). Without this the card looked inert and the only
+  // hint that anything happened was the network tab.
+  const inert = busy || disabled;
+  const select = () => {
+    if (!inert) onSelect(quote);
+  };
   return (
     <div
       className="pollar-ramp-route-card"
       data-recommended={quote.recommended}
+      data-busy={busy || undefined}
+      data-disabled={disabled || undefined}
       role="button"
-      tabIndex={0}
-      onClick={() => onSelect(quote)}
-      onKeyDown={(e) => e.key === 'Enter' && onSelect(quote)}
+      aria-busy={busy}
+      aria-disabled={inert}
+      tabIndex={inert ? -1 : 0}
+      onClick={select}
+      onKeyDown={(e) => e.key === 'Enter' && select()}
     >
       <div className="pollar-ramp-route-left">
         <span className="pollar-ramp-route-provider">{quote.provider}</span>
         <span className="pollar-ramp-route-meta">
-          {RAIL_LABELS[quote.rail] ?? quote.rail} · {quote.protocol} · {quote.estimatedTime}
+          {busy ? 'Starting…' : `${RAIL_LABELS[quote.rail] ?? quote.rail} · ${quote.protocol} · ${quote.estimatedTime}`}
         </span>
       </div>
       <div className="pollar-ramp-route-right">
-        <span className="pollar-ramp-route-fee">{quote.fee}% fee</span>
-        {quote.recommended && <span className="pollar-ramp-route-badge">Best rate</span>}
+        {busy ? (
+          <span className="pollar-spinner pollar-spinner-sm" />
+        ) : (
+          <>
+            <span className="pollar-ramp-route-fee">{quote.fee}% fee</span>
+            {quote.recommended && <span className="pollar-ramp-route-badge">Best rate</span>}
+          </>
+        )}
       </div>
     </div>
   );

--- a/packages/react/src/components/ramp-widget/RouteDisplay.tsx
+++ b/packages/react/src/components/ramp-widget/RouteDisplay.tsx
@@ -4,7 +4,7 @@ import type { RampQuote } from '@pollar/core';
 
 interface RouteDisplayProps {
   quote: RampQuote;
-  /** This route is the one being started — it owns the in-flight request. */
+  /** This route is the one being started - it owns the in-flight request. */
   busy?: boolean;
   /** Another route is starting, so this one is not selectable meanwhile. */
   disabled?: boolean;

--- a/packages/react/src/components/receive-modal/ReceiveModal.tsx
+++ b/packages/react/src/components/receive-modal/ReceiveModal.tsx
@@ -8,6 +8,7 @@ import { addressForChain } from '../ChainSelect';
 import '../shared.css';
 import './ReceiveModal.css';
 import { ReceiveModalTemplate } from './ReceiveModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface ReceiveModalProps {
   onClose: () => void;
@@ -15,7 +16,7 @@ interface ReceiveModalProps {
 
 export function ReceiveModal({ onClose }: ReceiveModalProps) {
   const { wallets, styles } = usePollar();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -49,10 +50,11 @@ export function ReceiveModal({ onClose }: ReceiveModalProps) {
   }
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <ReceiveModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         walletAddress={walletAddress}
         chains={chains}
         selectedChain={selectedChain}

--- a/packages/react/src/components/receive-modal/ReceiveModalTemplate.tsx
+++ b/packages/react/src/components/receive-modal/ReceiveModalTemplate.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { WalletChain } from '@pollar/core';
-import { type CSSProperties } from 'react';
 import { QRCode } from '../../lib/qr-code';
 import { ChainSelect } from '../ChainSelect';
 import { PollarModalFooter } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 /** Network name as it reads in a sentence ("Share your Stellar address"). */
 const CHAIN_NAME: Record<string, string> = {
@@ -16,6 +16,8 @@ const CHAIN_NAME: Record<string, string> = {
 export interface ReceiveModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   /** Address of the wallet on {@link selectedChain}. */
   walletAddress: string;
   /** Networks the user holds a wallet on; the first one is the default. */
@@ -30,6 +32,7 @@ export interface ReceiveModalTemplateProps {
 export function ReceiveModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   walletAddress,
   chains,
   selectedChain,
@@ -40,23 +43,7 @@ export function ReceiveModalTemplate({
 }: ReceiveModalTemplateProps) {
   const isDark = theme === 'dark';
 
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const chainName = selectedChain ? (CHAIN_NAME[selectedChain] ?? selectedChain) : 'wallet';
 

--- a/packages/react/src/components/send-modal/SendModal.tsx
+++ b/packages/react/src/components/send-modal/SendModal.tsx
@@ -9,6 +9,7 @@ import '../shared.css';
 import '../transaction-modal/TransactionModal.css';
 import './SendModal.css';
 import { SendModalTemplate } from './SendModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface SendModalProps {
   onClose: () => void;
@@ -38,7 +39,7 @@ export function SendModal({ onClose }: SendModalProps) {
   // External-wallet signing-adapter id (freighter/albedo) drives the wallet logo;
   // null for custodial/smart, which fall back to the Pollar logo.
   const walletType = wallet?.custody === 'external' ? wallet.provider : null;
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const [step, setStep] = useState<'form' | 'tx'>('form');
   const [amount, setAmount] = useState('');
@@ -235,10 +236,11 @@ export function SendModal({ onClose }: SendModalProps) {
   }
 
   return (
-    <div className="pollar-overlay" onClick={!isInProgress ? onClose : undefined}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={!isInProgress ? onClose : undefined}>
       <SendModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         step={step}
         txTitle={txTitle}
         assets={sortedAssets}

--- a/packages/react/src/components/send-modal/SendModal.tsx
+++ b/packages/react/src/components/send-modal/SendModal.tsx
@@ -78,7 +78,7 @@ export function SendModal({ onClose }: SendModalProps) {
 
   const balanceData = walletBalance.step === 'loaded' ? walletBalance.data : null;
   // Only the picked network's assets. The backend returns every chain in one
-  // payload, so this is a local filter — switching networks costs no request.
+  // payload, so this is a local filter - switching networks costs no request.
   const allAssets = (balanceData?.balances ?? []).filter((b) => resolveChain(b.chain) === selectedChain);
   // App assets first, then native XLM (always, even at 0, so the user knows to
   // fund) and any other non-app asset the wallet actually holds.
@@ -174,7 +174,7 @@ export function SendModal({ onClose }: SendModalProps) {
     }
 
     // Solana takes integer base units while the form (like the balance above it)
-    // is in decimals, so convert before sending — with the asset's own decimals,
+    // is in decimals, so convert before sending - with the asset's own decimals,
     // and via strings so a 9-decimal amount is not rounded by a float. The
     // fallback is native SOL's 9, reached only on the native row (the guard above
     // rejects any other asset that lacks `decimals`).

--- a/packages/react/src/components/send-modal/SendModalTemplate.tsx
+++ b/packages/react/src/components/send-modal/SendModalTemplate.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { TransactionState, WalletBalanceRecord, WalletChain, WalletId } from '@pollar/core';
-import { type CSSProperties } from 'react';
 import { AssetSelect } from '../AssetSelect';
 import { ChainSelect } from '../ChainSelect';
 import { CopyButton, cropAddress, PollarModalFooter } from '../commons';
 import { TxStatusView } from '../transaction-modal/TxStatusView';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 // A null balance means the chain could not be read; it shows as a dash rather
 // than as 0, so an unreadable wallet never looks empty.
@@ -22,6 +22,8 @@ function assetKey(record: WalletBalanceRecord): string {
 export interface SendModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   step: 'form' | 'tx';
   txTitle: string;
   assets: WalletBalanceRecord[];
@@ -62,6 +64,7 @@ export interface SendModalTemplateProps {
 export function SendModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   step,
   txTitle,
   assets,
@@ -95,25 +98,7 @@ export function SendModalTemplate({
   onRetry,
   onDone,
 }: SendModalTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const selectedKey = selectedAsset ? assetKey(selectedAsset) : '';
   const canSubmit = canSendOnChain && !!selectedAsset && !!amount && !!destination.trim() && !isLoadingBalance;

--- a/packages/react/src/components/send-modal/SendModalTemplate.tsx
+++ b/packages/react/src/components/send-modal/SendModalTemplate.tsx
@@ -165,7 +165,7 @@ export function SendModalTemplate({
       {/* Form step */}
       {step === 'form' && (
         <>
-          {/* Network selector — drives the address and the asset list below */}
+          {/* Network selector - drives the address and the asset list below */}
           <ChainSelect value={selectedChain} options={chains} onChange={onSelectChain} disabled={isLoadingBalance} />
 
           {walletAddress && (
@@ -186,7 +186,7 @@ export function SendModalTemplate({
             options={assets.map((a) => ({
               key: assetKey(a),
               code: a.code,
-              // Unreadable (null) drops the "— X available" suffix instead of
+              // Unreadable (null) drops the "- X available" suffix instead of
               // claiming a zero balance.
               available: a.available ?? undefined,
               enabledInApp: a.enabledInApp,

--- a/packages/react/src/components/sessions-modal/SessionsModal.tsx
+++ b/packages/react/src/components/sessions-modal/SessionsModal.tsx
@@ -5,6 +5,7 @@ import { usePollar } from '../../context';
 import '../shared.css';
 import './SessionsModal.css';
 import { SessionsModalTemplate } from './SessionsModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface SessionsModalProps {
   onClose: () => void;
@@ -12,7 +13,7 @@ interface SessionsModalProps {
 
 export function SessionsModal({ onClose }: SessionsModalProps) {
   const { getClient, styles, sessions } = usePollar();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   // Only the per-action button spinners are local UI state. The list itself
   // (idle/loading/loaded/error) lives in the client's observable `sessions`
@@ -73,10 +74,11 @@ export function SessionsModal({ onClose }: SessionsModalProps) {
   }, [getClient, onClose]);
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <SessionsModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         state={sessions}
         revokingFamilyId={revokingFamilyId}
         signingOutEverywhere={signingOutEverywhere}

--- a/packages/react/src/components/sessions-modal/SessionsModal.tsx
+++ b/packages/react/src/components/sessions-modal/SessionsModal.tsx
@@ -17,7 +17,7 @@ export function SessionsModal({ onClose }: SessionsModalProps) {
 
   // Only the per-action button spinners are local UI state. The list itself
   // (idle/loading/loaded/error) lives in the client's observable `sessions`
-  // store, read straight from the provider — so this component is a pure
+  // store, read straight from the provider - so this component is a pure
   // reader and there's no `await`-then-`setState` to guard against unmount.
   const [revokingFamilyId, setRevokingFamilyId] = useState<string | null>(null);
   const [signingOutEverywhere, setSigningOutEverywhere] = useState(false);
@@ -48,7 +48,7 @@ export function SessionsModal({ onClose }: SessionsModalProps) {
       try {
         await getClient().revokeSession(familyId);
       } catch {
-        // Swallow — the refresh below resyncs the list with server truth, so a
+        // Swallow - the refresh below resyncs the list with server truth, so a
         // failed revoke simply leaves the (still-active) row in place.
       } finally {
         setRevokingFamilyId(null);
@@ -63,7 +63,7 @@ export function SessionsModal({ onClose }: SessionsModalProps) {
     setSigningOutEverywhere(true);
     try {
       await getClient().logoutEverywhere();
-      // After logout-everywhere the auth state flips to 'idle' — the
+      // After logout-everywhere the auth state flips to 'idle' - the
       // provider closes the parent overlay automatically. Belt-and-braces:
       // call onClose so the modal also tears down even if the consumer
       // wired it up outside the provider.

--- a/packages/react/src/components/sessions-modal/SessionsModalTemplate.tsx
+++ b/packages/react/src/components/sessions-modal/SessionsModalTemplate.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import type { SessionInfo, SessionsState } from '@pollar/core';
-import { type CSSProperties } from 'react';
 import { PollarModalFooter } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 export type { SessionsState };
 
 export interface SessionsModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   state: SessionsState;
   revokingFamilyId: string | null;
   signingOutEverywhere: boolean;
@@ -80,6 +82,7 @@ function shortIp(hash: string | null): string {
 export function SessionsModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   state,
   revokingFamilyId,
   signingOutEverywhere,
@@ -88,24 +91,7 @@ export function SessionsModalTemplate({
   onLogoutEverywhere,
   onClose,
 }: SessionsModalTemplateProps) {
-  const isDark = theme === 'dark';
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const isLoading = state.step === 'loading';
   const sessions = state.step === 'loaded' ? state.sessions : [];

--- a/packages/react/src/components/shared.css
+++ b/packages/react/src/components/shared.css
@@ -19,7 +19,7 @@
 .pollar-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: var(--pollar-overlay-z-index, 50);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -35,7 +35,7 @@
 .pollar-modal-card {
   position: relative;
   width: 100%;
-  border-radius: 1rem;
+  border-radius: var(--pollar-modal-border-radius, 1rem);
   border: 1px solid var(--pollar-border);
   padding: var(--pollar-modal-padding, 1.75rem);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
@@ -163,7 +163,9 @@
   border: none;
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
   background-color: var(--pollar-accent);
-  color: #fff;
+  /* Falls back to white — the hardcoded value this replaced — so a consumer
+   * mounting a template without the button vars keeps the original look. */
+  color: var(--pollar-btn-primary-fg, #fff);
   font-size: 0.9375rem;
   font-weight: 700;
   cursor: pointer;
@@ -188,8 +190,9 @@
   padding: 0 1rem;
   border: 1px solid var(--pollar-border);
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
-  background-color: transparent;
-  color: var(--pollar-muted);
+  /* Stays a ghost button unless a secondary fill was configured. */
+  background-color: var(--pollar-btn-secondary-bg, transparent);
+  color: var(--pollar-btn-secondary-fg, var(--pollar-muted));
   font-size: 0.9375rem;
   font-weight: 600;
   cursor: pointer;
@@ -221,11 +224,13 @@
   border-width: 2px;
 }
 
-/* When a spinner sits on an accent-filled surface (e.g. inside a primary
- * button) its accent-colored ring is invisible — recolor it to white. */
+/* When a spinner sits on the primary button's accent-filled surface its
+ * accent-colored ring is invisible — recolor it to the button's own label color,
+ * which follows the accent's luminance (white on a dark accent, dark on a pale
+ * one). */
 .pollar-btn-primary .pollar-spinner {
-  border-color: rgba(255, 255, 255, 0.35);
-  border-top-color: #fff;
+  border-color: color-mix(in srgb, var(--pollar-btn-primary-fg, #fff) 35%, transparent);
+  border-top-color: var(--pollar-btn-primary-fg, #fff);
 }
 
 /* Spinner that inherits the current text color — for inline use inside custom /

--- a/packages/react/src/components/shared.css
+++ b/packages/react/src/components/shared.css
@@ -1,4 +1,4 @@
-/* ─── Animations ──────────────────────────────────────────────────────────────── */
+/* --- Animations ---------------------------------------------------------------- */
 @keyframes pollar-spin {
   to {
     transform: rotate(360deg);
@@ -15,7 +15,7 @@
   }
 }
 
-/* ─── Overlay ─────────────────────────────────────────────────────────────────── */
+/* --- Overlay ------------------------------------------------------------------- */
 .pollar-overlay {
   position: fixed;
   inset: 0;
@@ -31,7 +31,7 @@
   background-color: rgba(0, 0, 0, 0.5);
 }
 
-/* ─── Modal card base (all modals extend this) ────────────────────────────────── */
+/* --- Modal card base (all modals extend this) ---------------------------------- */
 .pollar-modal-card {
   position: relative;
   width: 100%;
@@ -48,7 +48,7 @@
   overflow-y: auto;
 }
 
-/* ─── Common input ────────────────────────────────────────────────────────────── */
+/* --- Common input -------------------------------------------------------------- */
 .pollar-input {
   width: 100%;
   height: var(--pollar-input-height, 44px);
@@ -74,7 +74,7 @@
   cursor: not-allowed;
 }
 
-/* ─── Modal header (title left, actions right) ────────────────────────────────── */
+/* --- Modal header (title left, actions right) ---------------------------------- */
 .pollar-modal-header {
   display: flex;
   align-items: center;
@@ -95,7 +95,7 @@
   gap: 0.5rem;
 }
 
-/* ─── Icon nav buttons (close / back — shared base) ──────────────────────────── */
+/* --- Icon nav buttons (close / back - shared base) ---------------------------- */
 .pollar-close-btn,
 .pollar-back-btn,
 .pollar-modal-close {
@@ -137,12 +137,12 @@
   left: 1rem;
 }
 
-/* ─── Refresh icon (icon-only refresh button reuses .pollar-modal-close base) ──── */
+/* --- Refresh icon (icon-only refresh button reuses .pollar-modal-close base) ---- */
 .pollar-modal-refresh-icon.pollar-spinning {
   animation: pollar-spin 0.8s linear infinite;
 }
 
-/* ─── Action button container ─────────────────────────────────────────────────── */
+/* --- Action button container --------------------------------------------------- */
 .pollar-modal-actions {
   display: flex;
   gap: 0.625rem;
@@ -151,19 +151,19 @@
 
 /* In a button row the primary grows to fill/share the available width. Scoped
  * here (rather than on the base class) so the button keeps its 44px height when
- * used inside a flex-column — a bare `flex: 1` collapses it to text height. */
+ * used inside a flex-column - a bare `flex: 1` collapses it to text height. */
 .pollar-modal-actions .pollar-btn-primary {
   flex: 1;
 }
 
-/* ─── Primary button ──────────────────────────────────────────────────────────── */
+/* --- Primary button ------------------------------------------------------------ */
 .pollar-btn-primary {
   width: 100%;
   height: var(--pollar-buttons-height, 44px);
   border: none;
   border-radius: var(--pollar-buttons-border-radius, 0.5rem);
   background-color: var(--pollar-accent);
-  /* Falls back to white — the hardcoded value this replaced — so a consumer
+  /* Falls back to white - the hardcoded value this replaced - so a consumer
    * mounting a template without the button vars keeps the original look. */
   color: var(--pollar-btn-primary-fg, #fff);
   font-size: 0.9375rem;
@@ -184,7 +184,7 @@
   cursor: not-allowed;
 }
 
-/* ─── Secondary button ────────────────────────────────────────────────────────── */
+/* --- Secondary button ---------------------------------------------------------- */
 .pollar-btn-secondary {
   height: var(--pollar-buttons-height, 44px);
   padding: 0 1rem;
@@ -204,7 +204,7 @@
   border-color: var(--pollar-text);
 }
 
-/* ─── Spinner ─────────────────────────────────────────────────────────────────── */
+/* --- Spinner ------------------------------------------------------------------- */
 .pollar-spinner {
   display: inline-block;
   vertical-align: middle;
@@ -217,7 +217,7 @@
   flex-shrink: 0;
 }
 
-/* Compact spinner for inline use (next to a label, inside a button, …). */
+/* Compact spinner for inline use (next to a label, inside a button, ...). */
 .pollar-spinner-sm {
   width: 1rem;
   height: 1rem;
@@ -225,7 +225,7 @@
 }
 
 /* When a spinner sits on the primary button's accent-filled surface its
- * accent-colored ring is invisible — recolor it to the button's own label color,
+ * accent-colored ring is invisible - recolor it to the button's own label color,
  * which follows the accent's luminance (white on a dark accent, dark on a pale
  * one). */
 .pollar-btn-primary .pollar-spinner {
@@ -233,7 +233,7 @@
   border-top-color: var(--pollar-btn-primary-fg, #fff);
 }
 
-/* Spinner that inherits the current text color — for inline use inside custom /
+/* Spinner that inherits the current text color - for inline use inside custom /
  * danger buttons where the accent ring would clash with the button's own color. */
 .pollar-spinner-current {
   border-color: color-mix(in srgb, currentColor 25%, transparent);
@@ -252,7 +252,7 @@
 }
 
 /* Inline spinner + label row for a compact loading state (next to a field, in a
- * list body, …). Pair with a muted text class for the label color. */
+ * list body, ...). Pair with a muted text class for the label color. */
 .pollar-inline-loading {
   display: flex;
   align-items: center;
@@ -269,7 +269,7 @@
   color: var(--pollar-muted);
 }
 
-/* ─── Segmented-control tabs (shared by Earn / Ramp modals) ───────────────────── */
+/* --- Segmented-control tabs (shared by Earn / Ramp modals) --------------------- */
 .pollar-tabs {
   display: flex;
   gap: 4px;
@@ -301,7 +301,7 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
 }
 
-/* ─── Empty / error states ────────────────────────────────────────────────────── */
+/* --- Empty / error states ------------------------------------------------------ */
 .pollar-modal-empty {
   text-align: center;
   padding: 2rem 1rem;
@@ -316,7 +316,7 @@
   font-size: 0.875rem;
 }
 
-/* ─── Footer ──────────────────────────────────────────────────────────────────── */
+/* --- Footer -------------------------------------------------------------------- */
 .pollar-footer {
   display: flex;
   align-items: center;
@@ -355,7 +355,7 @@
   opacity: 0.6;
 }
 
-/* ─── Status banner ───────────────────────────────────────────────────────────── */
+/* --- Status banner ------------------------------------------------------------- */
 .pollar-status {
   display: flex;
   align-items: center;
@@ -425,7 +425,7 @@
   border-color: var(--pollar-accent);
 }
 
-/* Compact variant used inline next to an address (issuer, tx counterparty…). */
+/* Compact variant used inline next to an address (issuer, tx counterparty...). */
 .pollar-copy-btn-sm {
   width: 20px;
   height: 20px;
@@ -433,7 +433,7 @@
   border: none;
 }
 
-/* ─── Chain tag + on-chain address, shared by the balance and asset lists ────
+/* --- Chain tag + on-chain address, shared by the balance and asset lists ----
    Both modals list per-chain assets, so the network tag and the cropped
    issuer/contract address live here rather than in either modal's own CSS. The
    tag's accent is passed in per chain via --pollar-chain-color. */
@@ -462,7 +462,7 @@
   color: var(--pollar-muted);
 }
 
-/* ─── Busy overlay ───────────────────────────────────────────────────────────
+/* --- Busy overlay -----------------------------------------------------------
    Covers the card while a refresh is in flight so the stale data underneath
    stays readable but untouchable. The card is the scroll container, so `inset:0`
    spans the whole scrollable height; the inner box is sticky to stay on screen
@@ -489,7 +489,7 @@
   font-size: 0.8125rem;
 }
 
-/* ─── On/off switch ──────────────────────────────────────────────────────────
+/* --- On/off switch ----------------------------------------------------------
    One control for a binary state (currently trustlines), replacing the old
    status-pill-plus-button pair. */
 .pollar-switch {
@@ -542,14 +542,14 @@
   color: var(--pollar-muted);
 }
 
-/* ─── Network picker, shared by the send / balance / assets modals ───────────
+/* --- Network picker, shared by the send / balance / assets modals -----------
    Sits directly above the address chip and drives what the rest of the modal
    shows, so it hugs the chip instead of keeping the full field gap. */
 .pollar-chain-field {
   margin-bottom: 0.75rem;
 }
 
-/* ─── Wallet address chip, shared by every modal that shows the user's address ──
+/* --- Wallet address chip, shared by every modal that shows the user's address --
    The address plus its copy button. One definition so the chip looks identical
    whichever modal it appears in. */
 .pollar-address-row {

--- a/packages/react/src/components/swap-modal/SwapModal.tsx
+++ b/packages/react/src/components/swap-modal/SwapModal.tsx
@@ -8,6 +8,7 @@ import '../transaction-modal/TransactionModal.css';
 import '../send-modal/SendModal.css';
 import './SwapModal.css';
 import { SwapAssetOption, SwapModalTemplate } from './SwapModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface SwapModalProps {
   onClose: () => void;
@@ -47,7 +48,7 @@ export function SwapModal({ onClose }: SwapModalProps) {
 
   const walletType = wallet?.custody === 'external' ? wallet.provider : null;
   const smartUnsupported = wallet?.custody === 'smart';
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const [step, setStep] = useState<'form' | 'tx'>('form');
   const [selectedSell, setSelectedSell] = useState<SwapAssetOption | null>(null);
@@ -346,10 +347,11 @@ export function SwapModal({ onClose }: SwapModalProps) {
   }
 
   return (
-    <div className="pollar-overlay" onClick={!isInProgress ? onClose : undefined}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={!isInProgress ? onClose : undefined}>
       <SwapModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         step={step}
         txTitle={txTitle}
         sellOptions={sellOptions}

--- a/packages/react/src/components/swap-modal/SwapModal.tsx
+++ b/packages/react/src/components/swap-modal/SwapModal.tsx
@@ -76,7 +76,7 @@ export function SwapModal({ onClose }: SwapModalProps) {
     void refreshAssets();
   }, [refreshWalletBalance, refreshAssets]);
 
-  // Which venues this app exposes (operator config ∩ server capability).
+  // Which venues this app exposes (operator config intersected with server capability).
   const loadConfig = useCallback(() => {
     setVenues(null); // back to loading
     return getSwapConfig()
@@ -121,7 +121,7 @@ export function SwapModal({ onClose }: SwapModalProps) {
   const isLoadingData = walletBalance.step === 'loading' || enabledAssets.step === 'loading';
 
   // Sell: native XLM + every asset the wallet has a trustline for, even at a 0
-  // balance — so the user always sees what they hold and knows when to fund
+  // balance - so the user always sees what they hold and knows when to fund
   // (the amount field guards against overselling). Buy: app-enabled assets.
   // Swap is Stellar-only, so the guard drops every non-Stellar balance and
   // narrows `type` for toRef(). It has to test `chain`, not `type`: SOL/POL
@@ -134,8 +134,8 @@ export function SwapModal({ onClose }: SwapModalProps) {
         (b.chain === undefined || b.chain === 'STELLAR') &&
         (b.type === 'native' || ((b.type === 'credit_alphanum4' || b.type === 'credit_alphanum12') && !b.trustlineRemoved)),
     )
-    // A null `available` (chain unreadable) maps to undefined — "unknown", which
-    // the option already models — rather than to a 0 that would read as "empty".
+    // A null `available` (chain unreadable) maps to undefined - "unknown", which
+    // the option already models - rather than to a 0 that would read as "empty".
     .map((b) => ({
       ref: toRef(b),
       code: b.code,
@@ -178,7 +178,7 @@ export function SwapModal({ onClose }: SwapModalProps) {
   const buyOptions: SwapAssetOption[] = [...enabledBuy, ...catalogBuy, ...customBuy].filter((o) => optKey(o) !== buyKeyOfSell);
 
   // Auto-select the first sell / buy asset once options are available, and keep a
-  // valid selection if the list changes — so the pickers never sit empty.
+  // valid selection if the list changes - so the pickers never sit empty.
   useEffect(() => {
     if (sellOptions.length === 0) return;
     if (!selectedSell || !sellOptions.some((o) => optKey(o) === optKey(selectedSell))) {

--- a/packages/react/src/components/swap-modal/SwapModalTemplate.tsx
+++ b/packages/react/src/components/swap-modal/SwapModalTemplate.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { SwapProvider, SwapQuote, SwapQuoteParams, TransactionState, WalletId } from '@pollar/core';
-import { type CSSProperties, useState } from 'react';
+import { useState } from 'react';
 import { AssetSelect } from '../AssetSelect';
 import { PollarModalFooter } from '../commons';
 import { TxStatusView } from '../transaction-modal/TxStatusView';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 /** A selectable asset in the sell/buy pickers, normalized across balance/enabled records. */
 export interface SwapAssetOption {
@@ -34,6 +35,8 @@ function formatAmount(value: string): string {
 export interface SwapModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   step: 'form' | 'tx';
   txTitle: string;
   sellOptions: SwapAssetOption[];
@@ -81,6 +84,7 @@ export interface SwapModalTemplateProps {
 export function SwapModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   step,
   txTitle,
   sellOptions,
@@ -120,8 +124,6 @@ export function SwapModalTemplate({
   onRetry,
   onDone,
 }: SwapModalTemplateProps) {
-  const isDark = theme === 'dark';
-
   const [customOpen, setCustomOpen] = useState(false);
   const [customCode, setCustomCode] = useState('');
   const [customIssuer, setCustomIssuer] = useState('');
@@ -139,23 +141,7 @@ export function SwapModalTemplate({
     setCustomOpen(false);
   };
 
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const sellKey = selectedSell ? assetOptionKey(selectedSell) : '';
   const buyKey = selectedBuy ? assetOptionKey(selectedBuy) : '';

--- a/packages/react/src/components/swap-modal/SwapModalTemplate.tsx
+++ b/packages/react/src/components/swap-modal/SwapModalTemplate.tsx
@@ -54,7 +54,7 @@ export interface SwapModalTemplateProps {
   smartUnsupported: boolean;
   /** Swap config is still loading. */
   configLoading: boolean;
-  /** Config loaded and this app exposes no swap venues — swap is disabled. */
+  /** Config loaded and this app exposes no swap venues - swap is disabled. */
   swapUnavailable: boolean;
   /** Buying the selected asset will create a trustline first (~0.5 XLM reserve). */
   buyNeedsTrustline: boolean;
@@ -203,7 +203,7 @@ export function SwapModalTemplate({
         <div className="pollar-modal-error">Swap is not available for this app.</div>
       )}
 
-      {/* Keep the form visible while the config loads — disable the inputs rather
+      {/* Keep the form visible while the config loads - disable the inputs rather
           than unmounting them, so the modal doesn't visibly collapse/jump. */}
       {step === 'form' && !swapUnavailable && (
         <>

--- a/packages/react/src/components/transaction-modal/TransactionModal.tsx
+++ b/packages/react/src/components/transaction-modal/TransactionModal.tsx
@@ -5,6 +5,7 @@ import { usePollar } from '../../context';
 import '../shared.css';
 import './TransactionModal.css';
 import { TransactionModalTemplate } from './TransactionModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface TransactionModalProps {
   onClose: () => void;
@@ -15,7 +16,7 @@ export function TransactionModal({ onClose }: TransactionModalProps) {
   // External-wallet signing-adapter id (freighter/albedo) drives the wallet logo;
   // null for custodial/smart, which fall back to the Pollar logo.
   const walletType = wallet?.custody === 'external' ? wallet.provider : null;
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const [showXdr, setShowXdr] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -64,10 +65,11 @@ export function TransactionModal({ onClose }: TransactionModalProps) {
   }
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <TransactionModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         transaction={transaction}
         showXdr={showXdr}
         copied={copied}

--- a/packages/react/src/components/transaction-modal/TransactionModalTemplate.tsx
+++ b/packages/react/src/components/transaction-modal/TransactionModalTemplate.tsx
@@ -4,10 +4,13 @@ import { TransactionState, WalletId } from '@pollar/core';
 import React from 'react';
 import { PollarModalFooter } from '../commons';
 import { TxStatusView } from './TxStatusView';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 export interface TransactionModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   transaction: TransactionState;
   showXdr: boolean;
   copied: boolean;
@@ -23,6 +26,7 @@ export interface TransactionModalTemplateProps {
 export function TransactionModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   transaction,
   showXdr,
   copied,
@@ -34,25 +38,7 @@ export function TransactionModalTemplate({
   onCopyHash,
   onRetry,
 }: TransactionModalTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as React.CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   return (
     <div className="pollar-modal-card pollar-tx-modal" data-theme={theme} style={cssVars} onClick={(e) => e.stopPropagation()}>

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.css
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.css
@@ -47,7 +47,7 @@
   white-space: nowrap;
 }
 
-/* Truncated identifier chip (trustline issuer, payment counterparty…). */
+/* Truncated identifier chip (trustline issuer, payment counterparty...). */
 .pollar-hist-item-issuer {
   display: inline-flex;
   align-items: center;

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
@@ -8,6 +8,7 @@ import { addressForChain } from '../ChainSelect';
 import '../shared.css';
 import './TxHistoryModal.css';
 import { TxHistoryModalTemplate } from './TxHistoryModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 const PAGE_SIZE = 10;
 
@@ -17,7 +18,7 @@ interface TxHistoryModalProps {
 
 export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
   const { getClient, styles, txHistory, wallets } = usePollar();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
   const [offset, setOffset] = useState(0);
 
   const { chains } = useChains();
@@ -52,10 +53,11 @@ export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
   };
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <TxHistoryModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         txHistory={txHistory}
         offset={offset}
         chains={chains}

--- a/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModal.tsx
@@ -31,7 +31,7 @@ export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
   const walletAddress = addressForChain(wallets, selectedChain);
 
   // The chain filter is a server query param (pagination is server-side), so a
-  // fetch always carries the selected chain. Null while chains resolve — the
+  // fetch always carries the selected chain. Null while chains resolve - the
   // effect below waits for it rather than fetching the whole unfiltered set.
   const load = useCallback(
     (nextOffset: number, chain: WalletChain) => {
@@ -42,7 +42,7 @@ export function TxHistoryModal({ onClose }: TxHistoryModalProps) {
   );
 
   // (Re)load from page 1 whenever the selected chain changes. Switching networks
-  // must reset the offset — page 3 of Stellar is not page 3 of Solana.
+  // must reset the offset - page 3 of Stellar is not page 3 of Solana.
   useEffect(() => {
     if (selectedChain) load(0, selectedChain);
   }, [selectedChain, load]);

--- a/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import { StellarNetwork, TxHistoryRecord, TxHistoryState, WalletChain } from '@pollar/core';
-import { type CSSProperties, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { ChainSelect } from '../ChainSelect';
 import { CopyButton, cropAddress, PollarModalFooter } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 const PAGE_SIZE = 10;
 
 interface TxHistoryModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   txHistory: TxHistoryState;
   offset: number;
   /** Networks the user holds a wallet on; the first one is the default. */
@@ -87,6 +90,7 @@ function renderSummary(summary: string): ReactNode {
 export function TxHistoryModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   txHistory,
   offset,
   chains,
@@ -98,25 +102,7 @@ export function TxHistoryModalTemplate({
   onNext,
   onClose,
 }: TxHistoryModalTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const isLoading = txHistory.step === 'loading';
   const records = txHistory.step === 'loaded' ? txHistory.data.records : [];

--- a/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
+++ b/packages/react/src/components/tx-history-modal/TxHistoryModalTemplate.tsx
@@ -47,7 +47,7 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
-/** Shorten a long identifier (issuer, hash, address) to `head…tail`. */
+/** Shorten a long identifier (issuer, hash, address) to `head...tail`. */
 function truncateMiddle(value: string, head = 4, tail = 4): string {
   return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
 }
@@ -55,7 +55,7 @@ function truncateMiddle(value: string, head = 4, tail = 4): string {
 // Stellar account (G) and contract (C) strkeys are 56 base32 chars.
 const STELLAR_ADDRESS = /\b[GC][A-Z2-7]{55}\b/g;
 
-/** Truncated address rendered as a copyable tag (issuer, wallet, contract…). */
+/** Truncated address rendered as a copyable tag (issuer, wallet, contract...). */
 function AddressChip({ value, label }: { value: string; label: string }) {
   return (
     <span className="pollar-hist-item-issuer">
@@ -66,8 +66,8 @@ function AddressChip({ value, label }: { value: string; label: string }) {
 }
 
 /**
- * Renders a summary string, swapping every full Stellar address (G… account or
- * C… contract) for an {@link AddressChip}. Plain-text runs are kept as-is.
+ * Renders a summary string, swapping every full Stellar address (G... account or
+ * C... contract) for an {@link AddressChip}. Plain-text runs are kept as-is.
  */
 function renderSummary(summary: string): ReactNode {
   const parts: ReactNode[] = [];
@@ -179,7 +179,7 @@ export function TxHistoryModalTemplate({
           // so the explorer link follows the row, not the picker.
           const explorerUrl = hash ? explorerUrlFor(record.chain, hash, record.network) : undefined;
           const asset = typeof record.details?.asset === 'string' ? record.details.asset : undefined;
-          // `change_trust` summaries embed the asset as `CODE:ISSUER` — split so
+          // `change_trust` summaries embed the asset as `CODE:ISSUER` - split so
           // the issuer can be truncated and copied on its own.
           const colon = asset ? asset.indexOf(':') : -1;
           const trustline =

--- a/packages/react/src/components/wallet-balance-modal/WalletBalanceModal.tsx
+++ b/packages/react/src/components/wallet-balance-modal/WalletBalanceModal.tsx
@@ -8,6 +8,7 @@ import { addressForChain } from '../ChainSelect';
 import '../shared.css';
 import './WalletBalanceModal.css';
 import { WalletBalanceModalTemplate } from './WalletBalanceModalTemplate';
+import { modalChrome } from '../modal-theme';
 
 interface WalletBalanceModalProps {
   onClose: () => void;
@@ -15,7 +16,7 @@ interface WalletBalanceModalProps {
 
 export function WalletBalanceModal({ onClose }: WalletBalanceModalProps) {
   const { walletBalance, refreshWalletBalance, wallets, network, styles } = usePollar();
-  const { theme = 'light', accentColor = '#005DB4' } = styles;
+  const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 
   const { chains } = useChains();
   const [selectedChain, setSelectedChain] = useState<WalletChain | null>(null);
@@ -32,10 +33,11 @@ export function WalletBalanceModal({ onClose }: WalletBalanceModalProps) {
   }, [refreshWalletBalance]);
 
   return (
-    <div className="pollar-overlay" onClick={onClose}>
+    <div className="pollar-overlay" style={overlayStyle} onClick={onClose}>
       <WalletBalanceModalTemplate
         theme={theme}
         accentColor={accentColor}
+        styleOverrides={styleOverrides}
         walletBalance={walletBalance}
         walletAddress={walletAddress}
         chains={chains}

--- a/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
+++ b/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { StellarNetwork, WalletBalanceRecord, WalletBalanceState, WalletChain } from '@pollar/core';
-import { type CSSProperties } from 'react';
 import { ChainSelect, resolveChain } from '../ChainSelect';
 import { BusyOverlay, CopyButton, cropAddress, PollarModalFooter, useStickyData } from '../commons';
+import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 
 // Stellar amounts are int64 scaled by 10^7, so 7 decimals is the ledger's exact
 // precision and the default. A Polygon/Solana token carries its own `decimals`
@@ -77,6 +77,8 @@ function BalanceItem({ record, faucet }: { record: WalletBalanceRecord; faucet: 
 export interface WalletBalanceModalTemplateProps {
   theme: string;
   accentColor: string;
+  /** Per-app modal chrome overrides (background, card + button radius). */
+  styleOverrides?: ModalStyleOverrides;
   walletBalance: WalletBalanceState;
   /** Address of the wallet on {@link selectedChain}. */
   walletAddress: string;
@@ -93,6 +95,7 @@ export interface WalletBalanceModalTemplateProps {
 export function WalletBalanceModalTemplate({
   theme,
   accentColor,
+  styleOverrides,
   walletBalance,
   walletAddress,
   chains,
@@ -102,25 +105,7 @@ export function WalletBalanceModalTemplate({
   onRefresh,
   onClose,
 }: WalletBalanceModalTemplateProps) {
-  const isDark = theme === 'dark';
-
-  const cssVars = {
-    '--pollar-accent': accentColor,
-    '--pollar-bg': isDark ? '#1a1a1a' : '#ffffff',
-    '--pollar-border': isDark ? '#374151' : '#e5e7eb',
-    '--pollar-text': isDark ? '#ffffff' : '#111827',
-    '--pollar-muted': isDark ? '#9ca3af' : '#6b7280',
-    '--pollar-input-bg': isDark ? '#374151' : '#f9fafb',
-    '--pollar-error-bg': isDark ? '#2a1515' : '#fef2f2',
-    '--pollar-error-border': isDark ? '#7f1d1d' : '#fecaca',
-    '--pollar-error-text': isDark ? '#f87171' : '#dc2626',
-    '--pollar-success-text': isDark ? '#4ade80' : '#16a34a',
-    '--pollar-buttons-border-radius': '6px',
-    '--pollar-buttons-height': '44px',
-    '--pollar-input-height': '44px',
-    '--pollar-input-border-radius': '0.5rem',
-    '--pollar-card-border-radius': '10px',
-  } as CSSProperties;
+  const cssVars = buildModalCssVars(theme, accentColor, styleOverrides);
 
   const isLoading = walletBalance.step === 'loading';
   // Keep the previous payload on screen while refreshing; the overlay below

--- a/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
+++ b/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
@@ -11,7 +11,7 @@ import { buildModalCssVars, type ModalStyleOverrides } from '../modal-theme';
 // blow the column apart. Digits are padded either way so amounts line up.
 //
 // A null balance means the chain could not be read. It renders as a dash, never
-// as 0.0000000 — a wallet that failed to load must not look empty.
+// as 0.0000000 - a wallet that failed to load must not look empty.
 function formatBalance(balance: string | null, decimals = 7): string {
   if (balance === null) return '—';
   const digits = Math.min(decimals, 7);
@@ -59,7 +59,7 @@ function BalanceItem({ record, faucet }: { record: WalletBalanceRecord; faucet: 
               {faucet.label}
             </a>
             {/* Pollar's Solana testnet is the devnet cluster, and both faucets
-                fund devnet — spell it out so nobody requests on the wrong one. */}
+                fund devnet - spell it out so nobody requests on the wrong one. */}
             <span className="pollar-bal-faucet-net"> (devnet)</span>
           </span>
         )}
@@ -85,7 +85,7 @@ export interface WalletBalanceModalTemplateProps {
   /** Networks the user holds a wallet on; the first one is the default. */
   chains: WalletChain[];
   selectedChain: WalletChain | null;
-  /** testnet vs mainnet — gates the Solana devnet faucet hint. */
+  /** testnet vs mainnet - gates the Solana devnet faucet hint. */
   network: StellarNetwork;
   onSelectChain: (chain: WalletChain) => void;
   onRefresh: () => void;
@@ -112,7 +112,7 @@ export function WalletBalanceModalTemplate({
   // blocks interaction so nothing is read against data that is changing.
   const data = useStickyData(walletBalance.step === 'loaded' ? walletBalance.data : null);
   // Only the picked network's balances. The backend returns every chain in one
-  // payload, so this is a local filter — switching networks costs no request.
+  // payload, so this is a local filter - switching networks costs no request.
   const balances = (data?.balances ?? []).filter((b) => resolveChain(b.chain) === selectedChain);
   // These faucets fund devnet/testnet only, so mainnet gets no hint at all.
   const showFaucets = selectedChain === 'SOLANA' && network === 'testnet';
@@ -166,7 +166,7 @@ export function WalletBalanceModalTemplate({
         </div>
       )}
 
-      {/* First load only — a refresh keeps the old list under the overlay. */}
+      {/* First load only - a refresh keeps the old list under the overlay. */}
       {isLoading && !data && (
         <div className="pollar-loading-block">
           <div className="pollar-spinner" />

--- a/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
+++ b/packages/react/src/components/wallet-balance-modal/WalletBalanceModalTemplate.tsx
@@ -36,8 +36,8 @@ function faucetFor(record: WalletBalanceRecord): FaucetHint | null {
   return null;
 }
 
-// The chain is no longer tagged per row: the list is filtered to the network
-// picked in the header, so every row would carry the same tag.
+// No per-row chain tag: the list is filtered to the network picked in the
+// header, so every row would carry the same tag.
 function BalanceItem({ record, faucet }: { record: WalletBalanceRecord; faucet: FaucetHint | null }) {
   const balanceDiffers = record.balance !== record.available;
   return (

--- a/packages/react/src/components/wallet-button/WalletButton.css
+++ b/packages/react/src/components/wallet-button/WalletButton.css
@@ -30,7 +30,7 @@
   transform: scale(0.98);
 }
 
-/* brightness-0 invert — white logo on colored background */
+/* brightness-0 invert - white logo on colored background */
 .pollar-wallet-btn-logo {
   width: 22px;
   height: 22px;

--- a/packages/react/src/components/wallet-button/WalletButton.tsx
+++ b/packages/react/src/components/wallet-button/WalletButton.tsx
@@ -23,7 +23,7 @@ export function WalletButton() {
     tx: transaction,
   } = usePollar();
   // The address shown (and copied) is the one on the app's FIRST configured
-  // chain, not `wallet.address` — that field is the Stellar wallet by definition
+  // chain, not `wallet.address` - that field is the Stellar wallet by definition
   // in core, so this button used to say "Stellar" to an app whose users live on
   // Polygon. Falls back to it while `/config` loads and for a legacy session that
   // enumerates no wallets.

--- a/packages/react/src/components/wallet-button/WalletButton.tsx
+++ b/packages/react/src/components/wallet-button/WalletButton.tsx
@@ -29,9 +29,6 @@ export function WalletButton() {
   // enumerates no wallets.
   const { primaryAddress } = useChains();
   const walletAddress = primaryAddress || (wallet?.address ?? '');
-  // External-wallet signing-adapter id (freighter/albedo) drives the wallet logo;
-  // null for custodial/smart, which fall back to the Pollar logo.
-  const walletType = wallet?.custody === 'external' ? wallet.provider : null;
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -154,7 +151,6 @@ export function WalletButton() {
       itemColor={itemColor}
       wrapperRef={wrapperRef}
       isInProgress={isInProgress}
-      walletType={walletType}
       showCreateAccount={canCreateAccount}
       creatingAccount={creating}
       onToggleOpen={() => setOpen((v) => !v)}

--- a/packages/react/src/components/wallet-button/WalletButtonTemplate.tsx
+++ b/packages/react/src/components/wallet-button/WalletButtonTemplate.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { WalletId } from '@pollar/core';
 import { LOGO_POLLAR } from '../../constants';
 import './WalletButton.css';
 
@@ -18,7 +17,6 @@ export interface WalletButtonTemplateProps {
   itemColor: string;
   wrapperRef: React.RefObject<HTMLDivElement>;
   isInProgress: boolean;
-  walletType: WalletId | null;
   /** Show the "Create account" action (external wallet not yet on-chain, IMMEDIATE funding). */
   showCreateAccount: boolean;
   creatingAccount: boolean;

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -263,6 +263,11 @@ interface PollarProviderProps {
    *
    * The client is locked at first render: changing this prop afterwards is
    * ignored. To swap clients, unmount and remount the provider.
+   *
+   * Either form gets the web passkey ceremony installed (a pre-built instance
+   * is filled in via `setPasskeyDefaults`), so the "Smart Wallet" login works
+   * without the consumer wiring WebAuthn. A ceremony you configured yourself is
+   * always kept.
    */
   client: PollarClient | PollarClientConfig;
   /**
@@ -312,15 +317,23 @@ export function PollarProvider({
   onStorageDegrade,
   children,
 }: PollarProviderProps) {
-  // When the consumer passes a config (not a ready client), inject the browser
-  // passkey ceremony so `loginSmartWallet()` works out of the box on web. The
-  // consumer can override it (e.g. a React Native native provider) via
-  // `client.passkey`.
-  const [pollarClient] = useState<PollarClient>(() =>
-    client instanceof PollarClient
-      ? client
-      : new PollarClient({ passkey: browserPasskeyCeremony, passkeySign: browserPasskeySigner, ...client }),
-  );
+  // Inject the browser passkey ceremony so `loginSmartWallet()` /
+  // `createSmartWallet()` work out of the box on web, whichever way the client
+  // arrives: built here from a config, or handed over ready-made (a consumer
+  // singleton shared with non-React code). The consumer can override it (e.g. a
+  // React Native native provider) via `client.passkey`; `??` keeps an explicit
+  // ceremony winning while an absent/undefined one still gets the default.
+  const [pollarClient] = useState<PollarClient>(() => {
+    if (client instanceof PollarClient) {
+      client.setPasskeyDefaults({ passkey: browserPasskeyCeremony, passkeySign: browserPasskeySigner });
+      return client;
+    }
+    return new PollarClient({
+      ...client,
+      passkey: client.passkey ?? browserPasskeyCeremony,
+      passkeySign: client.passkeySign ?? browserPasskeySigner,
+    });
+  });
   // Only a client WE constructed is ours to tear down on unmount; a client the
   // consumer passed in is theirs to manage. Captured once (the useState
   // initializer above made the same decision).

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -58,7 +58,7 @@ const DEFAULT_APP_CONFIG: PollarConfig = {
 
 /**
  * Compares the fields of a persisted session that actually drive UI re-renders.
- * Replaces a per-listener `JSON.stringify(...) !== JSON.stringify(...)` call —
+ * Replaces a per-listener `JSON.stringify(...) !== JSON.stringify(...)` call -
  * cheaper, allocation-free, and explicit about what counts as "changed".
  *
  * If a field is added to `PollarPersistedSession` that consumers read through
@@ -82,13 +82,13 @@ interface PollarContextValue {
   /**
    * The authenticated user's wallet as a discriminated union over `custody`
    * (`internal` | `smart` | `external`), or `null` when unauthenticated. Every
-   * field is meaningful for any login method — `custody` is always present and
+   * field is meaningful for any login method - `custody` is always present and
    * strictly determines the shape of `provider`. Use `wallet.address` for the
    * on-chain address and `wallet.provider` for the wallet/login provider.
    */
   wallet: WalletInfo | null;
   /**
-   * Every wallet the user holds, one per chain — a superset of {@link wallet},
+   * Every wallet the user holds, one per chain - a superset of {@link wallet},
    * with `chain` populated. `[]` when unauthenticated. Drives the network
    * selector in the Send / Wallet Balance / Assets modals: each entry is a
    * network the user can switch to, and the first one is the default.
@@ -101,7 +101,7 @@ interface PollarContextValue {
   /**
    * `true` once the server has confirmed the session (login / refresh /
    * `/auth/session/resume`). `false` while a cold-start session is still
-   * optimistic — gate sensitive actions (e.g. signing) on this.
+   * optimistic - gate sensitive actions (e.g. signing) on this.
    */
   verified: boolean;
   login: (options: PollarLoginOptions) => void;
@@ -114,7 +114,7 @@ interface PollarContextValue {
   styles: PollarStyles;
   /** Remote app-config load state. 'loading' while the initial fetch is in
    *  flight, 'error' if it failed (styles fall back to empty defaults), 'ready'
-   *  once resolved — or immediately 'ready' when `appConfig` is passed as a prop.
+   *  once resolved - or immediately 'ready' when `appConfig` is passed as a prop.
    *  The login modal shows a spinner/retry instead of an empty shell until this
    *  is 'ready'. */
   configStatus: 'loading' | 'ready' | 'error';
@@ -133,7 +133,7 @@ interface PollarContextValue {
   /** External-wallet only. Custodial flows should use `signAndSubmitTx`. */
   signTx: (unsignedXdr: string) => Promise<SignOutcome>;
   submitTx: (signedXdr: string) => Promise<SubmitOutcome>;
-  /** One-shot: build → sign → submit. Drives the same TransactionState flow as the split calls. */
+  /** One-shot: build -> sign -> submit. Drives the same TransactionState flow as the split calls. */
   buildAndSignAndSubmitTx: (
     operation: TxBuildBody['operation'],
     params: TxBuildBody['params'],
@@ -282,13 +282,13 @@ interface PollarProviderProps {
    * bypass the type anyway (plain JS, or a cast), each missing field lands on a
    * default scattered across the components rather than on anything central:
    *
-   *   chains       absent → the chain order/filter falls back to the order the
+   *   chains       absent -> the chain order/filter falls back to the order the
    *                         session listed the user's wallets in (see useChains)
-   *   name         absent → 'Pollar'
-   *   theme        absent → 'light'
-   *   accentColor  absent → '#005DB4'
+   *   name         absent -> 'Pollar'
+   *   theme        absent -> 'light'
+   *   accentColor  absent -> '#005DB4'
    *   emailEnabled, providers, embeddedWallets, smartWallet
-   *                absent → false. NOTE: that means EVERY login method is off
+   *                absent -> false. NOTE: that means EVERY login method is off
    *                         and the login modal renders with no way in.
    *
    * Leave this `undefined` to have the SDK fetch `/applications/config` on
@@ -381,7 +381,7 @@ export function PollarProvider({
   const builtFromConfigRef = useRef<PollarClientConfig | null>(isPollarClient(client) ? null : client);
 
   // Tear down the client on a real unmount so its cross-tab storage listener,
-  // refresh timer, and live-client registry entry don't leak — matters when the
+  // refresh timer, and live-client registry entry don't leak - matters when the
   // provider is keyed (e.g. `key={apiKey}`) and remounts on network change.
   useEffect(() => {
     if (!ownsClientRef.current) return;
@@ -392,7 +392,7 @@ export function PollarProvider({
       clientByConfig.delete(builtFromConfigRef.current);
       builtFromConfigRef.current = null;
     }
-    // This mount is live again — cancel any teardown scheduled by a prior
+    // This mount is live again - cancel any teardown scheduled by a prior
     // (StrictMode dev) unmount before it can destroy the client we still use.
     if (destroyTimerRef.current) {
       clearTimeout(destroyTimerRef.current);
@@ -470,7 +470,7 @@ export function PollarProvider({
       if (authState.step === 'authenticated') {
         setSessionState((prev) => (sessionsEqual(prev, authState.session) ? prev : authState.session));
         // The session object is identical between the optimistic restore and
-        // the post-resume confirmation, so `verified` is tracked separately —
+        // the post-resume confirmation, so `verified` is tracked separately -
         // otherwise the sessionsEqual short-circuit would swallow the flip.
         setVerified(authState.verified);
       } else if (authState.step === 'idle') {
@@ -481,9 +481,9 @@ export function PollarProvider({
   }, [pollarClient]);
 
   // Auto-login for interactive adapters (e.g. Privy). When the adapter's
-  // provider authenticates *outside* the sub-modal flow — after an OAuth redirect
+  // provider authenticates *outside* the sub-modal flow - after an OAuth redirect
   // (the page reloaded, so the sub-modal promise is gone) or a persisted provider
-  // session on load — and Pollar has no session yet, trigger `login({ provider })`
+  // session on load - and Pollar has no session yet, trigger `login({ provider })`
   // so `connect()` + SEP-10 run. Read the session through a ref so the
   // subscription is set up once and never re-subscribes on session changes.
   const sessionRef = useRef(sessionState);

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -310,6 +310,36 @@ interface PollarProviderProps {
   children: ReactNode;
 }
 
+/**
+ * Clients built from a `PollarClientConfig`, keyed by that exact config object.
+ *
+ * React StrictMode double-invokes the `useState` initializer below on mount and
+ * discards the FIRST pass's hook state entirely - the value the component keeps
+ * comes from the second pass, and `useRef` carries nothing between the two. So
+ * a ref guard cannot see the first construction, and without this map the
+ * provider built TWO clients and only ever tore down the one React kept. The
+ * orphan outlived the provider, holding a cross-tab `storage` listener, a
+ * refresh loop and a live-client registry entry for the life of the page - and
+ * two live clients on one API key share a session row and a DPoP keypair, which
+ * is exactly the configuration `@pollar/core`'s session teardown has to defend
+ * against. (See `tests/smoke-react.cjs`, which renders through jsdom because
+ * `react-test-renderer` does not reproduce the double render at all.)
+ *
+ * Both passes receive the same props object - React re-invokes a component's
+ * render function in place and reconciles children from the last pass - so
+ * keying on the config makes the second pass reuse the first pass's client
+ * instead of building another. Weak, so an abandoned config never keeps a
+ * client alive; and the entry is dropped as soon as the mount effect claims the
+ * client, so a later provider rendered with the same (retained) config object
+ * builds its own rather than receiving one this provider is about to destroy.
+ *
+ * Two providers sharing one config OBJECT still share the client. That is the
+ * better outcome of the two - one client per config identity, rather than two
+ * fighting over the same session row - and it matches what the SDK already
+ * warns about for multiple clients on one API key.
+ */
+const clientByConfig = new WeakMap<PollarClientConfig, PollarClient>();
+
 export function PollarProvider({
   client,
   appConfig: appConfigProp,
@@ -328,23 +358,39 @@ export function PollarProvider({
       client.setPasskeyDefaults({ passkey: browserPasskeyCeremony, passkeySign: browserPasskeySigner });
       return client;
     }
-    return new PollarClient({
+    // Reuse the instance a discarded render pass already built (see
+    // `clientByConfig`) instead of constructing a second one that nothing
+    // would ever tear down.
+    const alreadyBuilt = clientByConfig.get(client);
+    if (alreadyBuilt) return alreadyBuilt;
+    const built = new PollarClient({
       ...client,
       passkey: client.passkey ?? browserPasskeyCeremony,
       passkeySign: client.passkeySign ?? browserPasskeySigner,
     });
+    clientByConfig.set(client, built);
+    return built;
   });
   // Only a client WE constructed is ours to tear down on unmount; a client the
   // consumer passed in is theirs to manage. Captured once (the useState
   // initializer above made the same decision).
   const ownsClientRef = useRef(!(client instanceof PollarClient));
   const destroyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** The config this provider built from, until the mount effect claims it. */
+  const builtFromConfigRef = useRef<PollarClientConfig | null>(client instanceof PollarClient ? null : client);
 
   // Tear down the client on a real unmount so its cross-tab storage listener,
   // refresh timer, and live-client registry entry don't leak — matters when the
   // provider is keyed (e.g. `key={apiKey}`) and remounts on network change.
   useEffect(() => {
     if (!ownsClientRef.current) return;
+    // Claim the client. Effects run after the double render, so the shared
+    // entry has done its job; dropping it keeps a future provider from being
+    // handed a client this one will destroy on unmount.
+    if (builtFromConfigRef.current) {
+      clientByConfig.delete(builtFromConfigRef.current);
+      builtFromConfigRef.current = null;
+    }
     // This mount is live again — cancel any teardown scheduled by a prior
     // (StrictMode dev) unmount before it can destroy the client we still use.
     if (destroyTimerRef.current) {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  isPollarClient,
   BuildOutcome,
   EnabledAssetsState,
   isInteractiveAuthAdapter,
@@ -354,7 +355,7 @@ export function PollarProvider({
   // React Native native provider) via `client.passkey`; `??` keeps an explicit
   // ceremony winning while an absent/undefined one still gets the default.
   const [pollarClient] = useState<PollarClient>(() => {
-    if (client instanceof PollarClient) {
+    if (isPollarClient(client)) {
       client.setPasskeyDefaults({ passkey: browserPasskeyCeremony, passkeySign: browserPasskeySigner });
       return client;
     }
@@ -374,10 +375,10 @@ export function PollarProvider({
   // Only a client WE constructed is ours to tear down on unmount; a client the
   // consumer passed in is theirs to manage. Captured once (the useState
   // initializer above made the same decision).
-  const ownsClientRef = useRef(!(client instanceof PollarClient));
+  const ownsClientRef = useRef(!isPollarClient(client));
   const destroyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** The config this provider built from, until the mount effect claims it. */
-  const builtFromConfigRef = useRef<PollarClientConfig | null>(client instanceof PollarClient ? null : client);
+  const builtFromConfigRef = useRef<PollarClientConfig | null>(isPollarClient(client) ? null : client);
 
   // Tear down the client on a real unmount so its cross-tab storage listener,
   // refresh timer, and live-client registry entry don't leak — matters when the

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,10 @@ export type { LoginButtonProps, AuthModalProps, PollarStyles, PollarConfig } fro
 // Re-export the custom-provider contracts so consumers can author providers
 // (e.g. a Privy login provider) without importing from `@pollar/core` directly.
 export type { PollarAuthProvider, AuthProviderContext } from '@pollar/core';
+// The web WebAuthn implementations `PollarProvider` installs by default. Exported
+// for consumers who build their own `PollarClient` and want the ceremony wired at
+// construction, and for anyone wrapping it (logging, custom rpId).
+export { browserPasskeyCeremony, browserPasskeySigner } from './lib/passkey-ceremony';
 export { WalletButton } from './components/wallet-button/WalletButton';
 export { WalletButtonTemplate, type WalletButtonTemplateProps } from './components/wallet-button/WalletButtonTemplate';
 
@@ -34,6 +38,13 @@ export { EarnModal } from './components/earn-modal/EarnModal';
 export { ReceiveModal } from './components/receive-modal/ReceiveModal';
 export { SessionsModal } from './components/sessions-modal/SessionsModal';
 export { DistributionRulesModal } from './components/distribution-rules-modal/DistributionRulesModal';
+
+// ─── Modal theming ────────────────────────────────────────────────────────────
+// Exported alongside the templates: a consumer mounting a template itself needs
+// these to reproduce the exact CSS custom properties the built-in modals set,
+// and to forward the app's Branding overrides into them.
+export { buildModalCssVars, modalChrome, readableTextOn } from './components/modal-theme';
+export type { ModalStyleOverrides, ModalVariant, ModalChrome } from './components/modal-theme';
 
 // ─── Templates ────────────────────────────────────────────────────────────────
 export { LoginModalTemplate } from './components/login-modal/LoginModalTemplate';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -11,7 +11,7 @@ export { browserPasskeyCeremony, browserPasskeySigner } from './lib/passkey-cere
 export { WalletButton } from './components/wallet-button/WalletButton';
 export { WalletButtonTemplate, type WalletButtonTemplateProps } from './components/wallet-button/WalletButtonTemplate';
 
-// ─── Network picker ───────────────────────────────────────────────────────────
+// --- Network picker -----------------------------------------------------------
 // Exported alongside the templates: every template that takes `chains` /
 // `selectedChain` / `onSelectChain` needs these to build those props, so a
 // consumer mounting a template itself would otherwise have to reimplement the
@@ -25,7 +25,7 @@ export type { ChainSelectProps } from './components/ChainSelect';
 export { useChains } from './useChains';
 export type { UseChainsResult } from './useChains';
 
-// ─── Modals ───────────────────────────────────────────────────────────────────
+// --- Modals -------------------------------------------------------------------
 export { KycModal } from './components/kyc-modal/KycModal';
 export { KycStatus } from './components/kyc-modal/KycStatus';
 export { RampWidget } from './components/ramp-widget/RampWidget';
@@ -39,14 +39,14 @@ export { ReceiveModal } from './components/receive-modal/ReceiveModal';
 export { SessionsModal } from './components/sessions-modal/SessionsModal';
 export { DistributionRulesModal } from './components/distribution-rules-modal/DistributionRulesModal';
 
-// ─── Modal theming ────────────────────────────────────────────────────────────
+// --- Modal theming ------------------------------------------------------------
 // Exported alongside the templates: a consumer mounting a template itself needs
 // these to reproduce the exact CSS custom properties the built-in modals set,
 // and to forward the app's Branding overrides into them.
 export { buildModalCssVars, modalChrome, readableTextOn } from './components/modal-theme';
 export type { ModalStyleOverrides, ModalVariant, ModalChrome } from './components/modal-theme';
 
-// ─── Templates ────────────────────────────────────────────────────────────────
+// --- Templates ----------------------------------------------------------------
 export { LoginModalTemplate } from './components/login-modal/LoginModalTemplate';
 export { KycModalTemplate } from './components/kyc-modal/KycModalTemplate';
 export type { KycStep } from './components/kyc-modal/KycModalTemplate';

--- a/packages/react/src/lib/passkey-ceremony.ts
+++ b/packages/react/src/lib/passkey-ceremony.ts
@@ -1,7 +1,7 @@
 import type { PasskeyCeremony, PasskeySigner } from '@pollar/core';
 import { startAuthentication, startRegistration } from '@simplewebauthn/browser';
 
-// hex → base64url, for passing the raw auth digest as the WebAuthn challenge.
+// hex -> base64url, for passing the raw auth digest as the WebAuthn challenge.
 function hexToBase64url(hex: string): string {
   const bytes = new Uint8Array(hex.length / 2);
   for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
@@ -26,16 +26,16 @@ function randomUserId(): string {
  *
  * `mode` is set explicitly by the caller's button, so there's no ambiguous
  * autodetect:
- *   - `'login'`    → `get()` only (returning user — the OS shows the account
+ *   - `'login'`    -> `get()` only (returning user - the OS shows the account
  *                    picker for discoverable credentials on this domain). A
  *                    failure here is surfaced as-is; it never falls through to
  *                    registration, so cancelling the prompt can't accidentally
  *                    create a second wallet.
- *   - `'register'` → `create()` only (new user → the server deploys the
+ *   - `'register'` -> `create()` only (new user -> the server deploys the
  *                    C-address).
  *
  * rpId = the current page's hostname (the customer app's domain), which is what
- * the passkey is bound to — the anti-phishing guarantee.
+ * the passkey is bound to - the anti-phishing guarantee.
  */
 export const browserPasskeyCeremony: PasskeyCeremony = async ({ challenge, mode }) => {
   const rpId = window.location.hostname;
@@ -53,7 +53,7 @@ export const browserPasskeyCeremony: PasskeyCeremony = async ({ challenge, mode 
       challenge,
       rp: { id: rpId, name: rpId },
       user: { id: userId, name: 'Smart Wallet', displayName: 'Smart Wallet' },
-      // ES256 (secp256r1) — the curve the on-chain WebAuthn verifier expects.
+      // ES256 (secp256r1) - the curve the on-chain WebAuthn verifier expects.
       pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
       authenticatorSelection: { residentKey: 'required', userVerification: 'required' },
       attestation: 'none',

--- a/packages/react/src/lib/qr-code/index.tsx
+++ b/packages/react/src/lib/qr-code/index.tsx
@@ -1,5 +1,5 @@
 /**
- * QRCode component — vendored from react-qr-code (MIT License)
+ * QRCode component - vendored from react-qr-code (MIT License)
  * Original: https://github.com/rosskhanas/react-qr-code
  * Adapted: removed prop-types dependency, added TypeScript types.
  *
@@ -7,13 +7,13 @@
  * Copyright (c) 2018 Ross Khanas
  */
 
-// @ts-expect-error — qr.js ships CJS without type declarations; bundled via noExternal
+// @ts-expect-error - qr.js ships CJS without type declarations; bundled via noExternal
 import ErrorCorrectLevel from 'qr.js/lib/ErrorCorrectLevel';
-// @ts-expect-error — same as above
+// @ts-expect-error - same as above
 import QRCodeImpl from 'qr.js/lib/QRCode';
 import { forwardRef, type SVGProps } from 'react';
 
-// ─── Internal SVG renderer ────────────────────────────────────────────────────
+// --- Internal SVG renderer ----------------------------------------------------
 
 interface QRCodeSvgProps extends SVGProps<SVGSVGElement> {
   bgColor: string;
@@ -41,7 +41,7 @@ const QRCodeSvg = forwardRef<SVGSVGElement, QRCodeSvgProps>(function QRCodeSvg(
 
 QRCodeSvg.displayName = 'QRCodeSvg';
 
-// ─── Public component ─────────────────────────────────────────────────────────
+// --- Public component ---------------------------------------------------------
 
 export interface QRCodeProps extends SVGProps<SVGSVGElement> {
   value: string;

--- a/packages/react/src/useChains.ts
+++ b/packages/react/src/useChains.ts
@@ -1,6 +1,6 @@
 'use client';
 
-// ─── Chain order, one source of truth ─────────────────────────────────────────
+// --- Chain order, one source of truth -----------------------------------------
 // Every component that shows "the user's address" or offers a network picker
 // reads it from here, so the wallet button and the modals can never disagree
 // about which chain is first.
@@ -16,7 +16,7 @@
 //     enum order), identical for every app on the platform. That is fixed
 //     server-side now, but a session persisted before the fix still carries the
 //     old array, and re-deriving here repairs it without forcing a re-login.
-// ─────────────────────────────────────────────────────────────────────────────
+// -----------------------------------------------------------------------------
 
 import type { WalletChain } from '@pollar/core';
 import { useMemo } from 'react';

--- a/packages/solana-wallet-standard-adapter/package.json
+++ b/packages/solana-wallet-standard-adapter/package.json
@@ -40,7 +40,6 @@
     "@pollar/core": "^0.11.2"
   },
   "dependencies": {
-    "@pollar/core": "^0.11.2",
     "@solana/wallet-standard-features": "^1.4.0",
     "@wallet-standard/app": "^1.1.1",
     "@wallet-standard/base": "^1.1.1",
@@ -48,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@pollar/core": "^0.11.2",
     "eslint": "^10.5.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/solana-wallet-standard-adapter/package.json
+++ b/packages/solana-wallet-standard-adapter/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/pollar-xyz/pollar.git",
     "directory": "packages/solana-wallet-standard-adapter"
   },
-  "description": "Solana Wallet Standard adapter for @pollar/core — connect user-controlled Solana wallets (Phantom, Solflare, Backpack, …) via the Wallet Standard (@wallet-standard/* + @solana/wallet-standard-features), with SIWS login, without bundling any wallet SDK into @pollar/core.",
+  "description": "Solana Wallet Standard adapter for @pollar/core - connect user-controlled Solana wallets (Phantom, Solflare, Backpack, ...) via the Wallet Standard (@wallet-standard/* + @solana/wallet-standard-features), with SIWS login, without bundling any wallet SDK into @pollar/core.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/solana-wallet-standard-adapter/src/SolanaWalletStandardAdapter.ts
+++ b/packages/solana-wallet-standard-adapter/src/SolanaWalletStandardAdapter.ts
@@ -32,7 +32,7 @@ function isSolanaChain(chain: string): boolean {
 }
 
 /**
- * Wraps a Wallet Standard Solana wallet (Phantom, Solflare, Backpack, …) so it can
+ * Wraps a Wallet Standard Solana wallet (Phantom, Solflare, Backpack, ...) so it can
  * back a Pollar external-wallet login. The Wallet Standard is the headless
  * substrate `@solana/wallet-adapter` is built on, so this stays framework-agnostic
  * exactly like `@pollar/stellar-wallets-kit-adapter`.
@@ -102,7 +102,7 @@ export class SolanaWalletStandardAdapter implements WalletAdapter {
   /**
    * SIWS: sign the server-issued Sign In With Solana input. This is the Solana
    * analogue of the Stellar SEP-10 challenge, but the wallet signs a structured
-   * MESSAGE (domain, statement, nonce, …) rather than a transaction.
+   * MESSAGE (domain, statement, nonce, ...) rather than a transaction.
    */
   async signIn(input: SolanaSignInInput): Promise<SolanaSignInOutput> {
     const feature = this._wallet.features[SolanaSignIn] as SolanaSignInFeature[typeof SolanaSignIn] | undefined;
@@ -121,7 +121,7 @@ export class SolanaWalletStandardAdapter implements WalletAdapter {
     };
   }
 
-  /** Raw message signing — the SIWS fallback for wallets without `solana:signIn`. */
+  /** Raw message signing - the SIWS fallback for wallets without `solana:signIn`. */
   async signMessage(message: Uint8Array): Promise<SolanaSignMessageResponse> {
     const account = this._requireAccount();
     const feature = this._wallet.features[SolanaSignMessage] as SolanaSignMessageFeature[typeof SolanaSignMessage] | undefined;

--- a/packages/solana-wallet-standard-adapter/src/factory.ts
+++ b/packages/solana-wallet-standard-adapter/src/factory.ts
@@ -11,7 +11,7 @@ export interface SolanaWalletStandardAdapterOptions {
   labels?: Record<string, string>;
   /**
    * Gateway button label these wallets collapse behind in the login UI (applied
-   * as each adapter's `meta.group`). Default `'Solana Wallet'` — a distinct group
+   * as each adapter's `meta.group`). Default `'Solana Wallet'` - a distinct group
    * from the Stellar `'Wallet'` gateway, so the two chains render as separate
    * login buttons.
    */
@@ -26,7 +26,7 @@ function isSolanaWallet(w: Wallet): boolean {
 /**
  * Build one {@link SolanaWalletStandardAdapter} per installed Solana wallet discovered
  * through the Wallet Standard registry, to pass to
- * `PollarClientConfig.walletAdapters` (once `@pollar/core` is chain-aware — see the
+ * `PollarClientConfig.walletAdapters` (once `@pollar/core` is chain-aware - see the
  * design doc).
  *
  * @example
@@ -34,7 +34,7 @@ function isSolanaWallet(w: Wallet): boolean {
  * import { solanaWalletStandardAdapters } from '@pollar/solana-wallet-standard-adapter';
  *
  * const client = new PollarClient({
- *   apiKey: '…',
+ *   apiKey: '...',
  *   walletAdapters: [...stellarWalletsKitAdapters({ network }), ...solanaWalletStandardAdapters()],
  * });
  * ```

--- a/packages/stellar-wallets-kit-adapter/package.json
+++ b/packages/stellar-wallets-kit-adapter/package.json
@@ -40,12 +40,10 @@
     "@creit.tech/stellar-wallets-kit": "^2.0.0",
     "@pollar/core": "^0.11.2"
   },
-  "dependencies": {
-    "@pollar/core": "^0.11.2"
-  },
   "devDependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.3.0",
     "@eslint/js": "^10.0.1",
+    "@pollar/core": "^0.11.2",
     "eslint": "^10.5.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/stellar-wallets-kit-adapter/package.json
+++ b/packages/stellar-wallets-kit-adapter/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/pollar-xyz/pollar.git",
     "directory": "packages/stellar-wallets-kit-adapter"
   },
-  "description": "Stellar Wallets Kit adapter for @pollar/core — plug additional wallet modules (xBull, Lobstr, WalletConnect, hardware wallets…) into Pollar without bundling them into @pollar/core.",
+  "description": "Stellar Wallets Kit adapter for @pollar/core - plug additional wallet modules (xBull, Lobstr, WalletConnect, hardware wallets...) into Pollar without bundling them into @pollar/core.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
+++ b/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
@@ -15,7 +15,7 @@ import { getInitNetwork, getKitLogger } from './factory';
 
 /**
  * Wraps Stellar Wallets Kit so it satisfies the `@pollar/core` `WalletAdapter`
- * contract. The kit is a global singleton — `setWallet` is called before every
+ * contract. The kit is a global singleton - `setWallet` is called before every
  * operation so the correct module handles the request, which lets a single
  * `StellarWalletsKit.init(...)` cover many wallet modules.
  */

--- a/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
+++ b/packages/stellar-wallets-kit-adapter/src/StellarWalletsKitAdapter.ts
@@ -33,9 +33,9 @@ export class StellarWalletsKitAdapter implements WalletAdapter {
   async isAvailable(): Promise<boolean> {
     // `refreshSupportedWallets()` probes every module's own `isAvailable()`
     // hook (modules promise <1000ms per the kit contract) and returns a
-    // static snapshot. This avoids the old false-positive where we always
-    // claimed availability and let `connect()` fail later — the picker / UI
-    // can now short-circuit on `wallet_not_installed` immediately.
+    // static snapshot. Claiming availability blindly would let `connect()`
+    // fail later; probing lets the picker / UI short-circuit on
+    // `wallet_not_installed` immediately.
     try {
       const supported = await StellarWalletsKit.refreshSupportedWallets();
       const wallet = supported.find((w) => w.id === String(this.type));

--- a/packages/stellar-wallets-kit-adapter/src/factory.ts
+++ b/packages/stellar-wallets-kit-adapter/src/factory.ts
@@ -31,20 +31,20 @@ export interface KitPickerOptions {
   /**
    * Label of the gateway button these kit wallets collapse behind in the login
    * UI (the `meta.group` applied to every adapter this factory builds). Default
-   * `'Wallet'` — the same group as the built-in Freighter/Albedo, so they share
+   * `'Wallet'` - the same group as the built-in Freighter/Albedo, so they share
    * one gateway. Set a distinct value (e.g. `'More wallets'`) to render the kit
    * wallets as a *separate* gateway button from the built-in ones.
    */
   groupLabel?: string;
   /** Visual layout. Default `'grid'`. */
   layout?: 'grid' | 'list';
-  /** Theme passthrough — applied as CSS custom properties on the picker root. */
+  /** Theme passthrough - applied as CSS custom properties on the picker root. */
   theme?: { accent?: string; mode?: 'light' | 'dark' };
 }
 
 export interface StellarWalletsKitAdapterOptions {
   /**
-   * Stellar network the kit will use for signing. Required — there is no
+   * Stellar network the kit will use for signing. Required - there is no
    * default. The kit is a global singleton, so picking the network silently
    * for a consumer would risk signing real-looking transactions on the wrong
    * chain (testnet xdr signed on mainnet, etc.). Pass `Networks.TESTNET` or
@@ -55,7 +55,7 @@ export interface StellarWalletsKitAdapterOptions {
    * Wallet modules the kit should drive. Defaults to every module that works
    * out of the box (Albedo, Bitget, CactusLink, Fordefi, Freighter, Hana,
    * HotWallet, Klever, Lobstr, OneKey, Rabet, xBull). Pass an explicit list
-   * to add Ledger / Trezor / WalletConnect — those need extra setup (a
+   * to add Ledger / Trezor / WalletConnect - those need extra setup (a
    * Buffer polyfill for Ledger; constructor params for the other two) so we
    * don't auto-include them.
    *
@@ -90,7 +90,7 @@ export function getKitLogger(): PollarLogger {
   return _log;
 }
 
-/** @internal — used by the `/picker` subpath. */
+/** @internal - used by the `/picker` subpath. */
 export function buildDefaultModules(): ModuleInterface[] {
   return [
     new AlbedoModule(),
@@ -109,7 +109,7 @@ export function buildDefaultModules(): ModuleInterface[] {
 }
 
 /**
- * @internal — used by the `/picker` subpath.
+ * @internal - used by the `/picker` subpath.
  *
  * Accepts `Partial<...>` because the picker may be mounted in a flow where
  * `stellarWalletsKitAdapters({ network })` has already initialised the kit elsewhere;
@@ -121,7 +121,7 @@ export function ensureInit(options: Partial<StellarWalletsKitAdapterOptions>): v
     _log = createLogger(options.logLevel ?? 'info', options.logger);
   }
   if (initialised) {
-    // The kit is a global singleton — a second call with a different network
+    // The kit is a global singleton - a second call with a different network
     // would be silently ignored. Warn so the developer notices the
     // misconfiguration instead of debugging wrong-chain signatures later.
     if (options.network && options.network !== initNetwork) {
@@ -144,7 +144,7 @@ export function ensureInit(options: Partial<StellarWalletsKitAdapterOptions>): v
   initialised = true;
 }
 
-/** @internal — used by `StellarWalletsKitAdapter` to reject per-call network overrides that don't match init. */
+/** @internal - used by `StellarWalletsKitAdapter` to reject per-call network overrides that don't match init. */
 export function getInitNetwork(): Networks {
   if (initNetwork === null) {
     throw new Error('[StellarWalletsKit] not initialised — call `stellarWalletsKitAdapters({ network })` first');
@@ -153,8 +153,8 @@ export function getInitNetwork(): Networks {
 }
 
 /**
- * Build the list of {@link WalletAdapter}s backed by Stellar Wallets Kit — one
- * per kit module — to pass to `PollarClientConfig.walletAdapters`. Each adapter
+ * Build the list of {@link WalletAdapter}s backed by Stellar Wallets Kit - one
+ * per kit module - to pass to `PollarClientConfig.walletAdapters`. Each adapter
  * carries the module's name/icon as its button `meta`. `picker.wallets` (subset)
  * and `picker.labels` (overrides) are honored if provided.
  *
@@ -164,7 +164,7 @@ export function getInitNetwork(): Networks {
  * import { Networks } from '@creit.tech/stellar-wallets-kit';
  *
  * const client = new PollarClient({
- *   apiKey: '…',
+ *   apiKey: '...',
  *   walletAdapters: stellarWalletsKitAdapters({ network: Networks.PUBLIC }),
  * });
  * ```
@@ -172,7 +172,7 @@ export function getInitNetwork(): Networks {
 export function stellarWalletsKitAdapters(options: StellarWalletsKitAdapterOptions): WalletAdapter[] {
   // SSR / non-browser guard. Stellar Wallets Kit talks to browser wallet
   // extensions and touches `window` both at `StellarWalletsKit.init()` and in its
-  // wallet modules' constructors — there are no wallets server-side, so return an
+  // wallet modules' constructors - there are no wallets server-side, so return an
   // empty list instead of crashing during Next.js/Remix SSR. The real adapters
   // are built when this re-runs on the client (so build your PollarClient and
   // render the wallet UI on the client, e.g. behind a mounted flag or

--- a/tests/README.md
+++ b/tests/README.md
@@ -163,6 +163,32 @@ so a failing seed replays with `node tests/smoke-invariants.cjs <seed>`. It
 independently rediscovers the ownership bug fixed in this release when run
 against the build that predates it.
 
+### `smoke-cross-document.cjs`
+
+Cross-document (cross-tab) session semantics + persist-queue races — the two
+things the other suites' mocks cannot express: real `storage`-event delivery
+(every same-origin document EXCEPT the writer; each client gets its own
+"document" with its own window and listener set) and a storage adapter whose
+session writes can be held, giving the `_persistSession` queue actual depth.
+Ported from the scratchpad harnesses that found the cross-document teardown
+bugs. Negative-controlled: run against the pre-fix bundle, the ownership,
+handler-filter and triple-race blocks fail.
+
+- Positive control: the writing document never hears its own event
+- A login in one document is adopted by idle siblings in the others
+- A STALE document's teardown (logout / failed refresh / 401 resume) cannot
+  remove the row a fresh login now owns, nor destroy that login's keypair
+- A foreign `localStorage.clear()` (`key === null`) and events from a
+  different storage area (`sessionStorage`) are ignored
+- [known limitation, pinned] an external PHYSICAL deletion of the very row a
+  client holds still reads as a logout — the explicit logout-signal design
+  (backlog) is what would distinguish it
+- Triple race: a held login write + a queued login-over-login write + logout —
+  the row is removed via ownership-by-session-history and the key rotates
+- `destroy()` discards a refresh mutation still queued behind a held write
+- `logout()` with the login's persist still queued: no resurrection, no
+  leftover row
+
 ### `smoke-react.cjs`
 
 `PollarProvider` client lifecycle, rendered through jsdom + `react-dom/client`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,6 +84,27 @@ Session-lifecycle race safety (each block exercises one concurrency fix):
   `verified` without re-resuming; a legacy 8-hex session is not restored;
   cross-tab logout propagates even when this tab's storage is degraded
 
+### `smoke-resume.cjs`
+
+Session resume across "page loads" — DPoP key binding (regression guards for the
+0.11.2 reload-logout bug, `thumbprint-mismatch`). Runs against a mock server that
+actually verifies the binding (nonce challenge + proof-JWK thumbprint vs the
+`cnf.jkt` computed from the login's `dpopJwk`) and an in-memory IndexedDB shim
+that survives across client instances:
+
+- A fresh `PollarClient` over the same Storage + IndexedDB resumes: the resume
+  proof's thumbprint equals the token's `cnf.jkt`, and concurrent resume
+  triggers (visibility flaps) coalesce into a single request
+- A genuinely revoked session (403 on resume) still clears to `idle`
+- With IndexedDB unavailable, login warns that the keypair can't persist, and
+  the next load clears the doomed session locally via the persisted `dpopJkt`
+  check — no resume round trip, no phantom `authenticated` emission
+- A 5xx resume keeps the optimistic session and backs off instead of bursting
+- `logout()` rotates the DPoP keypair; a failure-path clear does not
+- Cross-tab logout → fresh login: the sibling tab resyncs its stale in-memory
+  key cache to the rotated shared key and resumes the new session instead of
+  clearing it
+
 ## What's not covered
 
 - Real network requests (`fetch` is mocked).

--- a/tests/README.md
+++ b/tests/README.md
@@ -226,3 +226,12 @@ needed. Both assertions fail against the provider that predates the fix.
 - Node ≥ 20 (the SDK runtime floor)
 - Built `dist/` (run `npm run build` first)
 - No external services — tests are fully self-contained
+
+### `check-comment-ascii.cjs`
+
+Style guard, not a smoke test: asserts that code comments (`.ts`/`.tsx`/`.css`
+under `packages/*/src`, minus the generated `schema.d.ts`) and every
+`package.json` description use only keyboard-typeable ASCII characters - no em
+dashes, box-drawing header lines, arrows or section signs. String literals are
+exempt on purpose: UI copy is a product decision. Runs at the end of
+`npm run test:smoke` and lists every violation on failure.

--- a/tests/README.md
+++ b/tests/README.md
@@ -128,6 +128,65 @@ Cross-document and logout-race guards (added after a cross-review):
   mid-logout login is now using); an owned external logout still disconnects
   exactly once.
 
+### `smoke-lifecycle.cjs`
+
+Teardown leaves nothing behind. `PollarClient` registers itself in a MODULE-level
+registry so an in-document logout can reach sibling instances, and a module-level
+map holding client references leaks unless registration and deregistration agree
+exactly. Observed through behavior, never private state:
+
+- the "another client is already active" warning fires for two live clients
+  (positive control - the assertions below are worthless without it)
+- 25 construct/destroy cycles leave no entry behind, and `destroy()` is idempotent
+- `destroy()` detaches the cross-tab `storage` listener, and a destroyed client
+  is not reached by a sibling's teardown
+- a destroyed client is garbage-collectable (needs `--expose-gc`, which the npm
+  script passes; skipped, not failed, without it), and a server-side client is
+  never retained
+
+### `smoke-invariants.cjs`
+
+Randomized operation order against fixed properties. Every session bug found in
+this area had the same shape: an `await` window let two pieces of state disagree.
+Scenario tests pin the cases we know; this one goes after the ones we do not. It
+drives seeded random sequences of login / logout / un-awaited logout racing a
+login / refresh / revalidate / reload / second instance / cross-tab clear /
+revocation, and after every step asserts:
+
+- I1 a persisted session's `dpopJkt` is the `cnf.jkt` the server really bound
+- I2 the keypair a persisted session names still exists locally
+- I3/I4 `authenticated` always carries a session, and that session has a token
+- I5 a client never returns to a session it logged out of
+
+Deterministic: a seeded PRNG picks the operations and every mock delay is fixed,
+so a failing seed replays with `node tests/smoke-invariants.cjs <seed>`. It
+independently rediscovers the ownership bug fixed in this release when run
+against the build that predates it.
+
+### `smoke-react.cjs`
+
+`PollarProvider` client lifecycle, rendered through jsdom + `react-dom/client`.
+Deliberately NOT `react-test-renderer`: that renderer does not enable
+StrictMode's double-render, so the central assertion would pass without the
+scenario ever running. Block 0 is a positive control that proves the
+double-invocation happens here.
+
+- StrictMode leaves exactly ONE live client, and nothing from that mount
+  outlives it. The config is written as an INLINE literal inside a component
+  StrictMode also double-renders, because that is what consumers write; hoisting
+  it would hand both passes the same object for a reason the SDK does not
+  control and the assertion would stop meaning anything.
+- unmount destroys a provider-built client, and leaves a consumer-passed one alive
+- five mount/unmount cycles leak no `storage` listeners
+
+The StrictMode block is what caught the orphan `PollarClient` this release fixes:
+the provider built the client in a `useState` initializer, StrictMode
+double-invoked it, React kept one and the other was never destroyed - it outlived
+the provider's unmount holding a `storage` listener, a refresh loop and a
+registry entry. Two live clients on one API key share a session row and a DPoP
+keypair, which is the precondition every session-teardown bug in `@pollar/core`
+needed. Both assertions fail against the provider that predates the fix.
+
 ## What's not covered
 
 - Real network requests (`fetch` is mocked).

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,6 +123,10 @@ Cross-document and logout-race guards (added after a cross-review):
   StrictMode leaves one behind) is notified in-process instead.
 - The `DPoP-Nonce` is persisted, so only the first reload pays the
   `use_dpop_nonce` challenge.
+- A superseded logout leaves the wallet adapter connected (registered adapters
+  are per-type singletons, so disconnecting could cut the connection the
+  mid-logout login is now using); an owned external logout still disconnects
+  exactly once.
 
 ## What's not covered
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -104,6 +104,12 @@ that survives across client instances:
 - Cross-tab logout → fresh login: the sibling tab resyncs its stale in-memory
   key cache to the rotated shared key and resumes the new session instead of
   clearing it
+- `logout()` aborts an in-flight login — the held `/auth/login` response can no
+  longer resurrect the session after the user logged out
+- The persisted `dpopJkt` equals the server's `cnf.jkt` even when the key
+  manager reports a different key at store time (simulated mid-login rotation)
+- `getThumbprint()` called while `init()` is mid-flight (keypair assigned, JWK
+  export pending) joins the in-flight init instead of throwing
 
 ## What's not covered
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -111,6 +111,19 @@ that survives across client instances:
 - `getThumbprint()` called while `init()` is mid-flight (keypair assigned, JWK
   export pending) joins the in-flight init instead of throwing
 
+Cross-document and logout-race guards (added after a cross-review):
+
+- `logout()` is async and consumers do not await it (`@pollar/react` fires it
+  from the login modal and the wallet button). A login that completes inside that
+  window must survive: the teardown is guarded on the session generation.
+- The DPoP keypair is shared per origin + API key, so `logout()` rotates it only
+  when it actually dropped its own session row.
+- A logout propagates to sibling clients in the SAME document; browsers deliver
+  `storage` events only to other documents, so a second instance (React
+  StrictMode leaves one behind) is notified in-process instead.
+- The `DPoP-Nonce` is persisted, so only the first reload pays the
+  `use_dpop_nonce` challenge.
+
 ## What's not covered
 
 - Real network requests (`fetch` is mocked).

--- a/tests/README.md
+++ b/tests/README.md
@@ -229,8 +229,8 @@ needed. Both assertions fail against the provider that predates the fix.
 
 ### `check-comment-ascii.cjs`
 
-Style guard, not a smoke test: asserts that code comments (`.ts`/`.tsx`/`.css`
-under `packages/*/src`, minus the generated `schema.d.ts`) and every
+Style guard, not a smoke test: asserts that code comments (every
+`.ts`/`.tsx`/`.css` under `packages/`, minus the generated `schema.d.ts`) and every
 `package.json` description use only keyboard-typeable ASCII characters - no em
 dashes, box-drawing header lines, arrows or section signs. String literals are
 exempt on purpose: UI copy is a product decision. Runs at the end of

--- a/tests/check-comment-ascii.cjs
+++ b/tests/check-comment-ascii.cjs
@@ -30,19 +30,34 @@ function commentSpans(line, inBlock, isCss) {
   while (i < n) {
     const ch = line[i];
     if (quote) {
-      if (ch === '\\') { i += 2; continue; }
+      if (ch === '\\') {
+        i += 2;
+        continue;
+      }
       if (ch === quote) quote = null;
-      i += 1; continue;
+      i += 1;
+      continue;
     }
-    if (!isCss && (ch === '"' || ch === "'" || ch === '`')) { quote = ch; i += 1; continue; }
+    if (!isCss && (ch === '"' || ch === "'" || ch === '`')) {
+      quote = ch;
+      i += 1;
+      continue;
+    }
     if (ch === '/' && i + 1 < n) {
       const nxt = line[i + 1];
-      if (nxt === '/' && !isCss) { spans.push([i, n]); return { spans, inBlock: false }; }
+      if (nxt === '/' && !isCss) {
+        spans.push([i, n]);
+        return { spans, inBlock: false };
+      }
       if (nxt === '*') {
         const end = line.indexOf('*/', i + 2);
-        if (end === -1) { spans.push([i, n]); return { spans, inBlock: true }; }
+        if (end === -1) {
+          spans.push([i, n]);
+          return { spans, inBlock: true };
+        }
         spans.push([i, end]);
-        i = end + 2; continue;
+        i = end + 2;
+        continue;
       }
     }
     i += 1;
@@ -70,7 +85,8 @@ for (const file of walk(ROOT)) {
   if (base === 'package.json') {
     const desc = JSON.parse(fs.readFileSync(file, 'utf8')).description ?? '';
     for (const ch of desc) {
-      if (ch.codePointAt(0) > 126) violations.push(`${rel} (description): "${ch}" U+${ch.codePointAt(0).toString(16).toUpperCase()}`);
+      if (ch.codePointAt(0) > 126)
+        violations.push(`${rel} (description): "${ch}" U+${ch.codePointAt(0).toString(16).toUpperCase()}`);
     }
     continue;
   }

--- a/tests/check-comment-ascii.cjs
+++ b/tests/check-comment-ascii.cjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+'use strict';
+
+// Guards the repo convention that code comments use only keyboard-typeable
+// (ASCII) characters: no em dashes, box-drawing header lines, arrows, section
+// signs or similar glyphs. Scans .ts/.tsx/.css comments under packages/*/src
+// (the generated schema.d.ts is exempt) plus every package.json "description".
+// String literals are out of scope on purpose: UI copy is a product decision.
+//
+// Exits 1 listing every violation, so it can run as part of `npm run test:smoke`.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', 'packages');
+
+/** Comment spans of one line, tracking block-comment state across lines. */
+function commentSpans(line, inBlock, isCss) {
+  const spans = [];
+  let i = 0;
+  const n = line.length;
+  if (inBlock) {
+    const end = line.indexOf('*/');
+    if (end === -1) return { spans: [[0, n]], inBlock: true };
+    spans.push([0, end]);
+    i = end + 2;
+    inBlock = false;
+  }
+  let quote = null;
+  while (i < n) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === '\\') { i += 2; continue; }
+      if (ch === quote) quote = null;
+      i += 1; continue;
+    }
+    if (!isCss && (ch === '"' || ch === "'" || ch === '`')) { quote = ch; i += 1; continue; }
+    if (ch === '/' && i + 1 < n) {
+      const nxt = line[i + 1];
+      if (nxt === '/' && !isCss) { spans.push([i, n]); return { spans, inBlock: false }; }
+      if (nxt === '*') {
+        const end = line.indexOf('*/', i + 2);
+        if (end === -1) { spans.push([i, n]); return { spans, inBlock: true }; }
+        spans.push([i, end]);
+        i = end + 2; continue;
+      }
+    }
+    i += 1;
+  }
+  return { spans, inBlock };
+}
+
+function* walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (['node_modules', 'dist', '.turbo'].includes(entry.name)) continue;
+      yield* walk(path.join(dir, entry.name));
+    } else {
+      yield path.join(dir, entry.name);
+    }
+  }
+}
+
+const violations = [];
+
+for (const file of walk(ROOT)) {
+  const base = path.basename(file);
+  const rel = path.relative(ROOT, file);
+
+  if (base === 'package.json') {
+    const desc = JSON.parse(fs.readFileSync(file, 'utf8')).description ?? '';
+    for (const ch of desc) {
+      if (ch.codePointAt(0) > 126) violations.push(`${rel} (description): "${ch}" U+${ch.codePointAt(0).toString(16).toUpperCase()}`);
+    }
+    continue;
+  }
+
+  if (!/\.(ts|tsx|css)$/.test(base) || base === 'schema.d.ts') continue;
+
+  const isCss = base.endsWith('.css');
+  let inBlock = false;
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  for (let lineNo = 0; lineNo < lines.length; lineNo++) {
+    const line = lines[lineNo];
+    const res = commentSpans(line, inBlock, isCss);
+    inBlock = res.inBlock;
+    for (let i = 0; i < line.length; i++) {
+      const code = line.codePointAt(i);
+      if (code <= 126) continue;
+      if (res.spans.some(([s, e]) => i >= s && i < e)) {
+        violations.push(`${rel}:${lineNo + 1}: "${line[i]}" U+${code.toString(16).toUpperCase()} in a comment`);
+      }
+      if (code > 0xffff) i++; // surrogate pair
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(`check-comment-ascii: ${violations.length} non-ASCII character(s) in comments:`);
+  for (const v of violations.slice(0, 50)) console.error('  ' + v);
+  if (violations.length > 50) console.error(`  ... and ${violations.length - 50} more`);
+  process.exit(1);
+}
+console.log('check-comment-ascii: OK (comments and package descriptions are ASCII-only)');

--- a/tests/check-comment-ascii.cjs
+++ b/tests/check-comment-ascii.cjs
@@ -3,7 +3,7 @@
 
 // Guards the repo convention that code comments use only keyboard-typeable
 // (ASCII) characters: no em dashes, box-drawing header lines, arrows, section
-// signs or similar glyphs. Scans .ts/.tsx/.css comments under packages/*/src
+// signs or similar glyphs. Scans every .ts/.tsx/.css comment under packages/
 // (the generated schema.d.ts is exempt) plus every package.json "description".
 // String literals are out of scope on purpose: UI copy is a product decision.
 //

--- a/tests/smoke-cross-document.cjs
+++ b/tests/smoke-cross-document.cjs
@@ -1,0 +1,389 @@
+// @pollar smoke test — cross-document session semantics + persist-queue races.
+//
+// Run with `node tests/smoke-cross-document.cjs` after `npm run build`. Ports
+// the scratchpad harnesses that found (and then verified the fixes for) the
+// cross-document session-teardown bugs — see tmp/session-cross-document-fixes
+// and tmp/session-resume-dpop for the full history. The rest of the suite
+// cannot cover this class of bug, for two mock deficiencies this file exists
+// to remove:
+//
+//  1. STORAGE-EVENT SEMANTICS. Browsers deliver the `storage` event to every
+//     same-origin document EXCEPT the one that made the write. The other smoke
+//     files dispatch synthetic events to every listener (writer included), so
+//     cross-document ownership bugs cannot even be written as tests there.
+//     Here, each client gets its own "document" (its own window + listener
+//     set) and `broadcast()` models all-but-the-writer delivery.
+//
+//  2. ADAPTER LATENCY. Instant `storage.set()` means the `_persistSession`
+//     queue never has depth, so the queued-write races (triple race, destroy
+//     with a queued mutation, logout with a queued login persist) never open.
+//     Here the adapter's writes can be HELD and released on demand.
+//
+// Some blocks drive private methods (`_storeSession`, `_clearSession`) on the
+// built bundle on purpose: the queued-write interleavings cannot be produced
+// through the public API with exact timing, and these are the only possible
+// tests of the ownership-by-session-history fix. Treat renames of those
+// privates as an API change for this file.
+
+const path = require('node:path');
+
+// ─── The origin: one storage area, N documents ──────────────────────────────
+const area = new Map(); // the localStorage backing store for the origin
+const documents = new Map(); // docId -> Set<storage handler>
+
+function makeWindow(docId) {
+  documents.set(docId, new Set());
+  return {
+    __docId: docId,
+    location: { origin: 'https://app.test', href: 'https://app.test/' },
+    addEventListener: (type, cb) => {
+      if (type === 'storage') documents.get(docId).add(cb);
+    },
+    removeEventListener: (type, cb) => {
+      if (type === 'storage') documents.get(docId).delete(cb);
+    },
+  };
+}
+
+/** Deliver to every document except the writer — real browser semantics. */
+function broadcast(fromDocId, ev) {
+  for (const [docId, handlers] of documents) {
+    if (docId === fromDocId) continue;
+    for (const cb of handlers) cb(ev);
+  }
+}
+
+/**
+ * A localStorage-backed Storage adapter owned by one document. Mirrors the
+ * HTML spec: no event when a set does not change the value, none when a
+ * remove targets a missing key, and the writer never hears its own event.
+ * Session-row writes can be HELD (see `holdWrites`) to give the persist
+ * queue depth.
+ */
+let holdWrites = null; // Promise or null — session-row writes await it
+function docStorage(docId) {
+  return {
+    async get(key) {
+      const v = area.get(key);
+      return v === undefined ? null : v;
+    },
+    async set(key, value) {
+      if (holdWrites && key.endsWith(':session')) await holdWrites;
+      const oldValue = area.has(key) ? area.get(key) : null;
+      if (oldValue === value) return;
+      area.set(key, value);
+      broadcast(docId, { key, oldValue, newValue: value, storageArea: globalThis.localStorage });
+    },
+    async remove(key) {
+      if (!area.has(key)) return;
+      const oldValue = area.get(key);
+      area.delete(key);
+      broadcast(docId, { key, oldValue, newValue: null, storageArea: globalThis.localStorage });
+    },
+  };
+}
+
+/** Unrelated same-origin code (another app, a demo, an injected script). */
+const FAKE_SESSION_STORAGE = { __area: 'sessionStorage' };
+function foreignClear(docId, which = 'localStorage') {
+  if (which === 'localStorage') area.clear();
+  broadcast(docId, {
+    key: null,
+    oldValue: null,
+    newValue: null,
+    storageArea: which === 'localStorage' ? globalThis.localStorage : FAKE_SESSION_STORAGE,
+  });
+}
+
+// ─── Browser globals the SDK reads at module load ───────────────────────────
+globalThis.window = makeWindow('bootstrap');
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+// Minimal network: these blocks exercise storage/queue semantics, not DPoP.
+globalThis.fetch = async (req) => {
+  const url = typeof req === 'string' ? req : req.url;
+  const json = (o) => new Response(JSON.stringify(o), { status: 200, headers: { 'content-type': 'application/json' } });
+  if (url.includes('/auth/logout')) return json({ success: true });
+  if (url.includes('/auth/refresh')) {
+    return json({
+      success: true,
+      content: { token: { accessToken: 'AT2', refreshToken: 'RT2', expiresAt: Math.floor(Date.now() / 1000) + 600 } },
+    });
+  }
+  return json({ success: true, content: {} });
+};
+
+const SDK_DIST = path.resolve(__dirname, '../packages/core/dist/index.js');
+const sdk = require(SDK_DIST);
+
+// A fake KeyManager: deterministic, no IndexedDB, and it records WHOSE key
+// gets destroyed so the ownership assertions can see it.
+const keyEvents = [];
+function fakeKeyManager(docId) {
+  return {
+    init: async () => {},
+    reset: async () => {
+      keyEvents.push(docId);
+    },
+    getPublicJwk: async () => ({ kty: 'EC', crv: 'P-256', x: 'x', y: 'y' }),
+    getThumbprint: async () => 'jkt',
+    sign: async () => new Uint8Array(64),
+  };
+}
+
+const API_KEY = 'pk_smoke_xdoc';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function loginContent(clientSessionId, userId) {
+  return {
+    clientSessionId,
+    userId,
+    status: 'CONSUMED',
+    token: {
+      accessToken: `AT_${clientSessionId}`,
+      refreshToken: `RT_${clientSessionId}`,
+      expiresAt: Math.floor(Date.now() / 1000) + 600,
+    },
+    user: { ready: true, id: userId },
+    wallet: { type: 'internal', address: `G_${userId}` },
+    data: { mail: `${userId}@test`, first_name: userId, last_name: 'X', avatar: null, providers: {} },
+  };
+}
+
+async function openDocument(docId) {
+  // Bind this client to its own document: the SDK installs its `storage`
+  // listener from `globalThis.window` inside _initialize().
+  globalThis.window = makeWindow(docId);
+  const client = new sdk.PollarClient({
+    apiKey: API_KEY,
+    storage: docStorage(docId),
+    keyManager: fakeKeyManager(docId),
+    baseUrl: 'https://x.test',
+    logLevel: 'silent',
+  });
+  await client.ready();
+  return client;
+}
+
+function resetOrigin() {
+  area.clear();
+  documents.clear();
+  keyEvents.length = 0;
+  holdWrites = null;
+}
+
+let pass = 0;
+let fail = 0;
+function check(label, ok, extra) {
+  if (ok) {
+    pass++;
+    console.log(`  OK    ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${label}`, extra ?? '');
+  }
+}
+
+async function sessionKeyOf() {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(API_KEY));
+  const hash = Array.from(new Uint8Array(digest).slice(0, 16))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `pollar:${hash}:session`;
+}
+
+(async () => {
+  const sessionKey = await sessionKeyOf();
+
+  console.log('── 1. Positive control: the writer never hears its own event ──');
+  {
+    resetOrigin();
+    const A = await openDocument('A');
+    await A._storeSession(loginContent('cs_A', 'alice'));
+    await sleep(30);
+    check('the writing document stays authenticated', A.getAuthState().step === 'authenticated');
+    check('  no keypair was destroyed', keyEvents.length === 0, keyEvents);
+    A.destroy();
+  }
+
+  console.log('\n── 2. A login in one document is adopted by the others ────────');
+  {
+    resetOrigin();
+    const A = await openDocument('A');
+    const B = await openDocument('B');
+    check('precondition: B is idle', B.getAuthState().step === 'idle');
+    await A._storeSession(loginContent('cs_A', 'alice'));
+    await sleep(30);
+    const bs = B.getAuthState();
+    check('B adopted the session with no user action', bs.step === 'authenticated' && bs.session.userId === 'alice', bs.step);
+    A.destroy();
+    B.destroy();
+  }
+
+  console.log("\n── 3. A stale document's teardown cannot kill a fresh login ───");
+  {
+    // The original T18: B logged in long ago and went stale (its listener is
+    // detached, modeling a suspended tab or an adapter degraded to memory, so
+    // it does NOT adopt A's fresh session). When B finally tears down — an
+    // explicit logout, a failed refresh, a 401 resume — it must not remove the
+    // row A now owns, and must not destroy A's keypair.
+    resetOrigin();
+    const B = await openDocument('B');
+    await B._storeSession(loginContent('cs_B_old', 'bob'));
+    await sleep(10);
+    documents.get('B').clear(); // B goes stale
+
+    const A = await openDocument('A');
+    await A._storeSession(loginContent('cs_A', 'alice'));
+    await sleep(20);
+    check('last-writer-wins: storage holds the fresh session', JSON.parse(area.get(sessionKey)).clientSessionId === 'cs_A');
+
+    await B._clearSession(); // the stale teardown, whatever triggered it
+    await sleep(30);
+    check("A survives B's teardown of a session B no longer owned", A.getAuthState().step === 'authenticated');
+    check('  the fresh row is still in storage', area.has(sessionKey));
+    check("  A's DPoP keypair was not destroyed", !keyEvents.includes('A'), keyEvents);
+    A.destroy();
+    B.destroy();
+  }
+
+  console.log('\n── 4. Foreign same-origin storage events are ignored ──────────');
+  {
+    resetOrigin();
+    const A = await openDocument('A');
+    makeWindow('unrelated-app');
+    await A._storeSession(loginContent('cs_A', 'alice'));
+    await sleep(20);
+    foreignClear('unrelated-app'); // localStorage.clear() by code that never heard of Pollar
+    await sleep(30);
+    check('a foreign localStorage.clear() (key === null) is not a logout', A.getAuthState().step === 'authenticated');
+
+    await A._storeSession(loginContent('cs_A2', 'alice')); // re-seed (the clear wiped the area)
+    await sleep(20);
+    foreignClear('oauth-iframe', 'sessionStorage'); // PKCE/state cleanup in an iframe
+    await sleep(30);
+    check('an event from a DIFFERENT storage area is ignored', A.getAuthState().step === 'authenticated');
+    check('  the localStorage row is untouched', area.has(sessionKey));
+    A.destroy();
+  }
+
+  console.log("\n── 5. [known limitation] external deletion of A's own row ─────");
+  {
+    // If something physically removes the very row A holds, A cannot locally
+    // distinguish that from a legitimate logout of its own session — the fix
+    // is the explicit logout signal carrying the revoked clientSessionId
+    // (designed, backlog). This block pins the CURRENT behavior so building
+    // that feature flips it consciously.
+    resetOrigin();
+    const A = await openDocument('A');
+    const B = await openDocument('B');
+    await B._storeSession(loginContent('cs_B_old', 'bob'));
+    await sleep(10);
+    await A._storeSession(loginContent('cs_A_new', 'alice'));
+    await sleep(20);
+    // B, still believing it owns cs_B_old, physically deletes the shared slot
+    // (bypassing the SDK's ownership rule — external/legacy code).
+    const evOld = area.get(sessionKey);
+    area.delete(sessionKey);
+    broadcast('B', { key: sessionKey, oldValue: evOld, newValue: null, storageArea: globalThis.localStorage });
+    await sleep(30);
+    check('an external removal of the row A holds does log A out (documented)', A.getAuthState().step === 'idle');
+    A.destroy();
+    B.destroy();
+  }
+
+  console.log('\n── 6. Triple race: held write + queued login + logout ─────────');
+  {
+    // The ownership-by-session-history fix (_ownedSessionIds): login B1's
+    // write passes the queue's pre-check and is HELD inside the adapter;
+    // login-over-login B2's write queues behind it (guard not yet evaluated);
+    // logout() fires with both in flight. The logout must still recognize the
+    // B1 row that lands as its OWN history and remove it — equality with the
+    // session being cleared would refuse ("not mine") and leave the old,
+    // never-revoked session to restore fully functional on the next reload.
+    resetOrigin();
+    const A = await openDocument('A');
+    let gate;
+    holdWrites = new Promise((r) => (gate = r));
+    const p1 = A._storeSession(loginContent('cs_B1', 'u'));
+    await sleep(15);
+    const p2 = A._storeSession(loginContent('cs_B2', 'u'));
+    await sleep(15);
+    const lo = A.logout();
+    await sleep(15);
+    holdWrites = null;
+    gate();
+    await Promise.allSettled([p1, p2, lo]);
+    await sleep(40);
+    check('the row is removed (own-history ownership, not equality)', !area.has(sessionKey), area.get(sessionKey));
+    check('  the keypair was rotated (removal owned by this client)', keyEvents.includes('A'), keyEvents);
+    check('  the client converged to idle', A.getAuthState().step === 'idle', A.getAuthState().step);
+    A.destroy();
+  }
+
+  console.log('\n── 7. destroy() discards a queued refresh write ───────────────');
+  {
+    // The login's write is held inside the adapter and OCCUPIES the queue; the
+    // refresh completes its network trip and queues its write behind it, guard
+    // not yet evaluated; destroy() lands; the queue then advances. The held
+    // login write is unavoidable (already inside the adapter) — the refresh's
+    // must be dropped by the _destroyed guard: exactly one write lands.
+    resetOrigin();
+    const A = await openDocument('A');
+    let writes = 0;
+    const counting = docStorage('A');
+    const origSet = counting.set.bind(counting);
+    // Wrap AFTER construction so only session writes from here on are counted.
+    let gate;
+    let armed = false;
+    A._storage.set = async (k, v) => {
+      if (armed && k.endsWith(':session')) {
+        writes++;
+        await new Promise((r) => (gate = r));
+      }
+      area.set(k, v);
+    };
+    armed = true;
+    const p = A._storeSession(loginContent('cs_dq', 'u'));
+    await sleep(20);
+    const r = A.refresh();
+    await sleep(30);
+    A.destroy(); // with the refresh mutation still queued
+    gate();
+    await Promise.allSettled([p, r]);
+    await sleep(30);
+    check('exactly ONE session write landed (the queued refresh was discarded)', writes === 1, `writes=${writes}`);
+    void origSet;
+  }
+
+  console.log("\n── 8. logout() with the login's persist still queued ──────────");
+  {
+    // An old row from a previous session sits in storage; a fresh login's
+    // write is HELD; logout() fires before it lands. The write must be
+    // discarded (no resurrection) and the old row must not survive either.
+    resetOrigin();
+    const A = await openDocument('A');
+    area.set(sessionKey, JSON.stringify(loginContent('cs_OLD', 'u1')));
+    let gate;
+    holdWrites = new Promise((r) => (gate = r));
+    const p = A._storeSession(loginContent('cs_NEW', 'u2'));
+    await sleep(20);
+    const lo = A.logout();
+    await sleep(20);
+    holdWrites = null;
+    gate();
+    await Promise.allSettled([p, lo]);
+    await sleep(30);
+    const row = area.get(sessionKey);
+    const id = row ? JSON.parse(row).clientSessionId : null;
+    check('no session row survives the logout', id === null, `row=${id}`);
+    check('  the queued login write did not resurrect (cs_NEW discarded)', id !== 'cs_NEW');
+    A.destroy();
+  }
+
+  console.log(`\n${pass} pass, ${fail} fail`);
+  process.exit(fail ? 1 : 0);
+})().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/smoke-invariants.cjs
+++ b/tests/smoke-invariants.cjs
@@ -1,0 +1,436 @@
+// @pollar smoke test — session/DPoP invariants under randomized operation order.
+//
+// Run with `node tests/smoke-invariants.cjs` after `npm run build`.
+// `node tests/smoke-invariants.cjs <seed>` replays one seed.
+//
+// Every session bug found in this area so far has the same shape: some `await`
+// window lets two pieces of state disagree — the persisted row vs the key it
+// names, the recorded `dpopJkt` vs the `cnf.jkt` the server bound, the auth
+// state vs the session behind it. Scenario tests pin the cases we already know.
+// This one goes after the ones we do not: it drives randomized sequences of
+// login / logout / refresh / revalidate / cross-tab events / reload / second
+// instance, including deliberately un-awaited overlaps, and after every step
+// asserts the properties that must hold no matter the order.
+//
+// Deterministic: a seeded PRNG picks the operations, and every delay the mock
+// server introduces is fixed, so a failing seed replays exactly. The seed is
+// printed with any failure.
+
+const path = require('node:path');
+
+// ─── Browser globals (shared across "documents" in one run) ──────────────────
+const storageHandlers = new Map(); // handler -> owning client id
+globalThis.window = {
+  location: { origin: 'https://x.test', href: 'https://x.test/' },
+  addEventListener: (type, fn) => {
+    if (type === 'storage') storageHandlers.set(fn, true);
+  },
+  removeEventListener: (type, fn) => {
+    if (type === 'storage') storageHandlers.delete(fn);
+  },
+  open: () => null,
+};
+globalThis.document = { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' };
+// Must exist BEFORE the SDK module is required: `isBrowser` is evaluated once,
+// at module load. Every client gets its own injected memory adapter, so this
+// one is never actually read.
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+// ─── Minimal IndexedDB shim (see tests/smoke-resume.cjs) ─────────────────────
+const IDB = new Map();
+function idbReq(run) {
+  const r = { result: undefined, error: null, onsuccess: null, onerror: null };
+  queueMicrotask(() => {
+    try {
+      r.result = run();
+      r.onsuccess?.();
+    } catch (e) {
+      r.error = e;
+      r.onerror?.();
+    }
+  });
+  return r;
+}
+globalThis.indexedDB = {
+  open(name) {
+    const req = { result: undefined, error: null, onsuccess: null, onerror: null, onupgradeneeded: null };
+    queueMicrotask(() => {
+      const isNew = !IDB.has(name);
+      if (isNew) IDB.set(name, new Map());
+      const stores = IDB.get(name);
+      req.result = {
+        objectStoreNames: { contains: (s) => stores.has(s) },
+        createObjectStore: (s) => (stores.set(s, new Map()), {}),
+        close: () => {},
+        transaction: (storeName) => {
+          const tx = { oncomplete: null, onerror: null, onabort: null, error: null };
+          tx.objectStore = () => {
+            if (!stores.has(storeName)) stores.set(storeName, new Map());
+            const store = stores.get(storeName);
+            const wrap = (fn) => {
+              const r = idbReq(fn);
+              queueMicrotask(() => queueMicrotask(() => tx.oncomplete?.()));
+              return r;
+            };
+            return {
+              get: (k) => wrap(() => (store.get(k) === undefined ? undefined : structuredClone(store.get(k)))),
+              put: (v, k) => wrap(() => (store.set(k, structuredClone(v)), k)),
+              delete: (k) => wrap(() => (store.delete(k), undefined)),
+            };
+          };
+          return tx;
+        },
+      };
+      if (isNew) req.onupgradeneeded?.();
+      req.onsuccess?.();
+    });
+    return req;
+  },
+};
+
+const SDK_DIST = path.resolve(__dirname, '../packages/core/dist/index.js');
+const sdk = require(SDK_DIST);
+
+let calculateJwkThumbprint;
+try {
+  ({ calculateJwkThumbprint } = require('jose'));
+} catch {
+  try {
+    ({ calculateJwkThumbprint } = require(path.resolve(__dirname, '../node_modules/jose')));
+  } catch {
+    console.error('FATAL: cannot resolve `jose`. Install it in this workspace.');
+    process.exit(1);
+  }
+}
+
+const b64uJson = (seg) => JSON.parse(Buffer.from(seg.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString());
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+/** Let every fire-and-forget continuation land before asserting. */
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await sleep(5);
+};
+
+/** mulberry32 — small, seeded, reproducible. */
+function rng(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ─── Mock server ─────────────────────────────────────────────────────────────
+// Records, per clientSessionId, the cnf.jkt it bound at /auth/login — the
+// ground truth every invariant is checked against.
+const boundJktBySession = new Map();
+let sessionSeq = 0;
+let revokeEverything = false;
+let logoutDelayMs = 0;
+let loginDelayMs = 0;
+
+globalThis.fetch = async (req) => {
+  const p = new URL(req.url).pathname;
+  const json = (obj, init) => new Response(JSON.stringify(obj), { status: 200, ...init });
+
+  if (p.endsWith('/auth/session')) return json({ success: true, content: { clientSessionId: `cs${sessionSeq + 1}` } });
+  if (p.endsWith('/auth/email')) return json({ success: true });
+  if (p.endsWith('/auth/email/verify-code')) return json({ code: 'SDK_EMAIL_CODE_VERIFIED', success: true });
+  if (p.includes('/auth/session/status/')) {
+    const body = new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode('data: {"status":"READY"}\n\n'));
+        c.close();
+      },
+    });
+    return new Response(body, { status: 200 });
+  }
+  if (p.endsWith('/auth/logout')) {
+    if (logoutDelayMs) await sleep(logoutDelayMs);
+    return json({ success: true });
+  }
+  if (p.endsWith('/auth/login')) {
+    const body = await req.clone().json();
+    const id = `cs${++sessionSeq}`;
+    boundJktBySession.set(id, await calculateJwkThumbprint(body.dpopJwk, 'sha256'));
+    if (loginDelayMs) await sleep(loginDelayMs);
+    return json({
+      code: 'SDK_LOGIN_SUCCESS',
+      success: true,
+      content: {
+        clientSessionId: id,
+        userId: 'u1',
+        status: 'CONSUMED',
+        token: { accessToken: `AT_${id}`, refreshToken: `RT_${id}`, expiresAt: Math.floor(Date.now() / 1000) + 600 },
+        user: { ready: true },
+        wallet: { type: 'internal', address: 'GABC' },
+        data: { mail: 'a@b.c', first_name: 'a', last_name: 'b', avatar: null, providers: {} },
+      },
+    });
+  }
+  if (p.endsWith('/auth/refresh')) {
+    if (revokeEverything) return json({ code: 'SDK_AUTH_INVALID_TOKEN' }, { status: 401 });
+    const body = await req
+      .clone()
+      .json()
+      .catch(() => ({}));
+    const id = String(body.refreshToken || '').replace(/^RT_/, '');
+    if (!boundJktBySession.has(id)) return json({ code: 'SDK_AUTH_INVALID_TOKEN' }, { status: 401 });
+    return json({
+      success: true,
+      content: { token: { accessToken: `AT_${id}`, refreshToken: `RT_${id}`, expiresAt: Math.floor(Date.now() / 1000) + 600 } },
+    });
+  }
+  if (p.endsWith('/auth/session/resume')) {
+    if (revokeEverything) return json({ code: 'SDK_AUTH_SESSION_REVOKED' }, { status: 403 });
+    const dpop = req.headers.get('DPoP');
+    if (!dpop) {
+      return json(
+        { code: 'SDK_AUTH_DPOP_USE_NONCE', reason: 'no-proof' },
+        { status: 401, headers: { 'WWW-Authenticate': 'DPoP error="use_dpop_nonce"', 'DPoP-Nonce': 'N1' } },
+      );
+    }
+    const [h, pl] = dpop.split('.');
+    if (!b64uJson(pl).nonce) {
+      return json(
+        { code: 'SDK_AUTH_DPOP_USE_NONCE', reason: 'no-nonce' },
+        { status: 401, headers: { 'WWW-Authenticate': 'DPoP error="use_dpop_nonce"', 'DPoP-Nonce': 'N1' } },
+      );
+    }
+    // The server checks the proof key against the token it was handed.
+    const at = (req.headers.get('Authorization') || '').replace(/^DPoP /, '');
+    const expected = boundJktBySession.get(at.replace(/^AT_/, ''));
+    const jkt = await calculateJwkThumbprint(b64uJson(h).jwk, 'sha256');
+    if (!expected || jkt !== expected) {
+      return json(
+        { code: 'SDK_AUTH_DPOP_INVALID', reason: 'thumbprint-mismatch' },
+        { status: 401, headers: { 'WWW-Authenticate': 'DPoP error="invalid_token"' } },
+      );
+    }
+    return json({ success: true, content: { mail: 'a@b.c', first_name: 'a', last_name: 'b', avatar: null, providers: {} } });
+  }
+  return json({ success: true, content: {} });
+};
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+function report(seed, step, label, detail) {
+  fail++;
+  failures.push(`seed ${seed}, after step ${step}: ${label}${detail ? ` (${detail})` : ''}`);
+}
+
+// ─── The invariants ──────────────────────────────────────────────────────────
+/**
+ * Checked after EVERY operation, for every live client. `world` carries the
+ * shared storage adapter and the API key. Returns a failure string or null.
+ */
+async function checkInvariants(world, clients) {
+  const raw = await world.storage.get(`pollar:${world.apiKeyHash}:session`);
+  const row = raw ? JSON.parse(raw) : null;
+
+  // I1 — a persisted session's recorded key binding must be the one the server
+  //      actually bound for that session. A row that vouches for the wrong key
+  //      makes the restore-time precheck wave through a doomed session.
+  if (row && row.dpopJkt) {
+    const truth = boundJktBySession.get(row.clientSessionId);
+    if (truth && row.dpopJkt !== truth) {
+      return `I1 persisted dpopJkt !== server cnf.jkt for ${row.clientSessionId}`;
+    }
+  }
+
+  // I2 — the key a persisted session names must still exist locally. Otherwise
+  //      the session is already dead and the user is logged out on next load.
+  if (row && row.dpopJkt) {
+    const live = await new sdk.WebCryptoKeyManager(world.apiKey).getThumbprint().catch(() => null);
+    if (live !== row.dpopJkt) return `I2 persisted session names a key that is not the stored one`;
+  }
+
+  for (const c of clients) {
+    if (c.destroyed) continue;
+    const st = c.client.getAuthState();
+    // I3 — `authenticated` always carries the session it is about.
+    if (st.step === 'authenticated' && !st.session) return `I3 authenticated with no session on ${c.id}`;
+    // I4 — an authenticated client must hold a usable token.
+    if (st.step === 'authenticated' && !st.session.token?.accessToken)
+      return `I4 authenticated without an access token on ${c.id}`;
+    // I5 — a client never comes back to a session it logged out of. This is
+    //      deliberately per-client: two instances in one document legitimately
+    //      hold DIFFERENT sessions (each is valid server-side, and only a clear
+    //      is announced between them), so "everyone agrees with storage" is not
+    //      a property the SDK offers. What it must offer is that a logout
+    //      sticks for the client that performed it - the resurrection bug.
+    if (st.step === 'authenticated' && c.loggedOut.has(st.session.clientSessionId)) {
+      return `I5 ${c.id} is authenticated again as ${st.session.clientSessionId}, which it logged out of`;
+    }
+  }
+  return null;
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+async function login(client) {
+  client.beginEmailLogin();
+  for (let i = 0; i < 200 && client.getAuthState().step !== 'entering_email'; i++) await sleep(2);
+  if (client.getAuthState().step !== 'entering_email') return;
+  client.sendEmailCode('a@b.c');
+  for (let i = 0; i < 200 && client.getAuthState().step !== 'entering_code'; i++) await sleep(2);
+  if (client.getAuthState().step !== 'entering_code') return;
+  client.verifyEmailCode('123456');
+  for (let i = 0; i < 300 && client.getAuthState().step !== 'authenticated'; i++) await sleep(2);
+}
+
+function makeVisibility() {
+  const cbs = [];
+  return {
+    provider: { isVisible: () => true, onChange: (cb) => (cbs.push(cb), () => {}) },
+    flap: () => cbs.forEach((cb) => cb(true)),
+  };
+}
+
+async function runSeed(seed, steps) {
+  const rand = rng(seed);
+  const pick = (arr) => arr[Math.floor(rand() * arr.length)];
+
+  const apiKey = `pk_inv_${seed}`;
+  const storage = sdk.createMemoryAdapter();
+  IDB.clear();
+  boundJktBySession.clear();
+  sessionSeq = 0;
+  revokeEverything = false;
+  logoutDelayMs = 0;
+  loginDelayMs = 0;
+
+  const world = { apiKey, storage, apiKeyHash: null };
+  const clients = [];
+  const spawn = async (id) => {
+    const vis = makeVisibility();
+    const client = new sdk.PollarClient({
+      apiKey,
+      storage,
+      baseUrl: 'https://x.test',
+      visibilityProvider: vis.provider,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+    });
+    await client.ready();
+    world.apiKeyHash = client.apiKeyHash;
+    const entry = { id, client, vis, destroyed: false, loggedOut: new Set() };
+    clients.push(entry);
+    return entry;
+  };
+
+  await spawn('A');
+
+  const OPS = [
+    'login',
+    'logout',
+    'logout-racing-login',
+    'refresh',
+    'revalidate',
+    'reload',
+    'second-instance',
+    'cross-tab-clear',
+    'revoke-then-use',
+  ];
+
+  for (let step = 1; step <= steps; step++) {
+    const live = clients.filter((c) => !c.destroyed);
+    const target = pick(live);
+    const op = pick(OPS);
+
+    try {
+      switch (op) {
+        case 'login':
+          await login(target.client);
+          break;
+        case 'logout': {
+          const before = target.client.getAuthState().session?.clientSessionId;
+          await target.client.logout();
+          if (before) target.loggedOut.add(before);
+          break;
+        }
+        case 'logout-racing-login': {
+          // The shape that produced the worst bug: logout is async and nobody
+          // awaits it, so a whole login lands inside its window.
+          logoutDelayMs = 60;
+          const before = target.client.getAuthState().session?.clientSessionId;
+          const pending = target.client.logout();
+          await sleep(5);
+          await login(target.client);
+          await pending;
+          if (before) target.loggedOut.add(before);
+          logoutDelayMs = 0;
+          break;
+        }
+        case 'refresh':
+          await target.client.refresh().catch(() => {});
+          break;
+        case 'revalidate':
+          target.vis.flap();
+          target.vis.flap();
+          break;
+        case 'reload': {
+          // Same storage + IndexedDB, brand new client: a page load.
+          target.client.destroy();
+          target.destroyed = true;
+          await spawn(target.id + "'");
+          break;
+        }
+        case 'second-instance':
+          if (live.length < 3) await spawn(`S${step}`);
+          break;
+        case 'cross-tab-clear': {
+          // Another document removed the row; deliver the event to everyone
+          // except the writer, like a browser does.
+          const key = `pollar:${world.apiKeyHash}:session`;
+          await storage.remove(key);
+          for (const fn of storageHandlers.keys()) fn({ key, newValue: null, storageArea: globalThis.localStorage });
+          break;
+        }
+        case 'revoke-then-use':
+          revokeEverything = true;
+          target.vis.flap();
+          await settle();
+          revokeEverything = false;
+          break;
+      }
+    } catch {
+      // An operation rejecting is allowed (a logout with no session, a refresh
+      // with no token). What is NOT allowed is the state it leaves behind.
+    }
+
+    await settle();
+    const broken = await checkInvariants(world, clients);
+    if (broken) {
+      report(seed, `${step} (${op} on ${target.id})`, broken);
+      break;
+    }
+  }
+
+  for (const c of clients) if (!c.destroyed) c.client.destroy();
+}
+
+(async () => {
+  const argSeed = process.argv[2] ? Number(process.argv[2]) : null;
+  const seeds = argSeed !== null ? [argSeed] : Array.from({ length: 12 }, (_, i) => 1000 + i);
+  const steps = argSeed !== null ? 40 : 18;
+
+  console.log(`── Randomized session/DPoP invariants (${seeds.length} seed(s) x ${steps} steps) ──`);
+  for (const seed of seeds) {
+    const before = fail;
+    await runSeed(seed, steps);
+    if (fail === before) {
+      pass++;
+      console.log(`  OK    seed ${seed}`);
+    } else {
+      console.log(`  FAIL  seed ${seed}`);
+    }
+  }
+  for (const f of failures) console.log(`        ${f}`);
+  if (failures.length) console.log(`\n  Replay one with: node tests/smoke-invariants.cjs <seed>`);
+  console.log(`\n${pass} pass, ${fail} fail`);
+  process.exit(fail ? 1 : 0);
+})().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/smoke-invariants.cjs
+++ b/tests/smoke-invariants.cjs
@@ -128,7 +128,6 @@ const boundJktBySession = new Map();
 let sessionSeq = 0;
 let revokeEverything = false;
 let logoutDelayMs = 0;
-let loginDelayMs = 0;
 
 globalThis.fetch = async (req) => {
   const p = new URL(req.url).pathname;
@@ -154,7 +153,6 @@ globalThis.fetch = async (req) => {
     const body = await req.clone().json();
     const id = `cs${++sessionSeq}`;
     boundJktBySession.set(id, await calculateJwkThumbprint(body.dpopJwk, 'sha256'));
-    if (loginDelayMs) await sleep(loginDelayMs);
     return json({
       code: 'SDK_LOGIN_SUCCESS',
       success: true,
@@ -299,7 +297,6 @@ async function runSeed(seed, steps) {
   sessionSeq = 0;
   revokeEverything = false;
   logoutDelayMs = 0;
-  loginDelayMs = 0;
 
   const world = { apiKey, storage, apiKeyHash: null };
   const clients = [];

--- a/tests/smoke-lifecycle.cjs
+++ b/tests/smoke-lifecycle.cjs
@@ -209,6 +209,59 @@ function newClient(apiKey, logger) {
     }
   }
 
+  console.log('\n── 8. A failing sibling cannot abort our own teardown ───────');
+  {
+    // The in-document announcement is a courtesy call made on behalf of OTHER
+    // instances. It used to run before the clearing client emitted `idle`, and
+    // nothing guarded it: a sibling that threw (a logger sink that chokes is
+    // the realistic version) left the clearing client reporting `authenticated`
+    // with its session row already gone - and `logout()` swallows the error, so
+    // nothing pointed at the sibling that caused it.
+    const quiet = { debug() {}, info() {}, warn() {}, error() {} };
+    const hostile = {
+      debug() {},
+      warn() {},
+      error() {},
+      info: (m) => {
+        if (String(m).includes('cleared by another client')) throw new Error('sibling logger blew up');
+      },
+    };
+    const storage = sdk.createMemoryAdapter();
+    const apiKey = 'pk_lifecycle_hostile_sibling';
+
+    const seed = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', logger: quiet });
+    await seed.ready();
+    const sessionKey = `pollar:${seed.apiKeyHash}:session`;
+    await storage.set(
+      sessionKey,
+      JSON.stringify({
+        clientSessionId: 'cs1',
+        userId: 'u1',
+        status: 'CONSUMED',
+        token: { accessToken: 'AT', refreshToken: 'RT', expiresAt: Math.floor(Date.now() / 1000) + 600 },
+        user: { ready: true },
+        wallet: { type: 'internal', address: 'G' },
+      }),
+    );
+    seed.destroy();
+
+    const origin = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', logger: quiet });
+    const sibling = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', logger: hostile });
+    await Promise.all([origin.ready(), sibling.ready()]);
+    await new Promise((r) => setTimeout(r, 40));
+    check(
+      '(baseline) both instances hold the session',
+      origin.getAuthState().step === 'authenticated' && sibling.getAuthState().step === 'authenticated',
+    );
+
+    await origin.logout();
+    await new Promise((r) => setTimeout(r, 40));
+    check('the clearing client still converges to idle', origin.getAuthState().step === 'idle', origin.getAuthState().step);
+    check('  and its session row is gone', (await storage.get(sessionKey)) == null);
+    origin.destroy();
+    sibling.destroy();
+  }
+
   console.log(`\n${pass} pass, ${fail} fail${skipped ? `, ${skipped} skip` : ''}`);
   process.exit(fail ? 1 : 0);
 })().catch((err) => {

--- a/tests/smoke-lifecycle.cjs
+++ b/tests/smoke-lifecycle.cjs
@@ -1,0 +1,217 @@
+// @pollar smoke test — client lifecycle: teardown leaves nothing behind.
+//
+// Run with `node tests/smoke-lifecycle.cjs` after `npm run build`. For the
+// reachability block, run it with `--expose-gc` (the npm script does); without
+// the flag that block is skipped, not failed.
+//
+// Why this file exists: `PollarClient` registers itself in a MODULE-level
+// registry (`liveClientsByApiKey`) so a logout can be announced to sibling
+// instances in the same document. A module-level map holding client references
+// is a leak waiting to happen - registration and deregistration have to agree
+// on exactly when they run, and nothing enforced that agreement. These are the
+// assertions that do.
+//
+// Nothing here reaches into private state. The registry is observed through the
+// behavior it drives (the "another client is already active" warning) and,
+// where the flag allows, through actual reachability.
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const winListeners = { storage: new Set() };
+globalThis.window = {
+  location: { origin: 'https://x.test', href: 'https://x.test/' },
+  addEventListener: (type, cb) => (winListeners[type] ??= new Set()).add(cb),
+  removeEventListener: (type, cb) => winListeners[type]?.delete(cb),
+  open: () => null,
+};
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+globalThis.document = { addEventListener: () => {}, removeEventListener: () => {}, visibilityState: 'visible' };
+globalThis.fetch = async () => new Response(JSON.stringify({ success: true, content: {} }), { status: 200 });
+
+const SDK_DIST = path.resolve(__dirname, '../packages/core/dist/index.js');
+const sdk = require(SDK_DIST);
+
+let pass = 0;
+let fail = 0;
+let skipped = 0;
+function check(label, ok, extra) {
+  if (ok) {
+    pass++;
+    console.log(`  OK    ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${label}`, extra ?? '');
+  }
+}
+function skip(label, why) {
+  skipped++;
+  console.log(`  SKIP  ${label} (${why})`);
+}
+
+/** A logger that records the "another client is already active" warning. */
+function makeLogger() {
+  const state = { collisionWarnings: 0, warnings: [] };
+  const noop = () => {};
+  return {
+    state,
+    logger: {
+      debug: noop,
+      info: noop,
+      error: noop,
+      warn: (msg) => {
+        state.warnings.push(String(msg));
+        if (String(msg).includes('Another PollarClient is already active')) state.collisionWarnings++;
+      },
+    },
+  };
+}
+
+function newClient(apiKey, logger) {
+  return new sdk.PollarClient({ apiKey, storage: sdk.createMemoryAdapter(), baseUrl: 'https://x.test', logger });
+}
+
+(async () => {
+  console.log('── 1. The collision warning actually fires (positive control) ──');
+  {
+    // Without this, every "no warning" assertion below could pass for the wrong
+    // reason (a detector that never fires proves nothing).
+    const { state, logger } = makeLogger();
+    const a = newClient('pk_lifecycle_control', logger);
+    const b = newClient('pk_lifecycle_control', logger);
+    check('two live clients on one API key warn', state.collisionWarnings === 1, `warnings=${state.collisionWarnings}`);
+    a.destroy();
+    b.destroy();
+  }
+
+  console.log('\n── 2. destroy() deregisters the client ───────────────────────');
+  {
+    // The registry is per API key, so a leaked entry from a destroyed client
+    // makes the NEXT client on that key look like a collision.
+    const { state, logger } = makeLogger();
+    for (let i = 0; i < 25; i++) newClient('pk_lifecycle_cycle', logger).destroy();
+    const after = newClient('pk_lifecycle_cycle', logger);
+    check(
+      '25 construct/destroy cycles leave no entry behind',
+      state.collisionWarnings === 0,
+      `warnings=${state.collisionWarnings}`,
+    );
+    after.destroy();
+  }
+
+  console.log('\n── 3. destroy() is idempotent ────────────────────────────────');
+  {
+    // A double destroy must not over-deregister and hide a real collision.
+    const { state, logger } = makeLogger();
+    const a = newClient('pk_lifecycle_idem', logger);
+    const b = newClient('pk_lifecycle_idem', logger);
+    state.collisionWarnings = 0;
+    b.destroy();
+    b.destroy();
+    b.destroy();
+    const c = newClient('pk_lifecycle_idem', logger);
+    check(
+      'a still-live sibling is still detected after a triple destroy',
+      state.collisionWarnings === 1,
+      `warnings=${state.collisionWarnings}`,
+    );
+    a.destroy();
+    c.destroy();
+  }
+
+  console.log('\n── 4. destroy() detaches the cross-tab storage listener ──────');
+  {
+    const before = winListeners.storage.size;
+    const a = newClient('pk_lifecycle_listener');
+    await a.ready();
+    check('a live client is listening for `storage`', winListeners.storage.size === before + 1);
+    a.destroy();
+    check('  destroy() removes the listener', winListeners.storage.size === before, `size=${winListeners.storage.size}`);
+  }
+
+  console.log('\n── 5. A destroyed client ignores a sibling teardown ──────────');
+  {
+    // The in-document logout announcement iterates the registry. A destroyed
+    // client must be gone from it; if it lingered, it would run a teardown (and
+    // emit auth state) after the host tore it down.
+    const a = newClient('pk_lifecycle_sibling');
+    const b = newClient('pk_lifecycle_sibling');
+    await Promise.all([a.ready(), b.ready()]);
+    let statesAfterDestroy = 0;
+    b.onAuthStateChange(() => statesAfterDestroy++);
+    b.destroy();
+    statesAfterDestroy = 0;
+    await a.logout();
+    await new Promise((r) => setTimeout(r, 30));
+    check('no auth state emitted to the destroyed sibling', statesAfterDestroy === 0, `emissions=${statesAfterDestroy}`);
+    a.destroy();
+  }
+
+  console.log('\n── 6. A destroyed client becomes unreachable ─────────────────');
+  {
+    if (typeof globalThis.gc !== 'function') {
+      skip('destroyed client is garbage-collectable', 'run with --expose-gc');
+    } else {
+      // Hold the client ONLY through an array we then empty. A plain `const`
+      // inside this async function would be kept alive by the function's own
+      // context for the rest of the block, and the assertion would then fail on
+      // the test's scope rather than on anything the SDK retains.
+      let holder = [newClient('pk_lifecycle_gc')];
+      await holder[0].ready();
+      holder[0].destroy();
+      const ref = new WeakRef(holder[0]);
+      holder.length = 0;
+      holder = null;
+      // Two collections with a turn of the loop between them: the first drops
+      // the object, the second clears any finalization-pending state.
+      await new Promise((r) => setTimeout(r, 20));
+      globalThis.gc();
+      await new Promise((r) => setTimeout(r, 10));
+      globalThis.gc();
+      check('a destroyed client is collectable (registry holds no strong ref)', ref.deref() === undefined);
+    }
+  }
+
+  console.log('\n── 7. A server-side client leaks nothing ─────────────────────');
+  {
+    // Server-rendered code builds one client per request and never destroys it,
+    // so nothing module-level may hold on to it. Today the constructor returns
+    // before it would register, which is what makes this hold; the assertion
+    // guards that property against a refactor that registers earlier. Run in a
+    // child process with NO window/localStorage so `isClientRuntime` is false.
+    const child = spawnSync(
+      process.execPath,
+      [
+        '--expose-gc',
+        '-e',
+        `
+        const sdk = require(${JSON.stringify(SDK_DIST)});
+        let ref;
+        {
+          // No window/localStorage here: this is the SSR path.
+          const c = new sdk.PollarClient({ apiKey: 'pk_ssr_leak', baseUrl: 'https://x.test',
+            logger: { debug(){}, info(){}, warn(){}, error(){} } });
+          ref = new WeakRef(c);
+        }
+        setTimeout(() => {
+          gc(); gc();
+          console.log(ref.deref() === undefined ? 'COLLECTED' : 'RETAINED');
+        }, 20);
+        `,
+      ],
+      { encoding: 'utf8', timeout: 20_000 },
+    );
+    const out = (child.stdout || '').trim().split('\n').pop();
+    if (child.error || (out !== 'COLLECTED' && out !== 'RETAINED')) {
+      skip('server-side client is not retained', `child failed: ${child.error?.message ?? child.stderr?.slice(0, 200)}`);
+    } else {
+      check('a server-side client is not retained by the module registry', out === 'COLLECTED', out);
+    }
+  }
+
+  console.log(`\n${pass} pass, ${fail} fail${skipped ? `, ${skipped} skip` : ''}`);
+  process.exit(fail ? 1 : 0);
+})().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/smoke-react.cjs
+++ b/tests/smoke-react.cjs
@@ -1,0 +1,228 @@
+// @pollar smoke test — `PollarProvider` client lifecycle.
+//
+// Run with `node tests/smoke-react.cjs` after `npm run build`.
+//
+// `@pollar/react` is where the double-instance hazard originates. The provider
+// builds the client in a `useState` initializer, and React StrictMode
+// double-invokes that initializer in development: the extra client's
+// constructor has already run - registering itself, attaching a cross-tab
+// `storage` listener, starting a refresh loop - while React keeps only one, and
+// the provider's cleanup only ever sees the one it kept. Two live clients on
+// one API key share a session row and a DPoP keypair, which is the exact
+// configuration every session-teardown bug in `@pollar/core` needed to bite.
+//
+// Rendered through jsdom + `react-dom/client`, NOT `react-test-renderer`: the
+// test renderer does not enable StrictMode's double-render, so the block below
+// would pass without the scenario ever happening. Verified: under jsdom the
+// initializer and effects each run twice, as they do in a browser dev build.
+// JSX is spelled out as `React.createElement` so this stays a plain .cjs script.
+
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', { url: 'https://x.test/' });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.navigator = dom.window.navigator;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Element = dom.window.Element;
+globalThis.Node = dom.window.Node;
+
+// Count live `storage` listeners: the client attaches one and must remove it on
+// destroy, so a leaked listener means a client outlived its provider.
+let storageListeners = 0;
+const realAdd = dom.window.addEventListener.bind(dom.window);
+const realRemove = dom.window.removeEventListener.bind(dom.window);
+dom.window.addEventListener = (type, ...rest) => {
+  if (type === 'storage') storageListeners++;
+  return realAdd(type, ...rest);
+};
+dom.window.removeEventListener = (type, ...rest) => {
+  if (type === 'storage') storageListeners--;
+  return realRemove(type, ...rest);
+};
+
+globalThis.fetch = async () => new Response(JSON.stringify({ success: true, content: {} }), { status: 200 });
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const React = require('react');
+const { act } = React;
+const { createRoot } = require('react-dom/client');
+const sdk = require(path.resolve(__dirname, '../packages/core/dist/index.js'));
+const { PollarProvider } = require(path.resolve(__dirname, '../packages/react/dist/index.js'));
+
+let pass = 0;
+let fail = 0;
+function check(label, ok, extra) {
+  if (ok) {
+    pass++;
+    console.log(`  OK    ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${label}`, extra ?? '');
+  }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Counts the "another client is already active" warning — how a live duplicate
+ *  announces itself without reaching into private state. */
+function makeLogger() {
+  const state = { collisions: 0 };
+  const noop = () => {};
+  return {
+    state,
+    logger: {
+      debug: noop,
+      info: noop,
+      error: noop,
+      warn: (msg) => {
+        if (String(msg).includes('Another PollarClient is already active')) state.collisions++;
+      },
+    },
+  };
+}
+
+const h = React.createElement;
+/** Passed so the provider never fetches /applications/config. */
+const APP_CONFIG = { branding: {}, features: {} };
+
+function mount(element) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { root, container, element };
+}
+async function render(handle) {
+  await act(async () => {
+    handle.root.render(handle.element);
+  });
+  await sleep(20);
+}
+async function unmount(handle) {
+  await act(async () => {
+    handle.root.unmount();
+  });
+  // The provider defers `destroy()` to a macrotask so a StrictMode remount can
+  // cancel it; wait past that.
+  await sleep(30);
+  handle.container.remove();
+}
+
+(async () => {
+  console.log('── 0. StrictMode really double-invokes here (positive control) ─');
+  {
+    // Without this the blocks below could pass because the scenario never runs.
+    let inits = 0;
+    function Probe() {
+      React.useState(() => (inits++, {}));
+      return null;
+    }
+    const handle = mount(h(React.StrictMode, null, h(Probe)));
+    await render(handle);
+    check('the useState initializer runs twice under StrictMode', inits === 2, `inits=${inits}`);
+    await unmount(handle);
+  }
+
+  console.log('\n── 1. StrictMode leaves exactly ONE live client ───────────────');
+  {
+    // Shaped like real usage: the config is an INLINE literal inside a
+    // component StrictMode also double-renders, not an object hoisted out of
+    // the render. Hoisting it would hand both passes the same object for a
+    // reason the SDK does not control, and this would then pass without
+    // exercising what consumers actually write.
+    const { state, logger } = makeLogger();
+    let appRenders = 0;
+    function App() {
+      appRenders++;
+      return h(
+        PollarProvider,
+        { client: { apiKey: 'pk_react_strict', baseUrl: 'https://x.test', logger }, appConfig: APP_CONFIG },
+        null,
+      );
+    }
+    const handle = mount(h(React.StrictMode, null, h(App)));
+    await render(handle);
+    check('the surrounding component really double-rendered', appRenders === 2, `renders=${appRenders}`);
+    check('  no orphaned second client under StrictMode', state.collisions === 0, `collisions=${state.collisions}`);
+    await unmount(handle);
+
+    // The orphan used to outlive the provider entirely: a later mount on the
+    // same API key would collide with it.
+    state.collisions = 0;
+    const after = mount(
+      h(
+        PollarProvider,
+        { client: { apiKey: 'pk_react_strict', baseUrl: 'https://x.test', logger }, appConfig: APP_CONFIG },
+        null,
+      ),
+    );
+    await render(after);
+    check('  nothing from the StrictMode mount outlived it', state.collisions === 0, `collisions=${state.collisions}`);
+    await unmount(after);
+  }
+
+  console.log('\n── 2. The provider tears down the client it built ────────────');
+  {
+    const { state, logger } = makeLogger();
+    const cfg = { apiKey: 'pk_react_owned', baseUrl: 'https://x.test', logger };
+    const first = mount(h(PollarProvider, { client: cfg, appConfig: APP_CONFIG }, null));
+    await render(first);
+    await unmount(first);
+    // A client that outlived its provider would collide with the next mount.
+    const second = mount(h(PollarProvider, { client: cfg, appConfig: APP_CONFIG }, null));
+    await render(second);
+    check('unmount destroys the provider-built client', state.collisions === 0, `collisions=${state.collisions}`);
+    await unmount(second);
+  }
+
+  console.log('\n── 3. A consumer-passed client survives unmount ──────────────');
+  {
+    // The provider must not destroy a client it does not own: a module
+    // singleton reused across route changes is the documented pattern, and
+    // destroying it would silently stop its refresh loop.
+    const { logger } = makeLogger();
+    const client = new sdk.PollarClient({ apiKey: 'pk_react_passed', baseUrl: 'https://x.test', logger });
+    await client.ready();
+    const handle = mount(h(PollarProvider, { client, appConfig: APP_CONFIG }, null));
+    await render(handle);
+    await unmount(handle);
+    let alive = false;
+    try {
+      await client.ready();
+      alive = client.getAuthState().step === 'idle';
+    } catch {
+      alive = false;
+    }
+    check('a client passed in is left alive after unmount', alive);
+    client.destroy();
+  }
+
+  console.log('\n── 4. Mount/unmount cycles leave no listeners behind ─────────');
+  {
+    const { logger } = makeLogger();
+    const before = storageListeners;
+    for (let i = 0; i < 5; i++) {
+      const handle = mount(
+        h(
+          PollarProvider,
+          { client: { apiKey: 'pk_react_cycles', baseUrl: 'https://x.test', logger }, appConfig: APP_CONFIG },
+          null,
+        ),
+      );
+      await render(handle);
+      await unmount(handle);
+    }
+    check(
+      '5 mount/unmount cycles leave no `storage` listeners',
+      storageListeners === before,
+      `now=${storageListeners}, was=${before}`,
+    );
+  }
+
+  console.log(`\n${pass} pass, ${fail} fail`);
+  process.exit(fail ? 1 : 0);
+})().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/smoke-react.cjs
+++ b/tests/smoke-react.cjs
@@ -220,6 +220,69 @@ async function unmount(handle) {
     );
   }
 
+  console.log('\n── 5. A client from a SECOND copy of core is recognised ──────');
+  {
+    // The failure this guards: a package that pulls its own @pollar/core (a
+    // `dependencies` entry instead of a peer, an exact pin that disagrees, a
+    // bundler that does not dedupe) hands the provider an instance built by a
+    // DIFFERENT class object. `instanceof` answers false, the provider decides
+    // it was given a config, and spreads a live client into
+    // `new PollarClient({...})`. Loading the bundle a second time from a copied
+    // path is exactly that situation - Node caches by resolved path, so this is
+    // a genuinely separate module instance, not the same one twice.
+    const fs = require('node:fs');
+    // Copied NEXT TO the original, not into a temp dir: the bundle resolves its
+    // own dependencies relative to its own path, so it has to sit inside the
+    // workspace to find node_modules.
+    const original = path.resolve(__dirname, '../packages/core/dist/index.js');
+    const copied = path.resolve(__dirname, '../packages/core/dist/__second-copy-under-test.cjs');
+    fs.copyFileSync(original, copied);
+    let otherCore;
+    try {
+      otherCore = require(copied);
+    } finally {
+      // The module is loaded and cached; the file on disk is no longer needed.
+      fs.rmSync(copied, { force: true });
+    }
+
+    check('the second copy really is a separate module', otherCore.PollarClient !== sdk.PollarClient);
+
+    const { logger } = makeLogger();
+    const foreign = new otherCore.PollarClient({ apiKey: 'pk_react_foreign', baseUrl: 'https://x.test', logger });
+    await foreign.ready();
+    check('  instanceof across copies is false (the trap)', !(foreign instanceof sdk.PollarClient));
+    check('  isPollarClient sees through it', sdk.isPollarClient(foreign) === true);
+    check('  and a plain config is still not a client', sdk.isPollarClient({ apiKey: 'x' }) === false);
+
+    // The provider must treat it as a ready client: adopt it, and leave it
+    // alive on unmount because it is not the provider's to destroy.
+    // Measure by `storage` listeners, not by liveness or by log lines. When the
+    // provider mistakes a client for a config it spreads it into
+    // `new PollarClient({...})`; the spread carries `apiKey` so the original
+    // stays alive (liveness passes either way), and it does NOT carry `logger`
+    // so the new client logs to the console instead of our spy (a log counter
+    // passes either way too). A new client always attaches its own cross-tab
+    // listener to the one shared jsdom window, whichever copy of core built it.
+    const listenersBefore = storageListeners;
+    const handle = mount(h(PollarProvider, { client: foreign, appConfig: APP_CONFIG }, null));
+    await render(handle);
+    check(
+      '  the provider adopts it, building nothing',
+      storageListeners === listenersBefore,
+      `listeners ${listenersBefore} -> ${storageListeners}`,
+    );
+    await unmount(handle);
+    let alive = false;
+    try {
+      await foreign.ready();
+      alive = foreign.getAuthState().step === 'idle';
+    } catch {
+      alive = false;
+    }
+    check("  and leaves it alive, since it is not the provider's to destroy", alive);
+    foreign.destroy();
+  }
+
   console.log(`\n${pass} pass, ${fail} fail`);
   process.exit(fail ? 1 : 0);
 })().catch((err) => {

--- a/tests/smoke-resume.cjs
+++ b/tests/smoke-resume.cjs
@@ -1,0 +1,404 @@
+// @pollar smoke test — session resume across "page loads" (DPoP key binding).
+//
+// Run with `node tests/smoke-resume.cjs` after `npm run build`. Regression
+// guards for the 0.11.2 field bug where a session died on the first reload
+// with `SDK_AUTH_DPOP_INVALID reason:"thumbprint-mismatch"`:
+//
+//  1. A fresh PollarClient over the SAME persisted storage + IndexedDB resumes
+//     the session — the resume proof's JWK thumbprint equals the `cnf.jkt` the
+//     server bound at login — and concurrent resume triggers (visibility flaps)
+//     coalesce into ONE `/auth/session/resume`.
+//  2. A genuinely revoked session (server 403 on resume) still clears.
+//  3. When the keypair cannot persist (IndexedDB unavailable), login warns
+//     loudly, and the reload clears the doomed session LOCALLY — no resume
+//     round trip, no 401 burst — via the persisted `dpopJkt` binding check.
+//  4. A non-terminal resume failure (5xx) backs off instead of bursting.
+//  5. `logout()` rotates the DPoP keypair; a failure-path clear does NOT.
+//
+// Mocks `fetch` with a server that actually verifies the DPoP binding: it
+// computes `cnf.jkt` from the login's `dpopJwk` and compares it against the
+// thumbprint of the JWK in each resume proof's header, including the RFC 9449
+// `use_dpop_nonce` challenge round trip. IndexedDB is a minimal in-memory shim
+// (Node has none) that survives across client instances to model a reload.
+
+const path = require('node:path');
+
+// Capture `storage` handlers so the cross-tab test can deliver events to a
+// specific "tab" (browsers never deliver storage events to the writing tab, so
+// dispatching selectively models the real thing).
+const storageHandlers = [];
+globalThis.window = {
+  location: { origin: 'https://x.test', href: 'https://x.test/' },
+  addEventListener: (type, fn) => {
+    if (type === 'storage') storageHandlers.push(fn);
+  },
+  removeEventListener: (type, fn) => {
+    if (type === 'storage') {
+      const i = storageHandlers.indexOf(fn);
+      if (i !== -1) storageHandlers.splice(i, 1);
+    }
+  },
+};
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+// ─── Minimal IndexedDB shim ──────────────────────────────────────────────────
+// Only the surface WebCryptoKeyManager touches: open/upgradeneeded, get/put/
+// delete, transaction `complete`/`abort` events (the durable-write path awaits
+// those), close. Values round-trip through structuredClone like real IDB.
+function makeIndexedDB() {
+  const dbs = new Map();
+  const fire = (t, type) => {
+    const h = t['on' + type];
+    if (typeof h === 'function') h({ target: t });
+  };
+  return {
+    open(name, version) {
+      const req = { result: undefined, error: null, onsuccess: null, onerror: null, onupgradeneeded: null };
+      queueMicrotask(() => {
+        let rec = dbs.get(name);
+        const isNew = !rec;
+        if (!rec) {
+          rec = { version: version || 1, stores: new Map() };
+          dbs.set(name, rec);
+        }
+        req.result = {
+          objectStoreNames: { contains: (s) => rec.stores.has(s) },
+          createObjectStore: (s) => (rec.stores.set(s, new Map()), {}),
+          close: () => {},
+          transaction: (storeName) => {
+            const tx = { oncomplete: null, onerror: null, onabort: null, error: null };
+            tx.objectStore = () => {
+              const store = rec.stores.get(storeName);
+              const wrap = (fn) => {
+                const r = { result: undefined, error: null, onsuccess: null, onerror: null };
+                queueMicrotask(() => {
+                  try {
+                    r.result = fn();
+                    fire(r, 'success');
+                    queueMicrotask(() => fire(tx, 'complete'));
+                  } catch (e) {
+                    r.error = e;
+                    fire(r, 'error');
+                    tx.error = e;
+                    queueMicrotask(() => fire(tx, 'abort'));
+                  }
+                });
+                return r;
+              };
+              return {
+                get: (k) => wrap(() => (store.get(k) === undefined ? undefined : structuredClone(store.get(k)))),
+                put: (v, k) => wrap(() => (store.set(k, structuredClone(v)), k)),
+                delete: (k) => wrap(() => (store.delete(k), undefined)),
+              };
+            };
+            return tx;
+          },
+        };
+        if (isNew) fire(req, 'upgradeneeded');
+        fire(req, 'success');
+      });
+      return req;
+    },
+  };
+}
+globalThis.indexedDB = makeIndexedDB();
+
+const SDK_DIST = path.resolve(__dirname, '../packages/core/dist/index.js');
+const sdk = require(SDK_DIST);
+
+// jose is hoisted at workspace root (transitive via sdk-api). If you run this
+// outside a workspace, install jose locally.
+let calculateJwkThumbprint;
+try {
+  ({ calculateJwkThumbprint } = require('jose'));
+} catch {
+  const candidates = [path.resolve(__dirname, '../node_modules/jose')];
+  for (const c of candidates) {
+    try {
+      ({ calculateJwkThumbprint } = require(c));
+      break;
+    } catch {}
+  }
+  if (!calculateJwkThumbprint) {
+    console.error('FATAL: cannot resolve `jose`. Install it in this workspace.');
+    process.exit(1);
+  }
+}
+
+let pass = 0;
+let fail = 0;
+function check(label, ok, extra) {
+  if (ok) {
+    pass++;
+    console.log(`  OK    ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${label}`, extra ?? '');
+  }
+}
+
+async function waitFor(cond, timeoutMs = 4000) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor: condition not met within timeout');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const b64uJson = (part) => JSON.parse(Buffer.from(part, 'base64url').toString('utf8'));
+
+// ─── Mock server ─────────────────────────────────────────────────────────────
+// `resumeMode` selects the behavior of GET /auth/session/resume per test case.
+let serverBoundJkt = null; // cnf.jkt bound at the last /auth/login
+let resumeMode = 'verify'; // 'verify' | 'revoked-403' | 'error-500'
+let resumeDelayMs = 0;
+let resumeHits = 0; // every fetch hit on the resume path (nonce retries included)
+const resumeProofJkts = []; // jkt of each nonce-carrying resume proof
+
+globalThis.fetch = async (req) => {
+  const p = new URL(req.url).pathname;
+  const json = (obj, init) => new Response(JSON.stringify(obj), { status: 200, ...init });
+
+  if (p.endsWith('/auth/session')) return json({ success: true, content: { clientSessionId: 'cs1' } });
+  if (p.endsWith('/auth/email')) return json({ success: true });
+  if (p.endsWith('/auth/email/verify-code')) return json({ code: 'SDK_EMAIL_CODE_VERIFIED', success: true });
+  if (p.includes('/auth/session/status/')) {
+    const body = new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode('data: {"status":"READY"}\n\n'));
+        c.close();
+      },
+    });
+    return new Response(body, { status: 200 });
+  }
+  if (p.endsWith('/auth/login')) {
+    const body = await req.clone().json();
+    serverBoundJkt = await calculateJwkThumbprint(body.dpopJwk, 'sha256');
+    return json({
+      code: 'SDK_LOGIN_SUCCESS',
+      success: true,
+      content: {
+        clientSessionId: 'cs1',
+        userId: 'u1',
+        status: 'CONSUMED',
+        token: { accessToken: 'AT1', refreshToken: 'RT1', expiresAt: Math.floor(Date.now() / 1000) + 600 },
+        user: { ready: true },
+        wallet: { type: 'internal', address: 'GABC' },
+        data: { mail: 'a@b.c', first_name: 'a', last_name: 'b', avatar: null, providers: {} },
+      },
+    });
+  }
+  if (p.endsWith('/auth/logout')) return json({ success: true });
+  if (p.endsWith('/auth/session/resume')) {
+    resumeHits++;
+    if (resumeDelayMs) await sleep(resumeDelayMs);
+    if (resumeMode === 'error-500') return json({ success: false }, { status: 500 });
+    if (resumeMode === 'revoked-403') return json({ code: 'SDK_AUTH_SESSION_REVOKED' }, { status: 403 });
+    // 'verify': real DPoP semantics — nonce challenge, then thumbprint check.
+    const dpop = req.headers.get('DPoP');
+    const challenge = (reason) =>
+      json(
+        { code: 'SDK_AUTH_DPOP_USE_NONCE', reason },
+        { status: 401, headers: { 'WWW-Authenticate': 'DPoP algs="ES256", error="use_dpop_nonce"', 'DPoP-Nonce': 'N1' } },
+      );
+    if (!dpop) return challenge('no-proof');
+    const [h, pl] = dpop.split('.');
+    if (!b64uJson(pl).nonce) return challenge('no-nonce');
+    const jkt = await calculateJwkThumbprint(b64uJson(h).jwk, 'sha256');
+    resumeProofJkts.push(jkt);
+    if (jkt !== serverBoundJkt) {
+      return json(
+        { code: 'SDK_AUTH_DPOP_INVALID', reason: 'thumbprint-mismatch' },
+        { status: 401, headers: { 'WWW-Authenticate': 'DPoP algs="ES256", error="invalid_token"' } },
+      );
+    }
+    return json({ success: true, content: { mail: 'a@b.c', first_name: 'a', last_name: 'b', avatar: null, providers: {} } });
+  }
+  return json({ success: true, content: {} });
+};
+
+// Full email-OTP login against the mock server.
+async function login(client) {
+  client.beginEmailLogin();
+  await waitFor(() => client.getAuthState().step === 'entering_email');
+  client.sendEmailCode('a@b.c');
+  await waitFor(() => client.getAuthState().step === 'entering_code');
+  client.verifyEmailCode('123456');
+  await waitFor(() => client.getAuthState().step === 'authenticated' && client.getAuthState().verified === true);
+}
+
+function makeVisibility() {
+  const cbs = [];
+  return {
+    provider: { isVisible: () => true, onChange: (cb) => (cbs.push(cb), () => {}) },
+    flap: () => cbs.forEach((cb) => cb(true)),
+  };
+}
+
+(async () => {
+  console.log('── 1. Fresh client over persisted storage resumes the session ─');
+  {
+    const apiKey = 'pk_smoke_resume_ok';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+    check('login reaches authenticated + verified', a.getAuthState().verified === true);
+    const persistedJkt = await new sdk.WebCryptoKeyManager(apiKey).getThumbprint();
+    check('  persisted keypair thumbprint === token cnf.jkt', persistedJkt === serverBoundJkt);
+
+    // "Reload": new client over the same Storage + IndexedDB.
+    a.destroy();
+    resumeHits = 0;
+    resumeDelayMs = 50;
+    const vis = makeVisibility();
+    const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', visibilityProvider: vis.provider });
+    await b.ready();
+    // Flap visibility while the startup resume is in flight — these used to
+    // abort + restart it, turning one resume into a burst of three.
+    vis.flap();
+    vis.flap();
+    await waitFor(() => b.getAuthState().step === 'authenticated' && b.getAuthState().verified === true);
+    check('fresh client resumes to authenticated + verified', true);
+    check('  resume proof thumbprint === token cnf.jkt', resumeProofJkts.at(-1) === serverBoundJkt);
+    // One logical resume = nonce challenge + retried proof = exactly 2 hits.
+    check('  concurrent triggers coalesced into ONE resume (2 hits: challenge + retry)', resumeHits === 2, `hits=${resumeHits}`);
+    check('  keypair unchanged across the reload', (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === persistedJkt);
+    resumeDelayMs = 0;
+
+    console.log('\n── 2. A genuinely revoked session still clears ───────────────');
+    b.destroy();
+    resumeMode = 'revoked-403';
+    const c = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await c.ready();
+    await waitFor(() => c.getAuthState().step === 'idle');
+    check('revoked session converges to idle', c.getAuthState().step === 'idle');
+    check('  session removed from storage', (await storage.get(`pollar:${c.apiKeyHash}:session`)) == null);
+    console.log('\n── 5a. Failure-path clear does NOT rotate the keypair ────────');
+    check('keypair survives the revoked-session clear', (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === persistedJkt);
+
+    console.log('\n── 5b. logout() DOES rotate the keypair ──────────────────────');
+    resumeMode = 'verify';
+    await login(c);
+    await c.logout();
+    await waitFor(() => c.getAuthState().step === 'idle');
+    const rotatedJkt = await new sdk.WebCryptoKeyManager(apiKey).getThumbprint();
+    check('logout rotates the keypair', rotatedJkt !== persistedJkt);
+    c.destroy();
+  }
+
+  console.log('\n── 3. Key persistence failure: clean local clear, no 401 burst ─');
+  {
+    const apiKey = 'pk_smoke_resume_noidb';
+    const storage = sdk.createMemoryAdapter();
+    const savedIdb = globalThis.indexedDB;
+    delete globalThis.indexedDB; // the keypair cannot persist in this "browser"
+    try {
+      const warnings = [];
+      const logger = {
+        debug: () => {},
+        info: () => {},
+        warn: (...a) => warnings.push(a.join(' ')),
+        error: (...a) => warnings.push(a.join(' ')),
+      };
+      const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', logger });
+      await a.ready();
+      await login(a);
+      check('login still works with a non-persistable keypair', a.getAuthState().verified === true);
+      check(
+        '  login warns that the session will not survive a reload',
+        warnings.some((w) => w.includes('could not be persisted')),
+      );
+
+      // "Reload": the stored session is bound to a key that no longer exists.
+      a.destroy();
+      resumeHits = 0;
+      const states = [];
+      const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', logger });
+      b.onAuthStateChange((s) => states.push(s.step));
+      await b.ready();
+      await waitFor(() => b.getAuthState().step === 'idle');
+      check('doomed session is cleared locally (idle)', b.getAuthState().step === 'idle');
+      check('  no resume round trip was attempted (dpopJkt precheck)', resumeHits === 0, `hits=${resumeHits}`);
+      check(
+        '  no phantom authenticated state was emitted',
+        !states.includes('authenticated'),
+        `states=${states.join(',')}`,
+      );
+      check('  session removed from storage', (await storage.get(`pollar:${b.apiKeyHash}:session`)) == null);
+      b.destroy();
+    } finally {
+      globalThis.indexedDB = savedIdb;
+    }
+  }
+
+  console.log('\n── 4. Non-terminal resume failure backs off (no burst) ────────');
+  {
+    const apiKey = 'pk_smoke_resume_backoff';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+    a.destroy();
+
+    resumeMode = 'error-500';
+    resumeHits = 0;
+    const vis = makeVisibility();
+    const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', visibilityProvider: vis.provider });
+    await b.ready();
+    await waitFor(() => resumeHits >= 1);
+    await sleep(50); // let the failure register and arm the backoff
+    vis.flap();
+    vis.flap();
+    await sleep(100);
+    check('5xx keeps the optimistic session', b.getAuthState().step === 'authenticated' && !b.getAuthState().verified);
+    check('  retriggers during backoff are suppressed', resumeHits === 1, `hits=${resumeHits}`);
+    b.destroy();
+    resumeMode = 'verify';
+  }
+
+  console.log('\n── 6. Cross-tab logout→re-login: stale key cache resyncs ──────');
+  {
+    // Tab A and tab B share the persisted key (IndexedDB) + session storage.
+    // A logs out (rotates the shared key) and logs in again with a NEW key;
+    // B — still caching the OLD key in memory — must adopt the new one when
+    // the fresh session arrives, not clear it as a binding mismatch.
+    const apiKey = 'pk_smoke_resume_xtab';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+    const sessionKey = `pollar:${a.apiKeyHash}:session`;
+
+    const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await b.ready(); // the storage handler registers inside async _initialize
+    const bHandler = storageHandlers.at(-1);
+    await waitFor(() => b.getAuthState().step === 'authenticated' && b.getAuthState().verified === true);
+    const jktBeforeLogout = serverBoundJkt;
+
+    // Tab A logs out → key reset + storage removed. Deliver the event to B.
+    await a.logout();
+    bHandler({ key: sessionKey, newValue: null });
+    await waitFor(() => b.getAuthState().step === 'idle');
+
+    // Tab A logs in again → a NEW keypair is generated and bound.
+    await login(a);
+    check('re-login bound a fresh keypair', serverBoundJkt !== jktBeforeLogout);
+
+    // Deliver the new session to B: it must resync to the new shared key and
+    // resume — not clear the session tab A just created.
+    bHandler({ key: sessionKey, newValue: await storage.get(sessionKey) });
+    await waitFor(() => b.getAuthState().step === 'authenticated' && b.getAuthState().verified === true);
+    check('tab B adopts the rotated key and resumes the new session', true);
+    check('  resume proof used the NEW key', resumeProofJkts.at(-1) === serverBoundJkt);
+    check('  the new session was not cleared from storage', (await storage.get(sessionKey)) != null);
+    a.destroy();
+    b.destroy();
+  }
+
+  console.log(`\n${pass} pass, ${fail} fail`);
+  process.exit(fail ? 1 : 0);
+})().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/smoke-resume.cjs
+++ b/tests/smoke-resume.cjs
@@ -147,6 +147,15 @@ async function waitFor(cond, timeoutMs = 4000) {
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const b64uJson = (part) => JSON.parse(Buffer.from(part, 'base64url').toString('utf8'));
 
+// Storage namespace for an API key: SHA-256, first 16 bytes, hex — mirrors
+// lib/api-key-hash.ts, for pre-seeding rows BEFORE a client exists.
+async function hashKey(apiKey) {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(apiKey));
+  return Array.from(new Uint8Array(digest).slice(0, 16))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 // ─── Mock server ─────────────────────────────────────────────────────────────
 // `resumeMode` selects the behavior of GET /auth/session/resume per test case.
 let serverBoundJkt = null; // cnf.jkt bound at the last /auth/login
@@ -606,6 +615,98 @@ function makeVisibility() {
     await c.ready();
     await waitFor(() => c.getAuthState().verified === true);
     check('  the NEXT reload resumes in ONE hit (challenge skipped)', resumeHits === 1, `hits=${resumeHits}`);
+    c.destroy();
+  }
+
+  console.log('\n── 14. superseded logout leaves the wallet adapter connected ──');
+  {
+    // Same race as block 10, from an EXTERNAL-wallet session: the logout's
+    // adapter disconnect must sit BEHIND the generation guard. Registered
+    // adapters are per-type singletons, so the "old" adapter reference can be
+    // the very instance a login that lands mid-logout is now using —
+    // disconnecting it would cut the new session's provider connection.
+    const apiKey = 'pk_smoke_resume_adapter_race';
+    const storage = sdk.createMemoryAdapter();
+    let disconnects = 0;
+    const adapter = {
+      type: 'mockwallet',
+      meta: { label: 'Mock' },
+      chain: 'STELLAR',
+      isAvailable: async () => true,
+      connect: async () => ({ address: 'GMOCK' }),
+      disconnect: async () => {
+        disconnects++;
+      },
+      getPublicKey: async () => 'GMOCK',
+      signTransaction: async () => ({ signedTxXdr: 'X' }),
+    };
+
+    // Seed an EXTERNAL session bound to the current persisted keypair, plus the
+    // walletType row, so the client restores with the adapter attached — the
+    // exact state a returning external-wallet user is in when they hit logout.
+    const kmJkt = await new sdk.WebCryptoKeyManager(apiKey).getThumbprint();
+    serverBoundJkt = kmJkt;
+    await storage.set(
+      `pollar:${await hashKey(apiKey)}:session`,
+      JSON.stringify({
+        clientSessionId: 'cs_ext',
+        userId: 'u1',
+        status: 'CONSUMED',
+        token: { accessToken: 'AT_EXT', refreshToken: 'RT_EXT', expiresAt: Math.floor(Date.now() / 1000) + 600 },
+        user: { ready: true },
+        dpopJkt: kmJkt,
+        wallet: { type: 'external', address: 'GMOCK' },
+      }),
+    );
+    await storage.set(`pollar:${await hashKey(apiKey)}:walletType`, 'mockwallet');
+
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', walletAdapters: [adapter] });
+    await a.ready();
+    await waitFor(() => a.getAuthState().step === 'authenticated' && a.getAuthState().verified === true);
+    check('external session restored with the adapter attached', a.getWalletType() === 'mockwallet', a.getWalletType());
+
+    logoutDelayMs = 150;
+    const pending = a.logout(); // NOT awaited — the UI pattern
+    await sleep(10);
+    await login(a); // a new login completes while the logout awaits the server
+    await pending;
+    await sleep(20);
+    logoutDelayMs = 0;
+
+    check('the mid-logout login survives (generation guard)', a.getAuthState().step === 'authenticated');
+    check('  the adapter was NOT disconnected by the superseded logout', disconnects === 0, `disconnects=${disconnects}`);
+
+    // Baseline: an owned, un-raced logout of an external session DOES disconnect.
+    // Re-seed the external state (the login above switched to an internal session).
+    await a.logout();
+    await waitFor(() => a.getAuthState().step === 'idle');
+    check('  (baseline) the un-raced logout ran to completion', a.getAuthState().step === 'idle');
+    a.destroy();
+
+    const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', walletAdapters: [adapter] });
+    await b.ready();
+    const kmJkt2 = await new sdk.WebCryptoKeyManager(apiKey).getThumbprint();
+    serverBoundJkt = kmJkt2;
+    await storage.set(
+      `pollar:${b.apiKeyHash}:session`,
+      JSON.stringify({
+        clientSessionId: 'cs_ext2',
+        userId: 'u1',
+        status: 'CONSUMED',
+        token: { accessToken: 'AT_EXT2', refreshToken: 'RT_EXT2', expiresAt: Math.floor(Date.now() / 1000) + 600 },
+        user: { ready: true },
+        dpopJkt: kmJkt2,
+        wallet: { type: 'external', address: 'GMOCK' },
+      }),
+    );
+    await storage.set(`pollar:${b.apiKeyHash}:walletType`, 'mockwallet');
+    b.destroy();
+    const c = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', walletAdapters: [adapter] });
+    await c.ready();
+    await waitFor(() => c.getAuthState().step === 'authenticated' && c.getAuthState().verified === true);
+    disconnects = 0;
+    await c.logout();
+    check('  (baseline) an owned external logout disconnects the adapter once', disconnects === 1, `disconnects=${disconnects}`);
     c.destroy();
   }
 

--- a/tests/smoke-resume.cjs
+++ b/tests/smoke-resume.cjs
@@ -153,6 +153,7 @@ let serverBoundJkt = null; // cnf.jkt bound at the last /auth/login
 let resumeMode = 'verify'; // 'verify' | 'revoked-403' | 'error-500'
 let resumeDelayMs = 0;
 let loginDelayMs = 0; // holds the /auth/login response so a logout can race it
+let logoutDelayMs = 0; // holds the /auth/logout response so a login can race the logout
 let resumeHits = 0; // every fetch hit on the resume path (nonce retries included)
 const resumeProofJkts = []; // jkt of each nonce-carrying resume proof
 
@@ -190,7 +191,10 @@ globalThis.fetch = async (req) => {
       },
     });
   }
-  if (p.endsWith('/auth/logout')) return json({ success: true });
+  if (p.endsWith('/auth/logout')) {
+    if (logoutDelayMs) await sleep(logoutDelayMs);
+    return json({ success: true });
+  }
   if (p.endsWith('/auth/session/resume')) {
     resumeHits++;
     if (resumeDelayMs) await sleep(resumeDelayMs);
@@ -264,8 +268,15 @@ function makeVisibility() {
     check('fresh client resumes to authenticated + verified', true);
     check('  resume proof thumbprint === token cnf.jkt', resumeProofJkts.at(-1) === serverBoundJkt);
     // One logical resume = nonce challenge + retried proof = exactly 2 hits.
-    check('  concurrent triggers coalesced into ONE resume (2 hits: challenge + retry)', resumeHits === 2, `hits=${resumeHits}`);
-    check('  keypair unchanged across the reload', (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === persistedJkt);
+    check(
+      '  concurrent triggers coalesced into ONE resume (2 hits: challenge + retry)',
+      resumeHits === 2,
+      `hits=${resumeHits}`,
+    );
+    check(
+      '  keypair unchanged across the reload',
+      (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === persistedJkt,
+    );
     resumeDelayMs = 0;
 
     console.log('\n── 2. A genuinely revoked session still clears ───────────────');
@@ -277,7 +288,10 @@ function makeVisibility() {
     check('revoked session converges to idle', c.getAuthState().step === 'idle');
     check('  session removed from storage', (await storage.get(`pollar:${c.apiKeyHash}:session`)) == null);
     console.log('\n── 5a. Failure-path clear does NOT rotate the keypair ────────');
-    check('keypair survives the revoked-session clear', (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === persistedJkt);
+    check(
+      'keypair survives the revoked-session clear',
+      (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === persistedJkt,
+    );
 
     console.log('\n── 5b. logout() DOES rotate the keypair ──────────────────────');
     resumeMode = 'verify';
@@ -322,11 +336,7 @@ function makeVisibility() {
       await waitFor(() => b.getAuthState().step === 'idle');
       check('doomed session is cleared locally (idle)', b.getAuthState().step === 'idle');
       check('  no resume round trip was attempted (dpopJkt precheck)', resumeHits === 0, `hits=${resumeHits}`);
-      check(
-        '  no phantom authenticated state was emitted',
-        !states.includes('authenticated'),
-        `states=${states.join(',')}`,
-      );
+      check('  no phantom authenticated state was emitted', !states.includes('authenticated'), `states=${states.join(',')}`);
       check('  session removed from storage', (await storage.get(`pollar:${b.apiKeyHash}:session`)) == null);
       b.destroy();
     } finally {
@@ -472,6 +482,131 @@ function makeVisibility() {
     } finally {
       crypto.subtle.exportKey = realExport;
     }
+  }
+
+  console.log('\n── 10. logout() does not destroy a session created during it ──');
+  {
+    // `logout()` awaits the server call, and consumers routinely do not await it
+    // (@pollar/react fires it from the login modal and the wallet button, then
+    // opens the login UI). A whole new login can land inside that window: the
+    // teardown must recognize it and leave it alone, or the user "logs in" and
+    // is thrown straight back out with the key that session was bound to gone.
+    const apiKey = 'pk_smoke_resume_logout_race';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+
+    logoutDelayMs = 150;
+    const pending = a.logout(); // deliberately NOT awaited
+    await sleep(10);
+    await login(a); // the user signs in again while the logout is still running
+    const jktAfterLogin = serverBoundJkt;
+    await pending;
+    await sleep(20);
+    logoutDelayMs = 0;
+
+    check('the session created during the logout survives', a.getAuthState().step === 'authenticated', a.getAuthState().step);
+    const row = await storage.get(`pollar:${a.apiKeyHash}:session`);
+    check('  its row is still in storage', row != null);
+    check(
+      '  the keypair it is bound to was not rotated away',
+      (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === jktAfterLogin,
+    );
+    check('  persisted dpopJkt still matches cnf.jkt', row != null && JSON.parse(row).dpopJkt === jktAfterLogin);
+    a.destroy();
+  }
+
+  console.log('\n── 11. logout() only rotates the key it still owns ────────────');
+  {
+    // The keypair record is shared per origin + API key, MORE shared than the
+    // session row. A client whose session was superseded must not destroy the
+    // key the current row's session is bound to.
+    const apiKey = 'pk_smoke_resume_logout_owner';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+    const sharedJkt = await new sdk.WebCryptoKeyManager(apiKey).getThumbprint();
+
+    // Another document logs in later and becomes the owner of the shared row.
+    const sessionKey = `pollar:${a.apiKeyHash}:session`;
+    const owned = JSON.parse(await storage.get(sessionKey));
+    owned.clientSessionId = 'cs_other_document';
+    await storage.set(sessionKey, JSON.stringify(owned));
+
+    await a.logout();
+    const after = await storage.get(sessionKey);
+    check(
+      'the row it no longer owns is left alone',
+      after != null && JSON.parse(after).clientSessionId === 'cs_other_document',
+    );
+    check(
+      '  and so is the keypair that row is bound to',
+      (await new sdk.WebCryptoKeyManager(apiKey).getThumbprint()) === sharedJkt,
+    );
+    a.destroy();
+  }
+
+  console.log('\n── 12. a logout propagates to siblings in the SAME document ───');
+  {
+    // Browsers never deliver `storage` events to the document that wrote the
+    // change, so a second instance in this one (React StrictMode double-invokes
+    // the useState initializer and leaves one behind, never destroyed) used to
+    // keep its session and re-persist the row after the other logged out.
+    const apiKey = 'pk_smoke_resume_siblings';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+    const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await b.ready();
+    await waitFor(() => b.getAuthState().step === 'authenticated');
+    check(
+      'both instances hold the session',
+      a.getAuthState().step === 'authenticated' && b.getAuthState().step === 'authenticated',
+    );
+
+    await a.logout();
+    await sleep(30);
+    check('  the sibling converges to idle', b.getAuthState().step === 'idle', b.getAuthState().step);
+    await b.refresh().catch(() => {});
+    await sleep(30);
+    check('  and does not re-persist the row', (await storage.get(`pollar:${b.apiKeyHash}:session`)) == null);
+    a.destroy();
+    b.destroy();
+  }
+
+  console.log('\n── 13. the DPoP nonce survives a page load ────────────────────');
+  {
+    // Every proof needs a server nonce, so without persistence the first
+    // authenticated request of EVERY page load is a guaranteed 401 challenge.
+    const apiKey = 'pk_smoke_resume_nonce';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    await login(a);
+    a.destroy();
+    // A login alone never signs a proof (its calls are pre-auth), so the first
+    // nonce arrives on the first RELOAD's resume: challenge + retry = 2 hits.
+    resumeHits = 0;
+    const b = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await b.ready();
+    await waitFor(() => b.getAuthState().verified === true);
+    check('first reload pays the challenge and learns a nonce', resumeHits === 2, `hits=${resumeHits}`);
+    check(
+      '  the nonce is persisted under the apiKeyHash namespace',
+      (await storage.get(`pollar:${b.apiKeyHash}:dpopNonce`)) === 'N1',
+    );
+    b.destroy();
+
+    // Every reload after that signs its first proof with the stored nonce.
+    resumeHits = 0;
+    const c = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await c.ready();
+    await waitFor(() => c.getAuthState().verified === true);
+    check('  the NEXT reload resumes in ONE hit (challenge skipped)', resumeHits === 1, `hits=${resumeHits}`);
+    c.destroy();
   }
 
   console.log(`\n${pass} pass, ${fail} fail`);

--- a/tests/smoke-resume.cjs
+++ b/tests/smoke-resume.cjs
@@ -706,7 +706,11 @@ function makeVisibility() {
     await waitFor(() => c.getAuthState().step === 'authenticated' && c.getAuthState().verified === true);
     disconnects = 0;
     await c.logout();
-    check('  (baseline) an owned external logout disconnects the adapter once', disconnects === 1, `disconnects=${disconnects}`);
+    check(
+      '  (baseline) an owned external logout disconnects the adapter once',
+      disconnects === 1,
+      `disconnects=${disconnects}`,
+    );
     c.destroy();
   }
 

--- a/tests/smoke-resume.cjs
+++ b/tests/smoke-resume.cjs
@@ -152,6 +152,7 @@ const b64uJson = (part) => JSON.parse(Buffer.from(part, 'base64url').toString('u
 let serverBoundJkt = null; // cnf.jkt bound at the last /auth/login
 let resumeMode = 'verify'; // 'verify' | 'revoked-403' | 'error-500'
 let resumeDelayMs = 0;
+let loginDelayMs = 0; // holds the /auth/login response so a logout can race it
 let resumeHits = 0; // every fetch hit on the resume path (nonce retries included)
 const resumeProofJkts = []; // jkt of each nonce-carrying resume proof
 
@@ -174,6 +175,7 @@ globalThis.fetch = async (req) => {
   if (p.endsWith('/auth/login')) {
     const body = await req.clone().json();
     serverBoundJkt = await calculateJwkThumbprint(body.dpopJwk, 'sha256');
+    if (loginDelayMs) await sleep(loginDelayMs);
     return json({
       code: 'SDK_LOGIN_SUCCESS',
       success: true,
@@ -394,6 +396,82 @@ function makeVisibility() {
     check('  the new session was not cleared from storage', (await storage.get(sessionKey)) != null);
     a.destroy();
     b.destroy();
+  }
+
+  console.log('\n── 7. logout() cancels an in-flight login (no resurrection) ───');
+  {
+    const apiKey = 'pk_smoke_resume_logoutrace';
+    const storage = sdk.createMemoryAdapter();
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test' });
+    await a.ready();
+    serverBoundJkt = null;
+    loginDelayMs = 300; // hold the /auth/login response so logout lands mid-flight
+    a.beginEmailLogin();
+    await waitFor(() => a.getAuthState().step === 'entering_email');
+    a.sendEmailCode('a@b.c');
+    await waitFor(() => a.getAuthState().step === 'entering_code');
+    a.verifyEmailCode('123456');
+    await waitFor(() => serverBoundJkt !== null); // the login POST reached the server
+    await a.logout(); // user logs out while the login response is still pending
+    await sleep(500); // let the held login response land
+    loginDelayMs = 0;
+    const sessionKey = `pollar:${a.apiKeyHash}:session`;
+    check('state stays idle after the login response lands', a.getAuthState().step === 'idle', a.getAuthState().step);
+    check('  no session row was resurrected in storage', (await storage.get(sessionKey)) == null);
+    a.destroy();
+  }
+
+  console.log('\n── 8. dpopJkt records the BOUND key, not the store-time key ───');
+  {
+    // A key manager whose getThumbprint LIES at store time models a rotation
+    // between the login's bind and its store. The persisted dpopJkt must come
+    // from the JWK actually sent to /auth/login (= cnf.jkt), not from this.
+    const apiKey = 'pk_smoke_resume_boundjkt';
+    const storage = sdk.createMemoryAdapter();
+    const real = new sdk.WebCryptoKeyManager(apiKey);
+    const lying = {
+      init: () => real.init(),
+      reset: () => real.reset(),
+      getPublicJwk: () => real.getPublicJwk(),
+      getThumbprint: async () => 'STORE-TIME-KEY-NOT-THE-BOUND-ONE',
+      sign: (payload) => real.sign(payload),
+    };
+    const a = new sdk.PollarClient({ apiKey, storage, baseUrl: 'https://x.test', keyManager: lying });
+    await a.ready();
+    await login(a);
+    const stored = JSON.parse(await storage.get(`pollar:${a.apiKeyHash}:session`));
+    check('persisted dpopJkt === server cnf.jkt (bound key wins)', stored.dpopJkt === serverBoundJkt, stored.dpopJkt);
+    a.destroy();
+  }
+
+  console.log('\n── 9. init() joins a half-built in-flight init ────────────────');
+  {
+    // _doInit assigns keyPair, THEN awaits the JWK export. Hold the export open
+    // and call getThumbprint() inside that window: it must join the in-flight
+    // init instead of early-returning into a half-built manager and throwing.
+    const realExport = crypto.subtle.exportKey.bind(crypto.subtle);
+    crypto.subtle.exportKey = async (...args) => {
+      await sleep(50);
+      return realExport(...args);
+    };
+    try {
+      const km = new sdk.WebCryptoKeyManager('pk_smoke_resume_halfinit');
+      const p1 = km.init();
+      const start = Date.now();
+      while (!km.keyPair && Date.now() - start < 2000) await sleep(1);
+      check('window is open (keyPair set, publicJwk pending)', !!km.keyPair && !km.publicJwk);
+      let thumb = null;
+      let threw = null;
+      try {
+        thumb = await km.getThumbprint();
+      } catch (e) {
+        threw = e.message;
+      }
+      check('getThumbprint during the window resolves (no half-built throw)', threw === null && !!thumb, threw);
+      await p1;
+    } finally {
+      crypto.subtle.exportKey = realExport;
+    }
   }
 
   console.log(`\n${pass} pass, ${fail} fail`);

--- a/tests/smoke-resume.cjs
+++ b/tests/smoke-resume.cjs
@@ -45,7 +45,10 @@ globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: 
 // Only the surface WebCryptoKeyManager touches: open/upgradeneeded, get/put/
 // delete, transaction `complete`/`abort` events (the durable-write path awaits
 // those), close. Values round-trip through structuredClone like real IDB.
-function makeIndexedDB() {
+// `readAs` makes every get hand back that value instead of what was stored -
+// it stands in for another tab overwriting the row between our write and our
+// read-back, which no single-threaded shim can produce on its own.
+function makeIndexedDB({ readAs } = {}) {
   const dbs = new Map();
   const fire = (t, type) => {
     const h = t['on' + type];
@@ -86,7 +89,11 @@ function makeIndexedDB() {
                 return r;
               };
               return {
-                get: (k) => wrap(() => (store.get(k) === undefined ? undefined : structuredClone(store.get(k)))),
+                get: (k) =>
+                  wrap(() => {
+                    if (readAs !== undefined) return readAs;
+                    return store.get(k) === undefined ? undefined : structuredClone(store.get(k));
+                  }),
                 put: (v, k) => wrap(() => (store.set(k, structuredClone(v)), k)),
                 delete: (k) => wrap(() => (store.delete(k), undefined)),
               };
@@ -348,6 +355,30 @@ function makeVisibility() {
       check('  no phantom authenticated state was emitted', !states.includes('authenticated'), `states=${states.join(',')}`);
       check('  session removed from storage', (await storage.get(`pollar:${b.apiKeyHash}:session`)) == null);
       b.destroy();
+    } finally {
+      globalThis.indexedDB = savedIdb;
+    }
+  }
+
+  console.log('\n── 3b. ensurePersisted() only trusts OUR key ──────────────────');
+  {
+    const apiKey = 'pk_smoke_resume_foreignkey';
+    const savedIdb = globalThis.indexedDB;
+    try {
+      globalThis.indexedDB = makeIndexedDB();
+      const km = new sdk.WebCryptoKeyManager(apiKey);
+      await km.init();
+      check('a freshly persisted keypair reads back as ours', (await km.ensurePersisted()) === true);
+
+      // Another tab rotated the shared row between our put and our get. A shape
+      // check accepts it, login binds the in-memory key, and the next reload
+      // adopts the other one - the thumbprint-mismatch logout, back again.
+      const foreign = await globalThis.crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, false, [
+        'sign',
+        'verify',
+      ]);
+      globalThis.indexedDB = makeIndexedDB({ readAs: foreign });
+      check("  a stored keypair that isn't ours is reported as not persisted", (await km.ensurePersisted()) === false);
     } finally {
       globalThis.indexedDB = savedIdb;
     }


### PR DESCRIPTION
## Summary

Release branch for `@pollar/core@0.11.3` and `@pollar/react@0.11.3`, a patch release centered on making the session lifecycle survive hostile-but-real conditions: storage that fails to persist, reloads, logout races, StrictMode double-rendering, and duplicate copies of core in one dependency tree. It also carries the ramp-widget UX and normalized deposit-instructions work that landed before the release was cut.

## `@pollar/core`: session resilience

- **Sessions survive reloads when the DPoP keypair fails to persist.** The persisted session records the thumbprint of the key its tokens are bound to (`dpopJkt`); a mismatch on restore is detected locally and logged with the real cause instead of producing a 401 burst and a silent logout, and clearing a session no longer destroys the (valid) keypair.
- **`logout()` hardening.** It cancels a login still in flight (no resurrected sessions bound to a destroyed key), never destroys a session created while it runs, rotates the keypair only when it still owns the teardown, and propagates to sibling clients in the same document; sibling notifications are isolated from the teardown that triggers them, so a throwing consumer log sink can no longer strand a client in `authenticated` with its session gone.
- **Cross-tab and cross-document hardening.** Shared session-row writes are serialized and ownership-gated (ownership by session history, so a logout racing a login-over-login cannot leave a stale row behind), the `storage` handler ignores events that are not ours, and unreadable session rows are preserved rather than deleted.
- The last server-issued `DPoP-Nonce` is persisted; `init()` no longer early-returns into a half-built key manager.
- **New public API:** `setPasskeyDefaults()`, `isPollarClient(value)` (a brand-based type guard that recognizes a client across duplicate copies of core, where `instanceof` cannot), `PollarApiError` (ramp failures keep the server's `details` and body), three ramp methods (`getRampLiquidity`, `getRampKycStatus`, `decodePixQr`) and the exported types `RampDepositInstructions` / `RampScannable` / `RampInstructionField`.

## `@pollar/react`

- A consumer-built `PollarClient` passed to `PollarProvider` keeps passkey support: the ceremony is installed on every path, an explicit `passkey: undefined` no longer wipes the default, and `browserPasskeyCeremony` / `browserPasskeySigner` are exported.
- StrictMode no longer leaves an orphaned client running whose refresh loop could clear the session a real login just wrote (dev only).
- The provider discriminates clients with `isPollarClient()` instead of `instanceof`.
- Type-level removal: `WalletButtonTemplateProps.walletType` (never rendered by the template; reconstruction snippet in UPGRADE.md).

## Ramp widget and deposit instructions (pre-cut work)

- The widget consumes the server's normalized deposit instructions: one shape for every provider, no client-side translation left, QR delivered by the server (inline markup for Pollar's own, `<img>` for provider bitmaps). A custom ramp template must adopt the normalized shape; this is the commit marked breaking in the range.
- Ramp UX: a link-less KYC gate (withdraw withheld with the reason stated, status polled), pre-submit amount checks against the route's `minAmount`/`maxAmount` with the warning in the route list, Back on `select_route`, per-route starting spinner, optional fields with per-kind placeholders and hints.
- Modal chrome configurable from Branding: one helper (`buildModalCssVars()` / `modalChrome()`) replaces a block copy-pasted into 14 templates; the primary button's label color follows the accent's luminance.

## Packaging

- `@pollar/core` is now a **peer dependency only** of `@pollar/react` and the four wallet adapters; the old `dependencies` entry is what installed the duplicate copy that broke `instanceof` and split the live-client registry. npm 7+ needs nothing; npm 6 / Yarn 1 / `--legacy-peer-deps` must add core directly.
- The workspace root is now `"private": true`.

## Tests, CI and docs

- Five new smoke suites (resume, lifecycle, invariants, cross-document semantics, react/provider) plus an ASCII comment-style guard, wired into `npm run test:smoke`; each new suite was verified to fail against the code that predates its fix. Full suite green (274 checks).
- CHANGELOG 0.11.3 section (session, passkey, ramps and packaging), `0.11.2 -> 0.11.3` UPGRADE entry, README headlines refreshed; comment-accuracy and prettier passes.

## Notes for reviewers

- The four adapters carry the peer-only change in-repo but remain at 0.11.2; whether they bump and publish with this release is still open.
- npm state: `latest` is still 0.11.2; 0.11.3 final publishes after this merge.
