### PR TITLE
feat(auth): support external identity wallet adapters

### DIFF
--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -604,6 +604,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/external/identity/challenge": {
+        parameters: { query?: never; header?: never; path?: never; cookie?: never };
+        get?: never;
+        put?: never;
+        post: operations["postAuthExternalIdentityChallenge"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/external/identity": {
+        parameters: { query?: never; header?: never; path?: never; cookie?: never };
+        get?: never;
+        put?: never;
+        post: operations["postAuthExternalIdentity"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/passkey/challenge": {
         parameters: {
             query?: never;
@@ -4399,6 +4421,57 @@ export interface operations {
                         code: string;
                         message?: string;
                         resultCode?: string;
+                    };
+                };
+            };
+        };
+    };
+    postAuthExternalIdentityChallenge: {
+        parameters: { query?: never; header?: never; path?: never; cookie?: never };
+        requestBody: {
+            content: {
+                "application/json": { clientSessionId: string; provider: "turnkey" };
+            };
+        };
+        responses: {
+            200: {
+                headers: { [name: string]: unknown };
+                content: {
+                    "application/json": {
+                        code: "SDK_WALLET_CHALLENGE_CREATED";
+                        success: true;
+                        content: { clientSessionId: string; challenge: string };
+                    };
+                };
+            };
+        };
+    };
+    postAuthExternalIdentity: {
+        parameters: { query?: never; header?: never; path?: never; cookie?: never };
+        requestBody: {
+            content: {
+                "application/json": {
+                    clientSessionId: string;
+                    provider: "turnkey";
+                    walletAddress: string;
+                    sessionToken: string;
+                    challengeSignature: string;
+                    accountRequest: {
+                        body: string;
+                        stampHeaderName: "X-Stamp";
+                        stampHeaderValue: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            200: {
+                headers: { [name: string]: unknown };
+                content: {
+                    "application/json": {
+                        code: "SDK_EXTERNAL_AUTHENTICATED";
+                        success: true;
+                        content: { clientSessionId: string; walletAddress: string; provider: string };
                     };
                 };
             };

--- a/packages/core/src/client/auth/walletFlow.ts
+++ b/packages/core/src/client/auth/walletFlow.ts
@@ -1,6 +1,6 @@
 import { abortError } from '../../lib/abort';
 import { AUTH_ERROR_CODES } from '../../types';
-import { WalletAdapter } from '../../wallets';
+import { isExternalIdentityAuthAdapter, WalletAdapter } from '../../wallets';
 import { authenticate } from './authenticate';
 import { createAuthSession, FlowDeps } from './deps';
 import { logApiError } from './logging';
@@ -81,6 +81,44 @@ export async function loginWithAdapter(adapter: WalletAdapter, deps: FlowDeps): 
 
     const { address } = await withSignal(adapter.connect(), signal);
     connectedWallet = address;
+
+    // Identity-backed adapters (Turnkey today) prove their provider session and
+    // its access to the wallet account. This deliberately bypasses SEP-10 so an
+    // ordinary login never invokes the wallet's on-chain Ed25519 signing key.
+    if (isExternalIdentityAuthAdapter(adapter)) {
+      currentStep = 'authenticating_wallet';
+      setAuthState({ step: 'authenticating_wallet' });
+
+      const challengeBody = { clientSessionId, provider: adapter.identityProvider };
+      const { data: challengeData, error: challengeError } = await api.POST('/auth/external/identity/challenge', {
+        body: challengeBody,
+        signal,
+      });
+      if (challengeError || !challengeData?.success) {
+        if (!challengeError) logApiError(logger, 'POST /auth/external/identity/challenge', { data: challengeData });
+        throw new Error('Failed to obtain an external identity challenge');
+      }
+
+      const proof = await withSignal(adapter.getIdentityAuthProof(challengeData.content.challenge), signal);
+      const identityBody = {
+        clientSessionId,
+        provider: adapter.identityProvider,
+        walletAddress: address,
+        ...proof,
+      };
+      const { data: identityData, error: identityError } = await api.POST('/auth/external/identity', {
+        body: identityBody,
+        signal,
+      });
+      if (identityError || !identityData?.success) {
+        if (!identityError) logApiError(logger, 'POST /auth/external/identity', { data: identityData });
+        throw new Error('External identity authentication failed');
+      }
+
+      await deps.storeWalletAdapter(adapter, type);
+      await authenticate(clientSessionId, deps, connectedWallet);
+      return;
+    }
 
     // SEP-10 challenge-response: prove control of the wallet key. Get a
     // server-signed challenge tx, have the wallet counter-sign it, and send the

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -23,7 +23,13 @@ export { computeJwkThumbprint, canonicalEcJwk } from './keys/thumbprint';
 export { buildProof, normalizeHtu } from './dpop';
 export type { BuildProofArgs } from './dpop';
 
-export { FreighterAdapter, AlbedoAdapter, WalletType, isInteractiveAuthAdapter } from './wallets';
+export {
+  FreighterAdapter,
+  AlbedoAdapter,
+  WalletType,
+  isExternalIdentityAuthAdapter,
+  isInteractiveAuthAdapter,
+} from './wallets';
 export type {
   WalletAdapter,
   WalletAdapterMeta,
@@ -41,6 +47,8 @@ export type {
   AuthOption,
   InteractiveAuthAdapter,
   ProviderAuthState,
+  ExternalIdentityAuthAdapter,
+  ExternalIdentityAuthProof,
 } from './wallets';
 export type * from './types';
 export { AUTH_ERROR_CODES, PollarNetworkError, isPollarNetworkError, PollarApiError, isPollarApiError } from './types';

--- a/packages/core/src/wallets/index.ts
+++ b/packages/core/src/wallets/index.ts
@@ -1,6 +1,6 @@
 export { FreighterAdapter } from './FreighterAdapter';
 export { AlbedoAdapter } from './AlbedoAdapter';
-export { WalletType, isInteractiveAuthAdapter } from './types';
+export { WalletType, isExternalIdentityAuthAdapter, isInteractiveAuthAdapter } from './types';
 export type {
   WalletAdapter,
   WalletAdapterMeta,
@@ -18,4 +18,6 @@ export type {
   AuthOption,
   InteractiveAuthAdapter,
   ProviderAuthState,
+  ExternalIdentityAuthAdapter,
+  ExternalIdentityAuthProof,
 } from './types';

--- a/packages/core/src/wallets/types.ts
+++ b/packages/core/src/wallets/types.ts
@@ -66,6 +66,17 @@ export interface SignMessageResponse {
   signerAddress?: string;
 }
 
+/** A provider-authenticated proof that does not use the on-chain wallet key. */
+export interface ExternalIdentityAuthProof {
+  sessionToken: string;
+  challengeSignature: string;
+  accountRequest: {
+    body: string;
+    stampHeaderName: 'X-Stamp';
+    stampHeaderValue: string;
+  };
+}
+
 // --- Solana (SIWS) ------------------------------------------------------------
 // Structural mirror of the Wallet Standard's `solana:signIn` IO, kept here so
 // `@pollar/core` types the Solana adapter contract WITHOUT depending on
@@ -123,8 +134,10 @@ export interface WalletAdapterMeta {
 /**
  * A client-side wallet integration: it does its own auth/connect (Freighter
  * approve, Privy modal, SWK picker...) and signs. `@pollar/core` treats it as a
- * black box - it wraps the generic SEP-10 login + tx signing around `connect()`
- * and `signTransaction()`. Register instances via `PollarClientConfig.walletAdapters`.
+ * black box. By default Core wraps Stellar adapters in its SEP-10 login flow;
+ * identity-backed adapters can instead expose `identityProvider` and
+ * `getIdentityAuthProof()` to prove the provider session without signing a
+ * Stellar transaction. Register instances via `PollarClientConfig.walletAdapters`.
  */
 export interface WalletAdapter {
   /** Stable id - matches `login({ provider: id })` and the server-side wallet provider. */
@@ -136,14 +149,23 @@ export interface WalletAdapter {
   /**
    * Which chain this adapter authenticates and signs on. Absent means `'STELLAR'`,
    * so every existing Stellar adapter keeps working unchanged. The login dispatch
-   * branches on this: STELLAR runs the SEP-10 challenge flow, SOLANA runs SIWS.
+   * branches on this: STELLAR normally runs SEP-10 (unless the adapter exposes
+   * identity auth), while SOLANA runs SIWS.
    */
   chain?: WalletChain;
+  /** Provider id used by an optional identity-backed login capability. */
+  readonly identityProvider?: 'turnkey';
   isAvailable(): Promise<boolean>;
   connect(): Promise<ConnectWalletResponse>;
   disconnect(): Promise<void>;
   getPublicKey(): Promise<string | null>;
-  // --- Stellar signing (SEP-10 login + Soroban) ------------------------------
+  /**
+   * Optional identity-backed login. Core uses this instead of SEP-10 when it is
+   * present: Pollar supplies a one-time challenge and the adapter returns a
+   * provider session proof plus a provider-authorized wallet-account query.
+   */
+  getIdentityAuthProof?(challenge: string): Promise<ExternalIdentityAuthProof>;
+  // --- Stellar signing (SEP-10 login when needed + Soroban) ------------------
   // Optional because non-Stellar adapters do not implement them. The Stellar
   // flows assert their presence (a STELLAR adapter that omits them is a bug).
   signTransaction?(xdr: string, options?: SignTransactionOptions): Promise<SignTransactionResponse>;
@@ -164,6 +186,17 @@ export interface WalletAdapter {
   signSolanaTransaction?(transaction: Uint8Array, chain?: string): Promise<Uint8Array>;
 }
 
+export interface ExternalIdentityAuthAdapter extends WalletAdapter {
+  readonly identityProvider: 'turnkey';
+  getIdentityAuthProof(challenge: string): Promise<ExternalIdentityAuthProof>;
+}
+
+export function isExternalIdentityAuthAdapter(
+  adapter: WalletAdapter | null | undefined,
+): adapter is ExternalIdentityAuthAdapter {
+  return !!adapter && adapter.identityProvider === 'turnkey' && typeof adapter.getIdentityAuthProof === 'function';
+}
+
 /** A single login option an {@link InteractiveAuthAdapter} can render. */
 export type AuthOption = 'email' | 'google' | 'github';
 
@@ -173,9 +206,10 @@ export type AuthOption = 'email' | 'google' | 'github';
  * sub-modal, instead of the adapter being an opaque `connect()` black box.
  *
  * The UI calls these methods to run the provider login; once they resolve, it
- * triggers the normal `login({ provider })` so `connect()` runs and core does the
- * SEP-10 flow against the now-authenticated wallet. An adapter that implements
- * this (e.g. `@pollar/privy-adapter`) is detected via {@link isInteractiveAuthAdapter}.
+ * triggers the normal `login({ provider })` so `connect()` runs. Core then uses
+ * the adapter's identity-proof capability when present; otherwise Stellar falls
+ * back to SEP-10. An adapter that implements this UI capability (e.g.
+ * `@pollar/privy-adapter`) is detected via {@link isInteractiveAuthAdapter}.
  */
 export interface InteractiveAuthAdapter extends WalletAdapter {
   /** Login options to render, in order. */

--- a/tests/smoke-providers.cjs
+++ b/tests/smoke-providers.cjs
@@ -69,6 +69,12 @@ async function waitFor(cond, timeoutMs = 1000) {
     if (url.includes('/auth/wallet')) {
       return new Response(JSON.stringify({ success: true, content: {} }), { status: 200 });
     }
+    if (url.includes('/auth/external/identity/challenge')) {
+      return new Response(JSON.stringify({ success: true, content: { challenge: 'nonce_test' } }), { status: 200 });
+    }
+    if (url.includes('/auth/external/identity')) {
+      return new Response(JSON.stringify({ success: true, content: {} }), { status: 200 });
+    }
     if (url.includes('/auth/email/verify-code') && nextVerifyCode) {
       const code = nextVerifyCode;
       nextVerifyCode = null;
@@ -399,7 +405,55 @@ async function waitFor(cond, timeoutMs = 1000) {
     walletChallengeXdr = null;
   }
 
-  console.log('\n── 14. request-body OTP `code` is masked in logs (redactBody) ──');
+  console.log('\n── 14. identity-backed adapter bypasses SEP-10 ───────────────');
+  {
+    let proofChallenge = null;
+    let signTransactionCalls = 0;
+    const adapter = {
+      type: 'turnkey-test',
+      meta: { label: 'Turnkey Test' },
+      identityProvider: 'turnkey',
+      isAvailable: async () => true,
+      connect: async () => ({ address: 'Gturnkey' }),
+      getPublicKey: async () => 'Gturnkey',
+      getIdentityAuthProof: async (challenge) => {
+        proofChallenge = challenge;
+        return {
+          sessionToken: 'turnkey.jwt',
+          challenge,
+          challengeSignature: 'a'.repeat(128),
+          accountRequest: {
+            body: JSON.stringify({ organizationId: 'org', walletId: 'wallet', address: 'Gturnkey' }),
+            stamp: 'turnkey-stamp',
+          },
+        };
+      },
+      signTransaction: async () => {
+        signTransactionCalls++;
+        return { signedTxXdr: 'SHOULD_NOT_BE_CALLED' };
+      },
+      signAuthEntry: async () => ({ signedAuthEntry: 'x' }),
+    };
+    const c = new sdk.PollarClient({
+      apiKey: 'pk_identity',
+      storage: sdk.createMemoryAdapter(),
+      baseUrl: 'https://x.test',
+      logLevel: 'silent',
+      walletAdapters: [adapter],
+    });
+    await c.ready();
+    calls.length = 0;
+    c.login({ provider: 'turnkey-test' });
+    await waitFor(() => calls.some((x) => x.url.includes('/auth/external/identity') && !x.url.includes('/challenge')));
+    check('Core requested the one-time identity challenge', calls.some((x) => x.url.includes('/auth/external/identity/challenge')));
+    check('  adapter received the server nonce', proofChallenge === 'nonce_test', proofChallenge);
+    check('  Core submitted the identity proof', calls.some((x) => x.url.includes('/auth/external/identity') && !x.url.includes('/challenge')));
+    check('  no SEP-10 challenge was requested', !calls.some((x) => x.url.includes('/auth/wallet/challenge')));
+    check('  no Stellar transaction was signed during login', signTransactionCalls === 0, signTransactionCalls);
+    c.destroy();
+  }
+
+  console.log('\n── 15. request-body OTP `code` is masked in logs (redactBody) ──');
   {
     const logs = [];
     const spyLogger = { error: (...a) => logs.push(a), warn() {}, info() {}, debug() {} };


### PR DESCRIPTION
## Summary

Adds a generic external-identity authentication capability to Pollar Core. Identity-backed wallet adapters such as Turnkey can prove their provider session and wallet access without signing a Stellar SEP-10 challenge during every login.

This PR targets `0.11.3` because the feature branch was built and validated on top of that release branch.

## What changed

- Adds the `ExternalIdentityAuthProof` and `ExternalIdentityAuthAdapter` contracts.
- Adds the `isExternalIdentityAuthAdapter` capability guard.
- Allows an adapter to declare `identityProvider: "turnkey"` and implement `getIdentityAuthProof(challenge)`.
- Updates the wallet login flow to request a one-time challenge from Platform.
- Submits the adapter proof to Platform and completes authentication without SEP-10.
- Preserves the existing SEP-10 flow for normal Stellar adapters.
- Preserves SIWS behavior for Solana adapters.
- Exports the new contracts through the public Core API.
- Adds the new Platform routes to the generated API typings.

## Authentication flow

1. Core connects the wallet adapter.
2. If the adapter exposes external identity auth, Core calls `POST /auth/external/identity/challenge`.
3. Core passes the returned nonce to `adapter.getIdentityAuthProof(challenge)`.
4. The adapter returns its provider session proof and provider-authorized wallet-account request.
5. Core calls `POST /auth/external/identity`.
6. Platform verifies the proof and marks the Pollar session ready.
7. Core skips `/auth/wallet/challenge` and never calls `signTransaction` during login.

Adapters without this capability continue through the existing SEP-10 path unchanged.

## Why

Turnkey login already establishes a short-lived P-256 session. Requiring that user to additionally sign SEP-10 with the wallet Ed25519 key consumes a remote signing activity merely to log in. The external identity contract lets Platform verify the provider session and wallet relationship while keeping Ed25519 signing reserved for real Stellar transactions.

## Validation

- `npm run lint --workspace=@pollar/core` (0 errors; existing warnings only)
- `npm run build --workspace=@pollar/core`
- `node tests/smoke-providers.cjs`
- 38/38 provider smoke checks passed
- Verified that identity login calls the challenge and identity endpoints
- Verified that identity login does not call `/auth/wallet/challenge`
- Verified that identity login does not call `signTransaction`
- Manually validated end-to-end with the local Demo and Platform

## Related PRs

- Platform verification: https://github.com/pollar-xyz/pollar-platform/pull/3
- Turnkey Demo adapter: https://github.com/pollar-xyz/demo/pull/1
