### PR TITLE
docs: wording improvements across READMEs, skills and API descriptions

### DIFF
--- a/.github/workflows/skills-changed.yml
+++ b/.github/workflows/skills-changed.yml
@@ -1,0 +1,56 @@
+name: Skills changed
+
+# Recordatorio, no automatizacion. pollar-web espeja skills/ hacia
+# pollar.xyz/.well-known/agent-skills/ con un cron diario, asi que un cambio
+# aqui tarda hasta un dia en publicarse. Este job avisa en el momento para
+# poder adelantarlo a mano si el cambio es urgente.
+#
+# Solo main: el trabajo aterriza primero en una rama de release (0.*) y el
+# espejo lee main, asi que avisar antes del merge seria avisar de algo que
+# todavia no se puede publicar.
+#
+# No dispara el sync directamente porque cruzar de repo necesita un PAT con
+# permiso de dispatch, y un token de larga vida no vale la pena para ahorrar
+# unas horas de desfase.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+
+permissions:
+  contents: read
+
+jobs:
+  remind:
+    name: remind to publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Announce what changed and how to publish it
+        env:
+          RUN_SYNC: https://github.com/pollar-xyz/pollar-web/actions/workflows/sync-llms.yml
+        run: |
+          changed="$(git diff --name-only HEAD^ HEAD -- skills/ || true)"
+          {
+            echo '## Skills changed'
+            echo
+            echo 'These files changed under `skills/`:'
+            echo
+            echo '```'
+            echo "${changed:-(could not diff, see the commit)}"
+            echo '```'
+            echo
+            echo "pollar.xyz mirrors them on a daily cron, so this reaches"
+            echo "<https://pollar.xyz/.well-known/agent-skills/index.json> within 24h."
+            echo
+            echo "To publish now, run **Sync mirrored content** in pollar-web:"
+            echo "$RUN_SYNC"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::notice title=Skills changed::Mirrored to pollar.xyz within 24h. To publish now, run 'Sync mirrored content' in pollar-web: $RUN_SYNC"

--- a/.github/workflows/skills-changed.yml
+++ b/.github/workflows/skills-changed.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Announce what changed and how to publish it
         env:
           RUN_SYNC: https://github.com/pollar-xyz/pollar-web/actions/workflows/sync-llms.yml
         run: |
-          changed="$(git diff --name-only HEAD^ HEAD -- skills/ || true)"
+          changed="$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- skills/ || true)"
           {
             echo '## Skills changed'
             echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1067,7 +1067,7 @@ network?, deployTxHash? }`. `address` is the on-chain address for every type
 
 - **Login no longer clears the session on every embedded (email/OAuth) login.**
   `authenticate()` validates the raw `/auth/login` wire response with
-  `isValidSession()` **before** `_storeSession` remaps `embedded → internal`,
+  `isValidSession()` **before** `_storeSession` remaps `custodial → internal`,
   so the transitional wire value `'custodial'` is tolerated at the guard and the
   flow no longer falls through to the error branch → `clearSession()`
   (`[PollarClient] Session cleared`). Callers still remap it before it reaches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,7 +398,7 @@
 > Stable release. Published under the default `latest` dist-tag
 > (`npm i @pollar/core`). Headline: **Stellar ownership proofs** — the new
 > `client.stellar` namespace signs SEP-53 messages and SEP-10 challenges across
-> custodial and external wallets — and the **Transaction History modal goes
+> embedded and external wallets — and the **Transaction History modal goes
 > multichain**. Additive, non-breaking on top of 0.11.1.
 
 ### Highlights (since 0.11.1)
@@ -406,10 +406,10 @@
 - **`client.stellar` — SEP ownership proofs.** `sep53.signMessage(message)` and
   `sep10.sign({ challengeXdr, ... })` prove wallet ownership to a verifier. Each
   dispatches by wallet type: external wallets sign client-side via their
-  adapter, custodial wallets sign server-side through sdk-api, and smart
+  adapter, embedded wallets sign server-side through sdk-api, and smart
   (passkey) wallets are rejected with a clear error (no classic ed25519 key).
   Both paths return the same `sep53` scheme (base64 signature + signer address),
-  so external and custodial proofs are interchangeable for a verifier.
+  so external and embedded proofs are interchangeable for a verifier.
 - **Multichain Transaction History modal.** The History modal gains the network
   picker and address chip the Balance / Send modals already have, per-chain
   explorer links, and the unified `{ amount, unit }` fee.
@@ -424,15 +424,15 @@
     wallets sign through the new **optional `signStellarMessage`** on the
     `WalletAdapter` interface (Freighter implements it via the v6 native
     `signMessage`; Albedo throws — its `sign_message` intent cannot produce a
-    SEP-53 signature). Custodial wallets post to `/v2/stellar/sep53/sign`. The
+    SEP-53 signature). Embedded wallets post to `/v2/stellar/sep53/sign`. The
     signature is base64 ed25519 over the SEP-53 digest
     (`SHA-256("Stellar Signed Message:\n" + message)`) on every path.
   - `sep10.sign({ challengeXdr, homeDomains?, webAuthDomain? })` — SEP-10
     challenge ownership proof. External wallets reuse the adapter's existing
-    `signTransaction`; custodial wallets post to `/v2/stellar/sep10/sign`,
+    `signTransaction`; embedded wallets post to `/v2/stellar/sep10/sign`,
     which reuses the audited sign-sep10-challenge path (validates the challenge
     is un-submittable). Passing the verifier domains enables full SEP-10
-    validation on the custodial path.
+    validation on the embedded path.
 - New exported types: `StellarSepApi`, `StellarMessageProof`, `Sep10SignParams`,
   `Sep10Proof`, `SignMessageOptions`, `SignMessageResponse`.
 - `@stellar/freighter-api` bumped `2.0.0` → `6.0.0` and `FreighterAdapter`
@@ -490,7 +490,7 @@
 
 > Stable release. Published under the default `latest` dist-tag
 > (`npm i @pollar/core`). Headline: the per-chain wallet rework plus **Solana
-> custodial wallets can send** — the atomic tx endpoint went multichain and the
+> embedded wallets can send** — the atomic tx endpoint went multichain and the
 > Send / Receive modals gained the network picker the balance and asset modals
 > already had.
 
@@ -507,7 +507,7 @@
   "unavailable" from "zero". `WalletBalanceRecord.balance` is therefore
   `string | null`.
 - **Send on Stellar and Solana.** `sendPayment()` is one entry point across
-  chains; Solana custodial sends land through the multichain atomic endpoint, and
+  chains; Solana embedded sends land through the multichain atomic endpoint, and
   the Send / Receive modals carry the network picker. Polygon is browse-only: it
   has no transfer path yet, so the Send modal blocks it and `sendPayment()`
   returns an error for it.
@@ -554,7 +554,7 @@
   Solana. Stellar routes through `buildAndSignAndSubmitTx`, so external adapters
   and passkey wallets keep the split build → sign → submit flow; chains whose
   signature expires (a Solana blockhash lapses in ~60s) do the whole thing in
-  one server-side call and are **custodial-only** for now. An `idempotencyKey`
+  one server-side call and are **embedded-only** for now. An `idempotencyKey`
   is minted per call, because a Solana submit is a single non-idempotent shot
   and a transport retry would otherwise transfer twice. `SendPaymentParams`
   carries a `POLYGON` member for the shape, but there is no transfer path for it
@@ -567,7 +567,7 @@
   cannot represent the value at all. More fractional digits than the asset has
   is an error, not a silent truncation, which would send less than was typed.
 - `setTrustline` no longer takes a `sponsored` opt-in flag. The app config
-  decides who pays server-side: custodial wallets hit `POST /wallet/assets/trustline`
+  decides who pays server-side: embedded wallets hit `POST /wallet/assets/trustline`
   (the server sponsors or self-pays, then submits), external wallets hit
   `/wallet/assets/trustline/build` and co-sign whichever XDR comes back
   (`sponsorSignedXdr` or a plain `unsignedXdr`). Pass `skipSponsorship` to force
@@ -741,7 +741,7 @@
   XDR server-side, then sign + submit through the `runTx` state machine. Smart
   (passkey) wallets fail fast for now.
 - **`createAccount()`** creates an external wallet's classic account on-chain via a
-  sponsored `createAccount`; not applicable to custodial (server-created) or smart
+  sponsored `createAccount`; not applicable to embedded (server-created) or smart
   (C-address) wallets.
 - **`existsOnStellar` + `fundingMode` surfaced on the wallet.**
 - **All swap builds executable.** `swap()` dispatches on the quote build union
@@ -991,7 +991,7 @@
 - **External-wallet signing** — SEP-10 challenges are validated before signing
   (including via custom providers); `signAuthEntry` signs on the currently
   configured network; smart-wallet sessions return an explicit error instead of
-  hitting the custodial endpoint.
+  hitting the embedded endpoint.
 - **Secret redaction** — request/response bodies and error logs no longer print
   access/refresh tokens, the DPoP key, OTPs, or signed XDRs (while keeping
   diagnostic error `code`s).
@@ -1065,9 +1065,9 @@ network?, deployTxHash? }`. `address` is the on-chain address for every type
 
 ### `@pollar/core` — fixes
 
-- **Login no longer clears the session on every custodial (email/OAuth) login.**
+- **Login no longer clears the session on every embedded (email/OAuth) login.**
   `authenticate()` validates the raw `/auth/login` wire response with
-  `isValidSession()` **before** `_storeSession` remaps `custodial → internal`,
+  `isValidSession()` **before** `_storeSession` remaps `embedded → internal`,
   so the transitional wire value `'custodial'` is tolerated at the guard and the
   flow no longer falls through to the error branch → `clearSession()`
   (`[PollarClient] Session cleared`). Callers still remap it before it reaches
@@ -1434,7 +1434,7 @@ const client = new PollarClient({ apiKey, walletAdapter });
 ### `@pollar/core` — BREAKING (behavior)
 
 - **`submitTx` always routes through `/tx/submit`.** External wallets no longer
-  submit directly to the public RPC; both custodial and external paths now go
+  submit directly to the public RPC; both embedded and external paths now go
   through sdk-api. Wins:
   - end-to-end `tx_records` persistence with full phase lifecycle so the
     developer dashboard can show every tx at
@@ -1494,7 +1494,7 @@ const client = new PollarClient({ apiKey, walletAdapter });
 Adds a per-call outcome API so headless callers can `await` a transaction and
 inspect the result instead of subscribing to `onTransactionStateChange`. Adds
 split `signTx` / `submitTx` for both wallet types, a one-shot atomic path
-for custodial flows, and a richer `TransactionState` vocabulary so modal UIs
+for embedded flows, and a richer `TransactionState` vocabulary so modal UIs
 can render every phase honestly (including the previously-elided "submitted
 to network, waiting for ledger" intermediate state). Existing `0.7.x`
 consumers that don't render `TransactionState` themselves keep working
@@ -1512,14 +1512,14 @@ unchanged.
 - **`signTx(unsignedXdr)`** and **`submitTx(signedXdr, { submissionToken? })`** —
   split-flow primitives that return `SignOutcome` / `SubmitOutcome`. External
   wallets sign locally via the adapter and submit directly to Stellar RPC.
-  Custodial wallets go through new sdk-api endpoints (`/tx/sign`,
+  Embedded wallets go through new sdk-api endpoints (`/tx/sign`,
   `/tx/submit`) so the wallet-service tracks the lifecycle and enforces
   idempotency by `submissionToken` (mapped to `idempotencyKey` server-side).
 - **`buildAndSignAndSubmitTx(operation, params, options?)`** and its alias
   **`runTx(...)`** — one method that picks the optimal path per wallet type:
   - External wallets: composes `buildTx + signAndSubmitTx` client-side,
     preserving `building → signing → success` state-machine transitions.
-  - Custodial wallets: single round-trip to `/tx/build-sign-submit`. The
+  - Embedded wallets: single round-trip to `/tx/build-sign-submit`. The
     signed XDR never leaves the backend. Skips intermediate state-machine
     transitions — if you need granular UI feedback, use `buildTx`, `signTx`,
     `submitTx` separately instead.
@@ -1549,8 +1549,8 @@ The `TransactionState` discriminated union grew from 6 step values to 11:
 - `signed` — signed XDR in hand, waiting for `submitTx`
 - `submitting` — pushing signed XDR to the network
 - `submitted` — Horizon ack received, ledger confirmation pending (previously misreported as `success`)
-- `signing-submitting` — compound state for `signAndSubmitTx` custodial (atomic `/tx/sign-and-send` round-trip — the SDK can't observe the sign/submit boundary inside)
-- `building-signing-submitting` — compound state for `runTx` / `buildAndSignAndSubmitTx` custodial (atomic `/tx/build-sign-submit` round-trip)
+- `signing-submitting` — compound state for `signAndSubmitTx` embedded (atomic `/tx/sign-and-send` round-trip — the SDK can't observe the sign/submit boundary inside)
+- `building-signing-submitting` — compound state for `runTx` / `buildAndSignAndSubmitTx` embedded (atomic `/tx/build-sign-submit` round-trip)
 
 **Changed**:
 
@@ -1760,7 +1760,7 @@ fails.
   can be passed via the provider's `config` prop.
 - **`sessionState` type narrowed** — context value's session is now `PollarPersistedSession | null`. Consumers reading
   `sessionState.data.*` need to migrate to `pollarClient.getUserProfile()`.
-- **`walletAddress` simplified** — for both external and custodial wallets, derived from
+- **`walletAddress` simplified** — for both external and embedded wallets, derived from
   `sessionState.wallet.publicKey`.
 - **New: `SessionsModal`** — drop-in active-sessions UI. Lists every refresh-token family for the current user with
   device metadata, marks the local session, and offers per-row revoke + a "Sign out everywhere" button. Available via
@@ -1968,9 +1968,9 @@ The following names exported from `usePollar()` have been renamed for consistenc
 
 - **New:** External wallet support (Freighter, Albedo, etc.) — users can now sign and submit transactions directly from
   their own wallet without Pollar holding the keys
-- **Refactor:** `signAndSubmitTx()` now handles both custodial (social/email login) and external wallet flows —
+- **Refactor:** `signAndSubmitTx()` now handles both embedded (social/email login) and external wallet flows —
   `signAndSubmitExternalTx()` removed
-- **Fix:** Connecting with an external wallet no longer triggers custodial wallet creation on the backend
+- **Fix:** Connecting with an external wallet no longer triggers embedded wallet creation on the backend
 
 ### `@pollar/react`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository is managed with [Turborepo](https://turbo.build/repo) and contai
 > `@pollar/core@^0.11.3`; if you pin exact versions, keep both on the same version.
 >
 > Earlier: **0.11.2** (additive) added the `client.stellar` namespace: sign **SEP-53
-> message** and **SEP-10 challenge** ownership proofs across custodial and external wallets,
+> message** and **SEP-10 challenge** ownership proofs across embedded and external wallets,
 > both returning the same `sep53` scheme so a verifier treats them alike. The Transaction
 > History modal goes **multichain** (network picker, per-chain explorer links, unified
 > `{ amount, unit }` fees), and the Freighter adapter runs on `@stellar/freighter-api` 6.0.0.
@@ -77,12 +77,12 @@ Pollar authentication and multichain (Stellar + Solana) transactions into any Ja
 - **SEP-24 on/off-ramps** - anchor deposit/withdraw interactive flow via the `ramps` endpoints
 - **Account creation** - `createAccount()` puts an external wallet's classic account on-chain via a sponsored
   `createAccount`; the wallet surfaces `existsOnStellar` + `fundingMode`
-- **Sponsored trustlines** - `setTrustline` lets the app config decide who pays (server-side): custodial wallets hit
+- **Sponsored trustlines** - `setTrustline` lets the app config decide who pays (server-side): embedded wallets hit
   the sponsored/self-pay trustline endpoint, external wallets co-sign whichever XDR the server returns. Pass
   `skipSponsorship` to force the user's own wallet to pay via `change_trust`
 - **Stellar ownership proofs (SEP-53 / SEP-10)** - `client.stellar.sep53.signMessage()` and
   `client.stellar.sep10.sign()` prove wallet ownership to a verifier. External wallets sign client-side via their
-  adapter, custodial wallets sign server-side, and both return the same `sep53` scheme
+  adapter, embedded wallets sign server-side, and both return the same `sep53` scheme
 - **Network resilience** - per-request timeout (default 10s) and idempotent-request retry; typed `PollarNetworkError`
 - KYC verification flow - provider selection, session start, and status polling
 - Transaction history - paginated fetch with status tracking
@@ -187,7 +187,7 @@ you do not wire up Privy's hooks yourself.
   `@privy-io/expo` on RN); a non-React host fails fast with `PrivyAdapterUnsupportedError`
 - Auto-sync host login (`onProviderAuthChange`) that recovers web OAuth redirects and persisted Privy sessions;
   optional `cleanupOAuthRedirect` and `debug` logging
-- For server-side custody instead, use `@pollar/privy-server-adapter` below
+- For server-side signing instead, use `@pollar/privy-server-adapter` below
 
 ```bash
 npm install @pollar/privy-adapter @pollar/core @stellar/stellar-sdk @privy-io/react-auth react react-dom

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -112,7 +112,7 @@ change needed if you use those.
 ### 5. `setTrustline` drops the `sponsored` opt-in flag
 
 `setTrustline(asset, { sponsored: true })` no longer type-checks. Who pays is now
-decided server-side from the app config, not by a caller flag: custodial wallets
+decided server-side from the app config, not by a caller flag: embedded wallets
 hit `POST /wallet/assets/trustline` (the server sponsors or self-pays, then
 submits) and external wallets co-sign whichever XDR the build endpoint returns.
 The only knob left is the opt-out `skipSponsorship`, which forces a self-pay

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,7 +16,7 @@ Core SDK for [Pollar](https://pollar.xyz) — authentication and transaction uti
 > Earlier: **0.11.2** added `client.stellar` — **SEP-53 message** and **SEP-10 challenge** ownership
 > proofs. External wallets sign client-side through their adapter (new optional
 > `signStellarMessage` on `WalletAdapter`; Freighter implements it, Albedo has no SEP-53
-> support), custodial wallets sign server-side, and both return the same `sep53` scheme so a
+> support), embedded wallets sign server-side, and both return the same `sep53` scheme so a
 > verifier treats them alike. Also: `@stellar/freighter-api` bumped to 6.0.0. Non-breaking.
 > New exported types: `StellarSepApi`, `StellarMessageProof`, `Sep10SignParams`, `Sep10Proof`,
 > `SignMessageOptions`, `SignMessageResponse`.
@@ -485,7 +485,7 @@ await client.buildTx('payment', {
 
 #### `client.signTx(unsignedXdr, options?): Promise<SignOutcome>`
 
-Signs an unsigned XDR. On a **custodial** session the backend signs and, by default, also applies sponsorship per the
+Signs an unsigned XDR. On an **embedded** session the backend signs and, by default, also applies sponsorship per the
 app's dashboard config - it returns a fee-bumped envelope the caller can broadcast directly, with the app paying the
 fee. Pass `skipSponsorship: true` to force the user to pay their own fee instead.
 
@@ -510,22 +510,22 @@ await client.submitTx(signedXdr);
 Puts an **external** wallet's classic account on the Stellar network when it doesn't exist yet. The server builds a
 sponsored `createAccount` (the new account starts at "0" balance; the app's sponsor wallet pays the base reserve and
 fee) and signs only the sponsor; this client adds the new-account signature with the user's own wallet and broadcasts
-via the submit path. Not applicable to custodial (internal) wallets — created on the server at login — nor to smart
+via the submit path. Not applicable to embedded (internal) wallets — created on the server at login — nor to smart
 (C-address) wallets. Trustlines are a separate step (`setTrustline`). The wallet exposes `existsOnStellar` +
 `fundingMode` so a UI can decide whether to offer this.
 
 #### `client.signAndSubmitTx(unsignedXdr?): Promise<SubmitOutcome>`
 
 Signs and submits in one call. This is the path smart-wallet (passkey) sessions use - it runs the passkey ceremony -
-and the argument is optional (it defaults to the transaction currently in `TransactionState`). Custodial and external
+and the argument is optional (it defaults to the transaction currently in `TransactionState`). Embedded and external
 sessions can call it too.
 
 #### `client.buildAndSignAndSubmitTx(operation, params, options?): Promise<SubmitOutcome>`
 
 Build + sign + submit in one call. External and passkey wallets keep the granular `building → built → signing →
-submitting → success` transitions (each composed call emits its own); custodial wallets take a single round-trip to
+submitting → success` transitions (each composed call emits its own); embedded wallets take a single round-trip to
 `/tx/build-sign-submit` and emit the compound `building-signing-submitting` step. For separate "Building…" / "Signing…"
-/ "Submitting…" indicators on a custodial flow, call `buildTx` / `signTx` / `submitTx` yourself instead.
+/ "Submitting…" indicators on an embedded flow, call `buildTx` / `signTx` / `submitTx` yourself instead.
 
 `client.runTx(...)` is an alias with the same signature - a shorter "just do the thing" name.
 
@@ -533,7 +533,7 @@ submitting → success` transitions (each composed call emits its own); custodia
 
 One entry point for a payment on Stellar or Solana. A Stellar payment routes through `buildAndSignAndSubmitTx` (so
 external adapters and passkey wallets keep the split flow); a Solana payment is a single server-side call and is
-**custodial-only** for now. `SendPaymentParams` is a per-chain union - a Stellar member with a decimal `amount` and an
+**embedded-only** for now. `SendPaymentParams` is a per-chain union - a Stellar member with a decimal `amount` and an
 `asset`, a Solana member with an integer base-unit `amount` and an optional `mint`. The union also carries a `POLYGON`
 member for the shape, but there is no transfer path for it yet: the call returns
 `{ status: 'error', details: 'Sending on POLYGON is not supported yet.' }`.
@@ -541,7 +541,7 @@ member for the shape, but there is no transfer path for it yet: the call returns
 ```ts
 // Stellar
 await client.sendPayment({ destination: 'G...', amount: '1.5', asset: { type: 'native' } });
-// Solana (custodial): amount in lamports; omit `mint` for native SOL
+// Solana (embedded): amount in lamports; omit `mint` for native SOL
 await client.sendPayment({ chain: 'SOLANA', destination: '...', amount: '1500000000' });
 ```
 
@@ -582,7 +582,7 @@ is no session, or when the session predates the backend's multichain `wallets[]`
 #### `client.setTrustline(asset, opts?): Promise<TrustlineOutcome>`
 
 Establishes (omit `limit`) or removes (`limit: '0'`) a trustline for `{ code, issuer }`. Who pays is decided
-**server-side** from the app config: custodial wallets hit `POST /wallet/assets/trustline` (the server sponsors or
+**server-side** from the app config: embedded wallets hit `POST /wallet/assets/trustline` (the server sponsors or
 self-pays, then submits), external wallets co-sign whichever XDR `/wallet/assets/trustline/build` returns. Pass
 `opts.skipSponsorship` to force a self-pay `change_trust`. Smart (passkey) wallets don't use classic trustlines.
 
@@ -624,7 +624,7 @@ hold a `PollarApiClient`.
 ### Ramps (SEP-24)
 
 On/off-ramp fiat through SEP-24 anchors (e.g. Anclap). Get a quote, create the on- or off-ramp, then drive the
-transaction to completion. Custodial wallets receive a `kycUrl` to open; external wallets receive a `pendingSignature`
+transaction to completion. Embedded wallets receive a `kycUrl` to open; external wallets receive a `pendingSignature`
 to sign and resume via `submitRampSignature`.
 
 ```ts
@@ -728,7 +728,7 @@ client.createSmartWallet(): void; // new user (WebAuthn create + sponsored deplo
 ### Stellar ownership proofs (SEP-53 / SEP-10)
 
 `client.stellar` namespaces the Stellar-specific proof standards so the multichain client stays clean. Each method
-dispatches by wallet type: external wallets sign client-side through their adapter, custodial wallets sign server-side
+dispatches by wallet type: external wallets sign client-side through their adapter, embedded wallets sign server-side
 through the API, and smart (passkey) wallets yield an error outcome — a C-address has no classic ed25519 key to prove.
 
 ```ts
@@ -739,14 +739,14 @@ const proof = await client.stellar.sep53.signMessage('verify me');
 // SEP-10: sign a verifier-issued web-auth challenge transaction
 const auth = await client.stellar.sep10.sign({
   challengeXdr,
-  homeDomains: 'verifier.example.com', // optional; enables full SEP-10 validation on the custodial path
+  homeDomains: 'verifier.example.com', // optional; enables full SEP-10 validation on the embedded path
   webAuthDomain: 'auth.verifier.example.com', // optional
 });
 // { status: 'signed', signedXdr, signerAddress } | { status: 'error', details?, code? }
 ```
 
 `signature` is base64 ed25519 over the SEP-53 digest (`SHA-256("Stellar Signed Message:\n" + message)`), produced
-identically by external wallets and the custodial signer — `scheme` is always `sep53`, so the two proof paths are
+identically by external wallets and the embedded signer — `scheme` is always `sep53`, so the two proof paths are
 interchangeable for a verifier.
 
 For external wallets, SEP-53 needs an adapter that implements the optional `signStellarMessage` method: the built-in

--- a/packages/core/src/api/endpoints/ramps.ts
+++ b/packages/core/src/api/endpoints/ramps.ts
@@ -59,8 +59,8 @@ export async function getRampsQuote(api: PollarApiClient, query: RampsQuoteQuery
 /**
  * POST /ramps/onramp
  * Creates an onramp transaction.
- * For custodial users: backend orchestrates the full SEP-24 flow and returns payment instructions.
- * For non-custodial: backend may return an unsigned XDR that the client must sign via a wallet adapter.
+ * For embedded users: backend orchestrates the full SEP-24 flow and returns payment instructions.
+ * For external wallets: backend may return an unsigned XDR that the client must sign via a wallet adapter.
  */
 export async function createOnRamp(api: PollarApiClient, body: RampsOnrampBody): Promise<RampsOnrampResponse> {
   const { data, error } = await api.POST('/ramps/onramp', { body });
@@ -82,7 +82,7 @@ export async function createOffRamp(api: PollarApiClient, body: RampsOfframpBody
 /**
  * POST /ramps/transaction/{txId}/complete
  * Completes an offramp once anchor KYC is done: builds + signs + submits the
- * on-chain withdraw payment. Custodial wallets complete server-side and return
+ * on-chain withdraw payment. Embedded wallets complete server-side and return
  * `stellarTxHash`; EXTERNAL wallets get a `pendingSignature` to sign and then
  * resume via {@link submitRampSignature}.
  */

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -84,7 +84,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Sign a Soroban authorization entry (Stellar, custodial) */
+        /** Sign a Soroban authorization entry (Stellar, embedded) */
         post: operations["postTxSignAuthEntry"];
         delete?: never;
         options?: never;
@@ -120,7 +120,7 @@ export interface paths {
         put?: never;
         /**
          * Atomic build + sign + submit (multichain, one round-trip)
-         * @description Custodial wallets only. `chain` defaults to STELLAR, which behaves exactly as v1. SOLANA takes an SPL/SOL transfer with integer base-unit amounts and a required idempotencyKey.
+         * @description Embedded wallets only. `chain` defaults to STELLAR, which behaves exactly as v1. SOLANA takes an SPL/SOL transfer with integer base-unit amounts and a required idempotencyKey.
          */
         post: operations["postTxBuildSignSubmit"];
         delete?: never;
@@ -241,7 +241,7 @@ export interface paths {
         put?: never;
         /**
          * Enable or remove a trustline for an enabled asset
-         * @description Establishes (no limit) or removes (limit '0') a trustline on the authenticated user's custodial wallet. When the asset is app-configured and sponsoring is on, the app wallets pay the reserve + fee; otherwise the server self-pays with the user's own wallet. Either way it submits server-side and returns the refreshed enabled-asset list. The wallet and network are derived from the session.
+         * @description Establishes (no limit) or removes (limit '0') a trustline on the authenticated user's embedded wallet. When the asset is app-configured and sponsoring is on, the app wallets pay the reserve + fee; otherwise the server self-pays with the user's own wallet. Either way it submits server-side and returns the refreshed enabled-asset list. The wallet and network are derived from the session.
          */
         post: operations["postWalletAssetsTrustline"];
         delete?: never;
@@ -261,7 +261,7 @@ export interface paths {
         put?: never;
         /**
          * Build a sponsored trustline for an external wallet to co-sign
-         * @description Builds a changeTrust for an EXTERNAL / adapter-managed wallet whose key the platform does not hold, and returns it for the caller to co-sign with its own wallet and broadcast via POST /tx/submit. When the app covers it, the response is `sponsorSignedXdr` (sponsor already signed, app pays the 0.5 XLM reserve + fee); otherwise it's `unsignedXdr`, a plain self-pay change_trust the trustor signs and pays for. The `sponsored` flag says which. Custodial wallets should use POST /wallet/assets/trustline instead. The wallet and network are derived from the session.
+         * @description Builds a changeTrust for an EXTERNAL / adapter-managed wallet whose key the platform does not hold, and returns it for the caller to co-sign with its own wallet and broadcast via POST /tx/submit. When the app covers it, the response is `sponsorSignedXdr` (sponsor already signed, app pays the 0.5 XLM reserve + fee); otherwise it's `unsignedXdr`, a plain self-pay change_trust the trustor signs and pays for. The `sponsored` flag says which. Embedded wallets should use POST /wallet/assets/trustline instead. The wallet and network are derived from the session.
          */
         post: operations["postWalletAssetsTrustlineBuild"];
         delete?: never;
@@ -281,7 +281,7 @@ export interface paths {
         put?: never;
         /**
          * Build a sponsored account creation for an external wallet to co-sign
-         * @description Builds a sponsored createAccount (the new account is created with a "0" starting balance; the app sponsor wallet pays the base reserve and the fee) and signs ONLY the sponsor, returning the partially-signed XDR. Use this for EXTERNAL wallets (Freighter / client-side Privy) whose key the platform does not hold: the caller adds the new-account signature client-side and broadcasts via POST /tx/submit. Custodial wallets are created on the server during login. Trustlines are a separate step — request each via POST /wallet/assets/trustline/build. The wallet and network are derived from the session.
+         * @description Builds a sponsored createAccount (the new account is created with a "0" starting balance; the app sponsor wallet pays the base reserve and the fee) and signs ONLY the sponsor, returning the partially-signed XDR. Use this for EXTERNAL wallets (Freighter / client-side Privy) whose key the platform does not hold: the caller adds the new-account signature client-side and broadcasts via POST /tx/submit. Embedded wallets are created on the server during login. Trustlines are a separate step — request each via POST /wallet/assets/trustline/build. The wallet and network are derived from the session.
          */
         post: operations["postWalletAccountCreateBuild"];
         delete?: never;
@@ -771,8 +771,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Sign a message (SEP-53 ownership proof, custodial)
-         * @description Signs a plaintext message with the user's custodial wallet using the SEP-53 "Stellar Signed Message" framing. Returns the base64 signature and signer address. External wallets sign client-side in the SDK.
+         * Sign a message (SEP-53 ownership proof, embedded)
+         * @description Signs a plaintext message with the user's embedded wallet using the SEP-53 "Stellar Signed Message" framing. Returns the base64 signature and signer address. External wallets sign client-side in the SDK.
          */
         post: operations["postStellarSep53Sign"];
         delete?: never;
@@ -791,8 +791,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Sign a SEP-10 web-auth challenge (ownership proof, custodial)
-         * @description Signs a verifier-issued SEP-10 challenge transaction with the user's custodial wallet. wallet-service validates the challenge is a harmless, un-submittable SEP-10 tx before signing. External wallets sign client-side in the SDK.
+         * Sign a SEP-10 web-auth challenge (ownership proof, embedded)
+         * @description Signs a verifier-issued SEP-10 challenge transaction with the user's embedded wallet. wallet-service validates the challenge is a harmless, un-submittable SEP-10 tx before signing. External wallets sign client-side in the SDK.
          */
         post: operations["postStellarSep10Sign"];
         delete?: never;
@@ -1252,7 +1252,7 @@ export interface paths {
         put?: never;
         /**
          * Complete an offramp (on-chain payment)
-         * @description Once anchor KYC is done and the anchor is awaiting the on-chain transfer, build + sign + submit the withdraw payment. Custodial wallets complete server-side; EXTERNAL wallets get a pendingSignature to sign and submit via the signature endpoint.
+         * @description Once anchor KYC is done and the anchor is awaiting the on-chain transfer, build + sign + submit the withdraw payment. Embedded wallets complete server-side; EXTERNAL wallets get a pendingSignature to sign and submit via the signature endpoint.
          */
         post: operations["postRampsTransactionByTxIdComplete"];
         delete?: never;

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -2023,7 +2023,7 @@ export class PollarClient {
    * when eligible); pass `skipSponsorship` to force the user's own wallet to pay,
    * mirroring the opt-out on the payment / swap / contract fee-bump surfaces. The
    * route is by wallet type, and each server endpoint sponsors-or-self-pays:
-   *  - **Custodial** (internal wallet, no adapter) -> one call to
+   *  - **Embedded** (internal wallet, no adapter) -> one call to
    *    `/wallet/assets/trustline`: the server holds the trustor key and either
    *    sponsors or self-pays, then submits, returning the refreshed asset list.
    *  - **External/adapter** -> `/wallet/assets/trustline/build` returns a
@@ -2080,7 +2080,7 @@ export class PollarClient {
       return this.runTx('change_trust', changeTrustParams);
     }
 
-    // Custodial: one server call. The server sponsors when the app config allows
+    // Embedded: one server call. The server sponsors when the app config allows
     // and self-pays otherwise, submitting either way and returning the refreshed
     // asset list - the client no longer decides the route.
     if (!this._walletAdapter && walletType === 'internal') {
@@ -2140,7 +2140,7 @@ export class PollarClient {
    * and fee) and signs only the sponsor. This client adds the new-account
    * signature with the user's own wallet and broadcasts it via the submit path.
    *
-   * Not applicable to custodial (internal) wallets - those are created on the
+   * Not applicable to embedded (internal) wallets - those are created on the
    * server at login - nor to smart (C-address) wallets, which don't use classic
    * accounts. Trustlines are a separate step: see {@link setTrustline}.
    */
@@ -2153,7 +2153,7 @@ export class PollarClient {
       return { status: 'error', details: 'Account creation does not apply to smart wallets' };
     }
     if (!this._walletAdapter && walletType === 'internal') {
-      return { status: 'error', details: 'Custodial wallets are created on the server at login' };
+      return { status: 'error', details: 'Embedded wallets are created on the server at login' };
     }
 
     try {
@@ -2322,9 +2322,9 @@ export class PollarClient {
   /**
    * For an EXTERNAL-wallet session whose signing adapter isn't attached (the host
    * didn't re-register the same `walletAdapters` this run, or the persisted
-   * walletType row was lost), the custodial signer can't help: the platform holds
+   * walletType row was lost), the embedded signer can't help: the platform holds
    * no key for a user-owned wallet. Return a clear reconnect error so the host can
-   * prompt the user, instead of POSTing to the custodial endpoint for a confusing
+   * prompt the user, instead of POSTing to the embedded endpoint for a confusing
    * 4xx. The session stays valid (reads/refresh still work); only signing needs the
    * wallet reconnected, so this is an error, NOT a logout.
    */
@@ -2339,7 +2339,7 @@ export class PollarClient {
    * Signs the given unsigned XDR and returns the signed XDR.
    *
    * - External wallets: signs locally via the wallet adapter.
-   * - Custodial wallets: posts to `/tx/sign`. The backend signs (through
+   * - Embedded wallets: posts to `/tx/sign`. The backend signs (through
    *   wallet-service or the app's customer-managed adapter) and returns the
    *   signed XDR plus an `idempotencyKey` the caller should echo back to
    *   `submitTx`.
@@ -2396,7 +2396,7 @@ export class PollarClient {
       }
     }
 
-    // Custodial path: backend signs and returns the XDR + idempotencyKey. By
+    // Embedded path: backend signs and returns the XDR + idempotencyKey. By
     // default the backend also applies sponsorship (per the app's dashboard
     // config), returning a fee-bumped envelope the caller can broadcast directly
     // - the app pays the fee. Pass `skipSponsorship` to force the user to pay.
@@ -2446,7 +2446,7 @@ export class PollarClient {
    * entry is returned as base64 XDR for the caller to compose into its tx.
    *
    * - External wallets (Freighter/Albedo) sign the entry via the provider.
-   * - Custodial wallets are signed by the backend, which FIRST validates the
+   * - Embedded wallets are signed by the backend, which FIRST validates the
    *   entry's invocation tree against the app's contract/function allowlist and
    *   caps the validity window - entries touching a non-allowlisted contract or
    *   function, or expiring too far ahead, are rejected.
@@ -2485,7 +2485,7 @@ export class PollarClient {
     }
 
     // Smart-wallet (C-address/passkey) sessions sign auth entries with their
-    // passkey credential, NOT the custodial endpoint. Standalone signAuthEntry
+    // passkey credential, NOT the embedded endpoint. Standalone signAuthEntry
     // doesn't run that ceremony, so return an explicit, actionable error instead
     // of silently POSTing to /tx/sign-auth-entry (which would sign with the wrong
     // key / 4xx). Mirrors the smart guards on the signing paths.
@@ -2496,7 +2496,7 @@ export class PollarClient {
       };
     }
 
-    // Custodial path: backend enforces the app's auth-entry policy, then signs.
+    // Embedded path: backend enforces the app's auth-entry policy, then signs.
     const address = this._session?.wallet?.address ?? '';
     try {
       const { data, error } = await this._api.POST('/tx/sign-auth-entry', {
@@ -2521,7 +2521,7 @@ export class PollarClient {
    *
    * - External wallets sign client-side via the adapter's `signStellarMessage`
    *   (Freighter/SWK produce the SEP-53 framing natively; Albedo has none).
-   * - Custodial wallets sign server-side via `/stellar/sep53/sign`, where the
+   * - Embedded wallets sign server-side via `/stellar/sep53/sign`, where the
    *   backend applies the mandatory SEP-53 prefix.
    * - Smart (passkey) wallets cannot: a C-address has no classic ed25519 key.
    */
@@ -2550,7 +2550,7 @@ export class PollarClient {
       }
     }
 
-    // Custodial: backend signs with the user's key (SEP-53 prefix enforced there).
+    // Embedded: backend signs with the user's key (SEP-53 prefix enforced there).
     try {
       const { data, error } = await this._api.POST('/stellar/sep53/sign', { body: { address, message } });
       if (!error && data?.success && data.content?.signature) {
@@ -2575,7 +2575,7 @@ export class PollarClient {
    * check with `WebAuth.readChallengeTx`.
    *
    * - External wallets sign the challenge transaction via the adapter.
-   * - Custodial wallets sign via `/stellar/sep10/sign`, which reuses the audited
+   * - Embedded wallets sign via `/stellar/sep10/sign`, which reuses the audited
    *   sign-sep10-challenge endpoint (validates the challenge is un-submittable).
    * - Smart (passkey) wallets cannot: SEP-10 is for classic accounts.
    */
@@ -2606,7 +2606,7 @@ export class PollarClient {
       }
     }
 
-    // Custodial path.
+    // Embedded path.
     try {
       const { data, error } = await this._api.POST('/stellar/sep10/sign', {
         body: {
@@ -2731,9 +2731,9 @@ export class PollarClient {
 
   /**
    * Submits a signed XDR via `/tx/submit` regardless of wallet type
-   * (custodial or external). Routing through sdk-api gives us:
+   * (embedded or external). Routing through sdk-api gives us:
    *   - End-to-end tx_records persistence with full phase lifecycle so the
-   *     developer dashboard can show every tx (both custodial and external
+   *     developer dashboard can show every tx (both embedded and external
    *     wallet flows) at `/apps/:id/monitor/transactions`.
    *   - Idempotency tracking via `submissionToken` (returned by `signTx`).
    *   - A single response shape (SUCCESS / PENDING / FAILED) shared by both
@@ -2765,7 +2765,7 @@ export class PollarClient {
           // well under the timeout, so it can't trip a transport-retry replay.
           waitForConfirmation: false,
         },
-        // Custodial submit does server-side work (wallet-service sign + network
+        // Embedded submit does server-side work (wallet-service sign + network
         // submit) that can exceed the 10s default; give it the longer budget.
         headers: { 'x-pollar-timeout-ms': String(this._submitTimeoutMs) },
       });
@@ -2826,7 +2826,7 @@ export class PollarClient {
    * - **External wallets**: composes `signTx` + `submitTx` client-side. State
    *   machine sees the full granular sequence `signing -> signed -> submitting
    *   -> success` because the underlying methods each emit.
-   * - **Custodial wallets**: atomic `/tx/sign-and-send` round-trip. State
+   * - **Embedded wallets**: atomic `/tx/sign-and-send` round-trip. State
    *   machine emits the compound `signing-submitting` step (the SDK can't
    *   observe when one phase ends and the next begins inside that single
    *   backend call) and then transitions to `submitted` (Horizon ack only) or
@@ -2868,7 +2868,7 @@ export class PollarClient {
       return this.submitTx(signed.signedXdr);
     }
 
-    // Custodial - atomic single backend call. Compound state.
+    // Embedded - atomic single backend call. Compound state.
     const buildData = this._currentBuildData();
     const outcomeExtra: { buildData?: TxBuildContent } = buildData ? { buildData } : {};
 
@@ -2952,13 +2952,13 @@ export class PollarClient {
    *   State machine sees the full granular sequence (`building -> built ->
    *   signing -> signed -> submitting -> success`) because each composed call
    *   emits its own transitions.
-   * - **Custodial wallets**: single round-trip to `/tx/build-sign-submit`. The
+   * - **Embedded wallets**: single round-trip to `/tx/build-sign-submit`. The
    *   signed XDR never leaves the backend. State machine emits the compound
    *   `building-signing-submitting` step (the SDK can't observe individual
    *   phase boundaries inside one atomic call) and then transitions to
    *   `submitted` / `success` / `error[phase: 'building-signing-submitting']`.
    *
-   * If you need granular UI feedback for custodial flows (separate
+   * If you need granular UI feedback for embedded flows (separate
    * "Building...", "Signing...", "Submitting..." indicators), call `buildTx`,
    * `signTx`, and `submitTx` separately instead.
    */
@@ -2987,7 +2987,7 @@ export class PollarClient {
       return this.signAndSubmitTx(built.buildData.unsignedXdr);
     }
 
-    // Custodial path - single backend call, compound state-machine step.
+    // Embedded path - single backend call, compound state-machine step.
     if (!this._session?.wallet?.address) {
       this._setTransactionState({ step: 'error', phase: 'building-signing-submitting', details: 'No wallet connected' });
       return { status: 'error', details: 'No wallet connected' };
@@ -3056,7 +3056,7 @@ export class PollarClient {
    * external adapters and passkey wallets via the split flow), while a chain
    * whose signature expires does the whole thing in one server-side call.
    *
-   * Custodial-only outside Stellar: a non-Stellar external wallet would have to
+   * Embedded-only outside Stellar: a non-Stellar external wallet would have to
    * sign client-side, and that path is not wired yet.
    */
   async sendPayment(params: SendPaymentParams): Promise<SubmitOutcome> {
@@ -3796,7 +3796,7 @@ export class PollarClient {
         }
       }
       // Only restore an adapter for an EXTERNAL session - those are the only ones
-      // signed via an adapter. `internal` is custodial (server-signed) and `smart`
+      // signed via an adapter. `internal` is embedded (server-signed) and `smart`
       // is passkey-signed; attaching an adapter to either (from a stale walletType
       // row left by a prior external login that was switched away from without a
       // logout) would mis-route their signing to the wrong key. (`_storeSession`
@@ -3807,7 +3807,7 @@ export class PollarClient {
       if (storedType) {
         // Look the adapter up in the registry. If it's no longer registered
         // (e.g. the consumer dropped the kit-adapter package), the session stays
-        // valid; signing falls back to the server-side custodial path until the
+        // valid; signing falls back to the server-side embedded path until the
         // user reconnects a wallet.
         const restored = this._walletAdapters.get(storedType);
         if (restored) this._walletAdapter = restored;

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -3807,8 +3807,7 @@ export class PollarClient {
       if (storedType) {
         // Look the adapter up in the registry. If it's no longer registered
         // (e.g. the consumer dropped the kit-adapter package), the session stays
-        // valid; signing falls back to the server-side embedded path until the
-        // user reconnects a wallet.
+        // valid; signing stays unavailable until the user reconnects the wallet.
         const restored = this._walletAdapters.get(storedType);
         if (restored) this._walletAdapter = restored;
         else this._log.warn('[PollarClient] No registered wallet adapter for stored id', { id: storedType });

--- a/packages/core/src/client/session.ts
+++ b/packages/core/src/client/session.ts
@@ -148,7 +148,7 @@ export function isValidSession(value: unknown, logger: PollarLogger = console): 
   }
 
   // The wallet object is always present; `type` discriminates internal (G,
-  // platform-custodied), smart/passkey (C), and external wallets. `address` is
+  // platform-managed), smart/passkey (C), and external wallets. `address` is
   // the on-chain address for all types.
   //
   // This guard runs against BOTH the persisted shape and the raw `/auth/login`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,7 +16,7 @@ export type PollarApplicationConfigContent = PollarApplicationConfigResponse['co
  * every entry of `wallets`, so the two can never drift apart in shape.
  *
  * `type` discriminates custody:
- *   - 'internal' -> platform-managed (custodial) account (G-address, 0x..., ...)
+ *   - 'internal' -> platform-managed (embedded) account (G-address, 0x..., ...)
  *   - 'smart'    -> Soroban smart-account / passkey (C-address)
  *   - 'external' -> user-connected wallet (Freighter/Albedo)
  * `address` is the on-chain address for every type.
@@ -88,7 +88,7 @@ export interface PollarPersistedSession {
 }
 
 /**
- * Custodial login methods - the providers that map to an `internal` wallet.
+ * Embedded-wallet login methods - the providers that map to an `internal` wallet.
  * Mirrors the backend `AuthProvider` enum minus passkey (-> smart) and
  * wallet/external (-> external).
  */
@@ -99,7 +99,7 @@ export type PollarAuthMethod = 'email' | 'google' | 'github' | 'oidc';
  * Every authenticated session has exactly one wallet whose custody is fixed at
  * account creation, so `custody` strictly determines the shape of `provider`:
  *
- *   - `internal` (platform-custodied G-address) -> `provider` is the login
+ *   - `internal` (platform-managed G-address) -> `provider` is the login
  *     method, or `null` if the session predates provider tracking server-side.
  *   - `smart` (passkey Soroban C-address) -> `provider` is always `'passkey'`.
  *   - `external` (user-connected wallet) -> `provider` is the on-chain adapter
@@ -191,7 +191,7 @@ export interface PollarClientConfig {
    * Per-request timeout (ms) applied to the submit-family tx calls
    * (`submitTx`, `signAndSubmitTx`, `buildAndSignAndSubmitTx`) instead of
    * {@link requestTimeoutMs}. These endpoints do real server-side work
-   * (custodial build + sign via wallet-service, then a network submit) that can
+   * (embedded build + sign via wallet-service, then a network submit) that can
    * take several seconds, so the default 10s request timeout is too tight and
    * would cut a submit that is actually succeeding. Everything else still uses
    * `requestTimeoutMs`.
@@ -488,8 +488,8 @@ export type TxBuildContent = TxBuildResponse['content'];
  *
  * **Compound** steps (`signing-submitting`, `building-signing-submitting`)
  * are emitted when multiple phases collapse into a single opaque backend
- * round-trip (`signAndSubmitTx` custodial -> `/tx/sign-and-send`, and `runTx`
- * / `buildAndSignAndSubmitTx` custodial -> `/tx/build-sign-submit`). The SDK
+ * round-trip (`signAndSubmitTx` embedded -> `/tx/sign-and-send`, and `runTx`
+ * / `buildAndSignAndSubmitTx` embedded -> `/tx/build-sign-submit`). The SDK
  * can't see when one phase ends and the next begins inside that request, so
  * it honestly reports a single fused state instead of fabricating
  * transitions.
@@ -508,7 +508,7 @@ export type TransactionState =
   | { step: 'signing'; buildData?: TxBuildContent }
   | { step: 'signed'; buildData?: TxBuildContent; signedXdr: string; submissionToken?: string }
   | { step: 'submitting'; buildData?: TxBuildContent; signedXdr?: string }
-  // --- Compound phases (custodial-only - backend swallows the boundaries) --
+  // --- Compound phases (embedded-only - backend swallows the boundaries) --
   | { step: 'signing-submitting'; buildData?: TxBuildContent }
   | { step: 'building-signing-submitting' }
   // --- Post-Horizon-ack, pre-ledger-confirm (shared) --------------------
@@ -559,7 +559,7 @@ export type SignAuthEntryOutcome = { status: 'signed'; signedAuthEntry: string }
 /**
  * Result of {@link StellarSepApi.sep53}.signMessage - a SEP-53 message signature.
  * `signature` is base64 ed25519 over SHA-256("Stellar Signed Message:\n" + message),
- * the same digest external wallets (Freighter/SWK) and the custodial signer both
+ * the same digest external wallets (Freighter/SWK) and the embedded signer both
  * produce, so `scheme` is always `sep53`.
  */
 export type StellarMessageProof =
@@ -570,9 +570,9 @@ export type StellarMessageProof =
 export interface Sep10SignParams {
   /** The SEP-10 challenge transaction (unsigned XDR) built by the verifier. */
   challengeXdr: string;
-  /** Verifier home domain(s); when present, the custodial signer runs full SEP-10 validation. */
+  /** Verifier home domain(s); when present, the embedded signer runs full SEP-10 validation. */
   homeDomains?: string | string[];
-  /** Verifier web-auth domain; enables full SEP-10 validation on the custodial path. */
+  /** Verifier web-auth domain; enables full SEP-10 validation on the embedded path. */
   webAuthDomain?: string;
 }
 
@@ -585,7 +585,7 @@ export type Sep10Proof =
  * Stellar Ecosystem Proposal ownership-proof surface, exposed as `client.stellar`.
  * These are Stellar-specific standards, namespaced so the multichain client stays
  * clean. Each method dispatches by wallet type: external wallets sign client-side
- * via their adapter, custodial wallets sign server-side through sdk-api.
+ * via their adapter, embedded wallets sign server-side through sdk-api.
  */
 export interface StellarSepApi {
   /** SEP-53: sign an arbitrary message (message ownership proof). */
@@ -981,7 +981,7 @@ export type RampDepositInstructions = NonNullable<RampsTransactionResponse['depo
 export type RampScannable = NonNullable<RampDepositInstructions['scannable']>;
 export type RampInstructionField = RampDepositInstructions['fields'][number];
 
-// SEP-24 anchor flow (e.g. Anclap): custodial wallets get a `kycUrl` to open;
+// SEP-24 anchor flow (e.g. Anclap): embedded wallets get a `kycUrl` to open;
 // EXTERNAL wallets get a `pendingSignature` to sign and resume.
 export type RampsPendingSignature = NonNullable<RampsOnrampResponse['pendingSignature']>;
 export type RampsSignatureBody = NonNullable<

--- a/packages/core/src/wallets/FreighterAdapter.ts
+++ b/packages/core/src/wallets/FreighterAdapter.ts
@@ -124,7 +124,7 @@ export class FreighterAdapter implements WalletAdapter {
 }
 
 /** Standard base64 (padded) via the pure-JS base64url encoder - no `Buffer`, no
- *  `btoa`, so it works in browser and RN alike. Matches the custodial path's
+ *  `btoa`, so it works in browser and RN alike. Matches the embedded path's
  *  `signature.toString('base64')` so both proof paths return one format. */
 function bytesToBase64(bytes: Uint8Array): string {
   const b64 = base64urlEncode(bytes).replace(/-/g, '+').replace(/_/g, '/');

--- a/packages/privy-adapter/README.md
+++ b/packages/privy-adapter/README.md
@@ -9,7 +9,7 @@ standard SEP-10 login + transaction flow.
 You configure it once with a slim, `PrivyClientConfig`-shaped object; you do **not**
 wire up Privy's hooks yourself.
 
-> Server-side custody (signing through your Privy app secret on your backend) is a
+> Server-side signing (through your Privy app secret on your backend) is a
 > different package: [`@pollar/privy-server-adapter`](../privy-server-adapter).
 
 ## Supported platforms

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -162,7 +162,7 @@ const {
   // Transactions
   tx, // TransactionState
   buildTx, // (operation, params, options?) => Promise<BuildOutcome>
-  signAndSubmitTx, // (unsignedXdr?: string) => Promise<SubmitOutcome>  (custodial; XDR optional)
+  signAndSubmitTx, // (unsignedXdr?: string) => Promise<SubmitOutcome>  (embedded; XDR optional)
   signTx, // (unsignedXdr: string) => Promise<SignOutcome>  (external-wallet only)
   sendPayment, // (params: SendPaymentParams) => Promise<SubmitOutcome>
   submitTx, // (signedXdr: string) => Promise<SubmitOutcome>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -162,8 +162,8 @@ const {
   // Transactions
   tx, // TransactionState
   buildTx, // (operation, params, options?) => Promise<BuildOutcome>
-  signAndSubmitTx, // (unsignedXdr?: string) => Promise<SubmitOutcome>  (embedded; XDR optional)
-  signTx, // (unsignedXdr: string) => Promise<SignOutcome>  (external-wallet only)
+  signAndSubmitTx, // (unsignedXdr?: string) => Promise<SubmitOutcome>  (the smart-wallet path; embedded and external can call it too; XDR optional)
+  signTx, // (unsignedXdr: string) => Promise<SignOutcome>  (embedded: server signs; external: adapter signs; not for smart wallets)
   sendPayment, // (params: SendPaymentParams) => Promise<SubmitOutcome>
   submitTx, // (signedXdr: string) => Promise<SubmitOutcome>
   buildAndSignAndSubmitTx, // (operation, params, options?) => Promise<SubmitOutcome>  (one-shot)

--- a/packages/react/src/components/ChainSelect.tsx
+++ b/packages/react/src/components/ChainSelect.tsx
@@ -30,7 +30,7 @@ export function resolveChain(chain: WalletChain | undefined): WalletChain {
 /**
  * The selectable chains - the first is the default everywhere (network picker,
  * the address the wallet button shows). De-duplicated because two wallets on one
- * chain (e.g. a custodial and a linked external Stellar wallet) are still one
+ * chain (e.g. an embedded and a linked external Stellar wallet) are still one
  * network choice.
  *
  * `order` is the app's chain list from `/applications/config`, as arranged in the

--- a/packages/react/src/components/send-modal/SendModal.tsx
+++ b/packages/react/src/components/send-modal/SendModal.tsx
@@ -37,7 +37,7 @@ export function SendModal({ onClose }: SendModalProps) {
     styles,
   } = usePollar();
   // External-wallet signing-adapter id (freighter/albedo) drives the wallet logo;
-  // null for custodial/smart, which fall back to the Pollar logo.
+  // null for embedded/smart, which fall back to the Pollar logo.
   const walletType = wallet?.custody === 'external' ? wallet.provider : null;
   const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 

--- a/packages/react/src/components/transaction-modal/TransactionModal.tsx
+++ b/packages/react/src/components/transaction-modal/TransactionModal.tsx
@@ -14,7 +14,7 @@ interface TransactionModalProps {
 export function TransactionModal({ onClose }: TransactionModalProps) {
   const { getClient, styles, tx: transaction, network, wallet } = usePollar();
   // External-wallet signing-adapter id (freighter/albedo) drives the wallet logo;
-  // null for custodial/smart, which fall back to the Pollar logo.
+  // null for embedded/smart, which fall back to the Pollar logo.
   const walletType = wallet?.custody === 'external' ? wallet.provider : null;
   const { theme, accentColor, styleOverrides, overlayStyle } = modalChrome(styles);
 

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -130,7 +130,7 @@ interface PollarContextValue {
     options?: TxBuildBody['options'],
   ) => Promise<BuildOutcome>;
   signAndSubmitTx: (unsignedXdr?: string) => Promise<SubmitOutcome>;
-  /** External-wallet only. Embedded flows should use `signAndSubmitTx`. */
+  /** Sign only. Embedded sessions sign server-side, external sessions through their adapter. Smart wallets use `signAndSubmitTx`. */
   signTx: (unsignedXdr: string) => Promise<SignOutcome>;
   submitTx: (signedXdr: string) => Promise<SubmitOutcome>;
   /** One-shot: build -> sign -> submit. Drives the same TransactionState flow as the split calls. */

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -130,7 +130,7 @@ interface PollarContextValue {
     options?: TxBuildBody['options'],
   ) => Promise<BuildOutcome>;
   signAndSubmitTx: (unsignedXdr?: string) => Promise<SubmitOutcome>;
-  /** External-wallet only. Custodial flows should use `signAndSubmitTx`. */
+  /** External-wallet only. Embedded flows should use `signAndSubmitTx`. */
   signTx: (unsignedXdr: string) => Promise<SignOutcome>;
   submitTx: (signedXdr: string) => Promise<SubmitOutcome>;
   /** One-shot: build -> sign -> submit. Drives the same TransactionState flow as the split calls. */
@@ -148,7 +148,7 @@ interface PollarContextValue {
   /**
    * Send a payment on any chain the user holds a wallet on. Stellar keeps the
    * split flow (so external adapters and passkeys still work); a chain whose
-   * signature expires goes through one server-side call and is custodial-only.
+   * signature expires goes through one server-side call and is embedded-only.
    */
   sendPayment: (params: SendPaymentParams) => Promise<SubmitOutcome>;
   // network

--- a/skills/pollar-wallet-auth/SKILL.md
+++ b/skills/pollar-wallet-auth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pollar-wallet-auth
-description: Add email, social, or passkey login with an embedded Stellar wallet to a web or React Native app using @pollar/core and @pollar/react. Covers dashboard setup and API keys, sponsored (gasless) account activation and trustlines, payments, multi-venue swaps, SEP-24 ramps, and SEP-53 / SEP-10 ownership proofs. Use when app users need a Stellar wallet without a seed phrase or a browser extension.
+description: Add embedded Stellar wallets and local fiat on/off-ramps to a web or React Native app with @pollar/core and @pollar/react. Users sign in with email, social, or a passkey and get a funded account with no seed phrase; the same client quotes and runs fiat deposits and withdrawals, payments, sponsored (gasless) activation and trustlines, multi-venue swaps, and SEP-53 / SEP-10 ownership proofs. Use when an app needs Stellar wallets for people who do not have one, or needs to move money between fiat and Stellar.
 user-invocable: true
 argument-hint: '[pollar task]'
 ---
@@ -19,11 +19,13 @@ modals). Server-side signing, sponsorship, and key management live behind the Po
 ## When to use this skill
 
 - The app wants Stellar accounts for users who do not have a wallet and should not manage keys
+- Users need to move money between local fiat (SPEI, Pix, PSE, ACH, and so on) and their wallet:
+  on-ramp quotes, deposit instructions, off-ramp payouts, and the identity checks in between
 - Onboarding must be gasless: the app pays the base reserve, trustline reserves, and fees
 - One login flow has to cover both embedded and external (Freighter / Albedo) wallets
 - The app needs passkey smart accounts (Soroban C-addresses) instead of classic G-addresses
-- The app needs payments, trustlines, swaps, SEP-24 fiat ramps, or SEP-10 / SEP-53 ownership proofs
-  on top of that wallet
+- The app needs payments, trustlines, swaps, or SEP-10 / SEP-53 ownership proofs on top of that
+  wallet
 
 ## When NOT to use this skill
 
@@ -41,7 +43,8 @@ modals). Server-side signing, sponsorship, and key management live behind the Po
 | Which wallet a user got, addresses, balances                     | [Wallets and balances](#wallets-and-balances) (below) |
 | React and Next.js wiring, `usePollar`, prebuilt modals, branding | [react.md](react.md)                                  |
 | React Native and Expo, polyfills, secure storage, deep links     | [react-native.md](react-native.md)                    |
-| Payments, sponsorship, trustlines, swaps, ramps, earn, proofs    | [transactions.md](transactions.md)                    |
+| Fiat on/off-ramps: quotes, deposit instructions, KYC, payouts    | [ramps.md](ramps.md)                                  |
+| Payments, sponsorship, trustlines, swaps, earn, proofs           | [transactions.md](transactions.md)                    |
 | Things that silently break an integration                        | [Gotchas](#gotchas) (below)                           |
 
 ## Install

--- a/skills/pollar-wallet-auth/SKILL.md
+++ b/skills/pollar-wallet-auth/SKILL.md
@@ -13,14 +13,14 @@ without ever seeing a secret key. The same client also connects external wallets
 xBull) so both kinds of user go through one code path.
 
 The SDK is `@pollar/core` (framework agnostic) plus `@pollar/react` (provider, hooks, and prebuilt
-modals). Server-side signing, sponsorship, and key custody live behind the Pollar API, configured from
+modals). Server-side signing, sponsorship, and key management live behind the Pollar API, configured from
 [dashboard.pollar.xyz](https://dashboard.pollar.xyz).
 
 ## When to use this skill
 
 - The app wants Stellar accounts for users who do not have a wallet and should not manage keys
 - Onboarding must be gasless: the app pays the base reserve, trustline reserves, and fees
-- One login flow has to cover both embedded (custodial) and external (Freighter / Albedo) wallets
+- One login flow has to cover both embedded and external (Freighter / Albedo) wallets
 - The app needs passkey smart accounts (Soroban C-addresses) instead of classic G-addresses
 - The app needs payments, trustlines, swaps, SEP-24 fiat ramps, or SEP-10 / SEP-53 ownership proofs
   on top of that wallet
@@ -60,11 +60,11 @@ Requires Node 20+ in the toolchain and React 18+ for `@pollar/react`.
 Every authenticated session carries a wallet with one of three custody types. Almost every branch in an
 integration comes down to which one the user has, so read it once and keep it:
 
-| `custody`  | What it is                                                                       | Address | Signing                                   |
-| ---------- | -------------------------------------------------------------------------------- | ------- | ----------------------------------------- |
-| `internal` | Custodial wallet Pollar creates at login. The default for social and email users | `G...`  | Server-side, sponsored per the app config |
-| `smart`    | Soroban smart account deployed for a device passkey                              | `C...`  | WebAuthn ceremony on the device           |
-| `external` | A wallet the user already had, connected through an adapter                      | `G...`  | The user's own extension or signer        |
+| `custody`  | What it is                                                                                                   | Address | Signing                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------ | ------- | ----------------------------------------- |
+| `internal` | Embedded wallet Pollar provisions at login, keys managed server-side. The default for social and email users | `G...`  | Server-side, sponsored per the app config |
+| `smart`    | Soroban smart account deployed for a device passkey                                                          | `C...`  | WebAuthn ceremony on the device           |
+| `external` | A wallet the user already had, connected through an adapter                                                  | `G...`  | The user's own extension or signer        |
 
 ```ts
 const wallet = client.getWallet(); // WalletInfo | null

--- a/skills/pollar-wallet-auth/ramps.md
+++ b/skills/pollar-wallet-auth/ramps.md
@@ -1,0 +1,244 @@
+# Fiat ramps
+
+Move money between local fiat rails and a Stellar wallet. The client never picks a provider: the
+backend ranks the app's enabled anchors by country, amount, fee and availability and returns
+quotes. Which anchor serves a corridor, and whether it speaks SEP-24 or REST, is a fact about the
+quote you were handed, not a decision your code makes. Write against the fields the API returns and
+the integration survives every provider change.
+
+Everything here needs an authenticated session. If the app uses `@pollar/react`, `openRampModal()`
+from `usePollar()` runs this entire flow with a prebuilt UI; the rest of this file is for driving it
+yourself.
+
+## The shape of a run
+
+```
+getRampCountries()            which corridors this app serves, to populate a selector
+getRampsQuote(query)          ranked quotes; quotes[0] is the recommendation; quoteId lives 15 min
+createOnRamp / createOffRamp  spend the quoteId, get back a RampResult
+apply the RampResult          branch on its optional fields (below)
+pollRampTransaction(txId)     until 'completed' | 'failed'
+```
+
+Every mutating call (`createOnRamp`, `createOffRamp`, `completeWithdraw`, `submitRampSignature`)
+returns the same result shape, and the whole integration is one function that reads it:
+
+```ts
+type RampResult = {
+  txId: string;
+  provider: string;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  pendingSignature?: { unsignedXdr: string; action: 'sep10' | 'withdraw_payment' };
+  kycUrl?: string; // hosted identity check to open
+  tosUrl?: string; // hosted terms acceptance, when the provider splits it out
+  kycRequired?: boolean; // link-less gate: nothing was signed, nothing moved
+  depositInstructions?: RampDepositInstructions; // on-ramp payment details as data
+  stellarTxHash?: string; // set once the on-chain leg has landed
+};
+```
+
+Read the fields in this order, because they are not mutually exclusive and the first one that applies
+decides what happens next:
+
+1. **`pendingSignature`** is set: the user's wallet has to sign. Sign it, submit it, and read the
+   result you get back as a new `RampResult` (it may carry another `pendingSignature`). Only EXTERNAL
+   wallets ever see this; custodial wallets sign server-side.
+2. **`kycUrl`** (and `tosUrl`) is set: open it in a new tab. The provider hosts the identity check and
+   the transaction advances on its own once the user clears it. Keep polling.
+3. **`kycRequired: true`** is set: the provider gated the flow on identity and offers no hosted URL.
+   Nothing was built or signed and no funds moved. Poll `getRampKycStatus()` until `hasApproved`,
+   then **request a fresh quote**; the provider consumed this one when it answered.
+4. **`depositInstructions`** is set (on-ramp): render them. This is where the user is told how to pay.
+5. Otherwise poll `status`.
+
+## Quotes
+
+```ts
+const { countries } = await client.getRampCountries(); // [{ code: 'MX', currency: 'MXN' }, ...]
+
+const { quotes } = await client.getRampsQuote({
+  country: 'MX',
+  amount: 500,
+  currency: 'MXN',
+  direction: 'onramp', // or 'offramp'
+});
+const quote = quotes[0]; // recommended
+```
+
+A quote carries what the UI needs to explain it, and one thing the UI must obey:
+
+| Field                                         | Use                                                                                                                                                               |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `quoteId`                                     | Pass to `createOnRamp` / `createOffRamp`. **Valid 15 minutes**, then a fresh quote is needed                                                                      |
+| `rate`, `fee`, `feeCurrency`, `estimatedTime` | Display                                                                                                                                                           |
+| `rail`                                        | `'SPEI' \| 'PIX' \| 'PSE' \| 'ACH' \| 'BREB' \| 'QR'`                                                                                                             |
+| `protocol`                                    | `'SEP-24' \| 'REST'`. Informational; the branching above already covers the difference                                                                            |
+| `minAmount`, `maxAmount`                      | Validate before creating; out of range fails with `RAMPS_AMOUNT_OUT_OF_RANGE`                                                                                     |
+| `requiredFields`                              | Inputs this route needs the client to collect (name, email, tax id, bank details). **Empty for SEP-24 routes**, which collect everything on their own hosted page |
+
+`requiredFields` is why a ramp form cannot be static. Each entry has `key`, `label`, `type`
+(`'text' | 'email' | 'tel' | 'select'`), and optionally `bankType`, `options`, `placeholder`,
+`hint`, `optional`. Render them from the quote, collect the values, and send them back under
+`fields` on the create call. A form hardcoded for one provider breaks the day a better quote wins.
+
+## On-ramp (fiat in)
+
+```ts
+const result = await client.createOnRamp({
+  quoteId: quote.quoteId,
+  amount: 500,
+  currency: 'MXN',
+  country: 'MX',
+  // only what the quote's requiredFields asked for: named ones as top-level keys,
+  // the rest under `fields`, keyed by each entry's `key`
+  fullName,
+  email,
+  fields: collectedFields,
+});
+```
+
+Then apply the result. For a hosted (SEP-24) route you get `kycUrl` and the user pays on the
+anchor's page. For a REST route you get `depositInstructions`:
+
+```ts
+type RampDepositInstructions = {
+  scannable?: {
+    kind: 'pix' | 'stellar' | 'url' | 'opaque';
+    payload: string | null; // the copy-and-paste code, when there is one
+    payloadLabel: string | null;
+    image: { mediaType: 'image/svg+xml' | 'image/png'; encoding: 'utf8' | 'base64'; data: string; inlineSafe: boolean };
+  };
+  fields: {
+    key: string;
+    label: string;
+    value: string;
+    type: 'text' | 'code' | 'amount' | 'datetime' | 'url';
+    copyable: boolean;
+  }[];
+};
+```
+
+Render `fields` as a labeled list with a copy button where `copyable` is true, and `scannable` as a
+QR when present. The `key` values are stable (`amount`, `reference`, `clabe`, `bank_account`,
+`expires_at`, `memo`, ...) so a UI can special-case one without parsing labels. Do not synthesize
+instructions from the quote; the reference and expiry only exist on the created transaction.
+
+## Off-ramp (fiat out)
+
+Two steps, because the provider needs to know where to send money before the wallet sends crypto.
+
+```ts
+const result = await client.createOffRamp({
+  quoteId: quote.quoteId,
+  amount: 100,
+  currency: 'USDC',
+  country: 'BR',
+  bankDetails: { type: 'PIX', value: pixKey }, // or CLABE / PSE / ACH / BREB
+  taxId, // when required
+  fields: collectedFields,
+});
+// apply the result: KYC gate, hosted URL, or straight to 'processing'
+
+// Once the provider is awaiting the on-chain transfer:
+const done = await client.completeWithdraw(result.txId);
+// custodial: done.stellarTxHash is set
+// external:  done.pendingSignature is set, sign and resume (below)
+```
+
+`completeWithdraw` is the moment real funds move. Gate the button on all of: direction is
+`offramp`, no `stellarTxHash` yet, and **not** `kycRequired`. On a link-less KYC gate the provider
+consumed the quote, so completing would fail or, worse, pay into a deposit it cannot pay out.
+Approval clears the gate for the _next_ quote, not for this transaction.
+
+### Paying a Pix QR
+
+For a Brazilian off-ramp against a "copia e cola" code, decode first and send the original payload:
+
+```ts
+const { decoded } = await client.decodePixQr(qrCode);
+if (!decoded) throw new Error('QR no longer resolves'); // dynamic QRs go stale once used or expired
+// quote decoded.amount, then:
+await client.createOffRamp({ ...body, qrCode }); // the ORIGINAL payload, not the bare key it decodes to
+```
+
+Paying the bare key the QR decodes to is rejected by the payee's bank. Decode immediately before
+quoting; a decoded QR does not stay valid while the user reads a confirmation screen.
+
+## External wallets: signing and resuming
+
+Custodial wallets never see `pendingSignature`. For an EXTERNAL wallet (Freighter, Albedo, xBull) the
+backend hands back an unsigned XDR at two points: `sep10` to open the anchor session, and
+`withdraw_payment` to broadcast the withdrawal. Sign with the session's own signer and resume:
+
+```ts
+async function resume(txId: string, ps: NonNullable<RampResult['pendingSignature']>): Promise<RampResult> {
+  const outcome = await client.signTx(ps.unsignedXdr);
+  if (outcome.status !== 'signed') throw new Error(outcome.message ?? 'signing cancelled');
+  const next = await client.submitRampSignature(txId, { signedXdr: outcome.signedXdr, action: ps.action });
+  return next.pendingSignature ? resume(next.txId, next.pendingSignature) : next;
+}
+```
+
+`signTx` dispatches through the wallet adapter for external wallets. Smart (passkey) wallets are not
+supported by ramps: `signTx` returns an error outcome for them and there is no server-side path.
+
+## Status and liquidity
+
+```ts
+const status = await client.pollRampTransaction(txId, { intervalMs: 5000, timeoutMs: 600_000 });
+// resolves 'completed' | 'failed'; throws on timeout
+
+const tx = await client.getRampTransaction(txId); // one read: status, direction, amount, currency, kycUrl, depositInstructions, stellarTxHash, updatedAt
+```
+
+`pollRampTransaction` only stops on a terminal status. A transaction parked on a hosted KYC page can
+sit in `pending` for as long as the user takes, so give the poll a timeout you are prepared to
+recover from, and offer `getRampTransaction` on demand rather than holding the UI on the poll.
+
+Some payout rails publish live liquidity. Check it before _offering_ the corridor, not after quoting:
+quoting a dry rail succeeds and then fails downstream, which reads to the user as a bug.
+
+```ts
+const { available, liquidity, message } = await client.getRampLiquidity('PIX'); // 'PIX' | 'BREB'
+```
+
+Only rails whose provider publishes liquidity answer; the rest return not found, which means "no
+signal", not "no liquidity".
+
+## Errors
+
+Ramp errors keep every field the API sent, not just the code, because these are the ones a UI has to
+explain: an amount below the minimum, a stale quote, a pending identity check.
+
+```ts
+import { PollarApiError } from '@pollar/core';
+try {
+  await client.createOnRamp(body);
+} catch (e) {
+  if (e instanceof PollarApiError) {
+    e.code; // e.g. 'RAMPS_AMOUNT_OUT_OF_RANGE'
+    e.body; // the full response, with whatever the provider added
+  }
+}
+```
+
+A quote that expired (15 minutes) fails the create with a validation error. Do not retry the create;
+request a new quote. The amount the user typed is still valid, the price is not.
+
+## Gotchas
+
+1. **Hardcoding a form.** `requiredFields` differ per quote. Render them from the quote every time.
+2. **Reusing a quote after `kycRequired`.** The provider consumed it. Wait for `hasApproved`, then
+   quote again.
+3. **Treating `pollRampTransaction` as the UI.** It only resolves on a terminal state. Hosted KYC can
+   take a day. Show `getRampTransaction` state and let the user leave.
+4. **Building deposit instructions client-side.** The reference and expiry only exist on the created
+   transaction. Use `depositInstructions` from the result.
+5. **Sending the decoded Pix key.** Send the original `qrCode` payload. The decoded form is for
+   display and for choosing the amount.
+6. **Checking liquidity after quoting.** Check before offering the corridor; a quote on a dry rail
+   succeeds and fails later.
+7. **Expecting smart wallets to ramp.** Passkey C-address sessions have no classic key to sign the
+   SEP-10 challenge or the withdraw payment.
+8. **Assuming the rail from the country.** Read `quote.rail`. A country can be served by more than one
+   rail, and the recommended quote is not always the one you expect.

--- a/skills/pollar-wallet-auth/transactions.md
+++ b/skills/pollar-wallet-auth/transactions.md
@@ -127,20 +127,17 @@ Units differ per side: the deposit `amount` is the underlying asset amount, whil
 is in the position's `withdrawUnit` (asset amount for Blend, share count for DeFindex). Smart wallets
 are not supported yet.
 
-## Fiat ramps (SEP-24)
+## Fiat ramps
 
-```ts
-const quote = await client.getRampsQuote(query);
-const onramp = await client.createOnRamp(body);
-const status = await client.pollRampTransaction(onramp.txId);
-```
+Moving money between local fiat rails and the wallet has its own file: [ramps.md](ramps.md). It
+covers quotes and the 15-minute `quoteId`, on-ramp deposit instructions, the two-step off-ramp,
+the three KYC shapes a result can carry, Pix QR payment, and the sign-and-resume loop for external
+wallets. The short version: every mutating call returns one `RampResult`, and the integration is a
+single function that branches on its optional fields in a fixed order.
 
-Embedded wallets get a `kycUrl` to open. External wallets get a `pendingSignature` to sign and resume
-through `submitRampSignature(txId, body)`. Off-ramps additionally need `completeWithdraw(txId)`. The
-rest of the surface: `getRampCountries`, `createOffRamp`, `getRampTransaction`.
-
-KYC has its own methods: `getKycProviders(country)`, `startKyc(body)`, `getKycStatus(providerId?)`,
-`pollKycStatus(providerId)`, `resolveKyc(providerId, level?)`.
+Identity verification outside a ramp run has its own methods on the client: `getKycProviders(country)`,
+`startKyc(body)`, `getKycStatus(providerId?)`, `pollKycStatus(providerId)`, `resolveKyc(providerId, level?)`,
+plus `openKycModal()` in `@pollar/react`.
 
 ## Ownership proofs (SEP-53 and SEP-10)
 

--- a/skills/pollar-wallet-auth/transactions.md
+++ b/skills/pollar-wallet-auth/transactions.md
@@ -7,7 +7,7 @@ wallet's `custody` (`internal`, `smart`, `external`), and the SDK hides most of 
 
 ```ts
 client.buildTx(operation, params, options?); // unsigned XDR from the Pollar API
-client.signTx(unsignedXdr, options?); // custodial: server signs; external: adapter signs
+client.signTx(unsignedXdr, options?); // embedded: server signs; external: adapter signs
 client.submitTx(signedXdr); // broadcast
 ```
 
@@ -23,14 +23,14 @@ client.sendPayment(params); // one entry point for a payment
 // Stellar payment
 await client.sendPayment({ destination: 'G...', amount: '1.5', asset: { type: 'native' } });
 
-// Solana payment: amount in base units (lamports), custodial only for now
+// Solana payment: amount in base units (lamports), embedded only for now
 await client.sendPayment({ chain: 'SOLANA', destination: '...', amount: '1500000000' });
 ```
 
 Subscribe to `client.onTransactionStateChange` for progress. External and passkey wallets keep the
-granular `building`, `built`, `signing`, `submitting`, `success` transitions. Custodial wallets take a
+granular `building`, `built`, `signing`, `submitting`, `success` transitions. Embedded wallets take a
 single round trip and emit one compound `building-signing-submitting` step, so if the UI needs separate
-"Building" / "Signing" / "Submitting" indicators on a custodial flow, call `buildTx`, `signTx`, and
+"Building" / "Signing" / "Submitting" indicators on an embedded flow, call `buildTx`, `signTx`, and
 `submitTx` yourself.
 
 Poll the result with `client.getTxStatus(hash)`, which returns
@@ -42,7 +42,7 @@ ceremony, and they need `passkeySign` injected in the client config.
 ## Sponsorship (gasless)
 
 Who pays the fee is decided **server-side** from the app's dashboard config, not by the caller. On a
-custodial session the backend signs and returns a fee-bumped envelope with the app paying. The client's
+embedded session the backend signs and returns a fee-bumped envelope with the app paying. The client's
 only lever is opting out:
 
 ```ts
@@ -63,7 +63,7 @@ if (wallet?.custody === 'external' && wallet.existsOnStellar === false) {
 }
 ```
 
-Not applicable to custodial wallets, which are created server-side at login, nor to smart wallets.
+Not applicable to embedded wallets, which are created server-side at login, nor to smart wallets.
 Trustlines remain a separate step.
 
 ## Trustlines
@@ -74,7 +74,7 @@ await client.setTrustline({ code: 'USDC', issuer: 'GA5Z...' }, { limit: '0' }); 
 await client.setTrustline(asset, { skipSponsorship: true }); // force self-pay change_trust
 ```
 
-Routing is by sponsorship flag, not by wallet type: custodial wallets hit the trustline endpoint where
+Routing is by sponsorship flag, not by wallet type: embedded wallets hit the trustline endpoint where
 the server sponsors or self-pays and submits; external wallets co-sign whichever XDR the build endpoint
 returns. Smart wallets do not use classic trustlines at all.
 
@@ -135,7 +135,7 @@ const onramp = await client.createOnRamp(body);
 const status = await client.pollRampTransaction(onramp.txId);
 ```
 
-Custodial wallets get a `kycUrl` to open. External wallets get a `pendingSignature` to sign and resume
+Embedded wallets get a `kycUrl` to open. External wallets get a `pendingSignature` to sign and resume
 through `submitRampSignature(txId, body)`. Off-ramps additionally need `completeWithdraw(txId)`. The
 rest of the surface: `getRampCountries`, `createOffRamp`, `getRampTransaction`.
 
@@ -145,7 +145,7 @@ KYC has its own methods: `getKycProviders(country)`, `startKyc(body)`, `getKycSt
 ## Ownership proofs (SEP-53 and SEP-10)
 
 `client.stellar` namespaces the Stellar-specific proof standards. Each method dispatches by wallet
-type: external wallets sign client-side through their adapter, custodial wallets sign server-side, and
+type: external wallets sign client-side through their adapter, embedded wallets sign server-side, and
 smart wallets return an error outcome because a C-address has no classic ed25519 key to prove.
 
 ```ts
@@ -156,7 +156,7 @@ const proof = await client.stellar.sep53.signMessage('verify me');
 // SEP-10: sign a verifier-issued web-auth challenge
 const auth = await client.stellar.sep10.sign({
   challengeXdr,
-  homeDomains: 'verifier.example.com', // optional, enables full SEP-10 validation on the custodial path
+  homeDomains: 'verifier.example.com', // optional, enables full SEP-10 validation on the embedded path
   webAuthDomain: 'auth.verifier.example.com',
 });
 // { status: 'signed', signedXdr, signerAddress } | { status: 'error', details?, code? }
@@ -164,7 +164,7 @@ const auth = await client.stellar.sep10.sign({
 
 `signature` is base64 ed25519 over the SEP-53 digest
 (`SHA-256("Stellar Signed Message:\n" + message)`), produced identically on both paths, and `scheme` is
-always `sep53`. A verifier can treat custodial and external proofs interchangeably.
+always `sep53`. A verifier can treat embedded and external proofs interchangeably.
 
 Note that Freighter implements the client-side message signing; Albedo has no SEP-53 support.
 


### PR DESCRIPTION
Documentation pass over the READMEs, UPGRADE.md, CHANGELOG.md, the
pollar-wallet-auth skill, and the JSDoc / comments in @pollar/core and
@pollar/react, so the wording is consistent everywhere the SDK is described.
schema.d.ts descriptions are regenerated to match sdk-api.

Also carries the skills-changed CI workflow, moved here from 0.11.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated wallet terminology across SDK, React, adapter, upgrade, skill, and API documentation from “custodial” to “embedded.”
  * Clarified server-side signing, wallet management, transaction flows, ramps, and ownership proofs.
  * Added comprehensive fiat on/off-ramp integration guidance, including quotes, KYC, deposits, withdrawals, and transaction status handling.
  * Added workflow guidance for publishing skill documentation changes and syncing mirrored content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->