### PR TITLE
feat(ramps): support Etherfuse quote lifecycle

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -621,11 +621,12 @@ hold a `PollarApiClient`.
 
 ---
 
-### Ramps (SEP-24)
+### Ramps (SEP-24 and REST providers)
 
-On/off-ramp fiat through SEP-24 anchors (e.g. Anclap). Get a quote, create the on- or off-ramp, then drive the
-transaction to completion. Custodial wallets receive a `kycUrl` to open; external wallets receive a `pendingSignature`
-to sign and resume via `submitRampSignature`.
+On/off-ramp fiat through SEP-24 anchors (e.g. Anclap) and REST providers (e.g. Etherfuse). Get a quote, create the on-
+or off-ramp, then drive the transaction to completion. Custodial wallets receive a `kycUrl` to open; external wallets
+receive a `pendingSignature` to sign and resume via `submitRampSignature`. Etherfuse also uses this callback for a
+first-time Stellar onramp claim after its order completes.
 
 ```ts
 const quote = await client.getRampsQuote({

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -6896,6 +6896,8 @@ export interface operations {
                                 protocol: "SEP-24" | "REST";
                                 estimatedTime: string;
                                 recommended: boolean;
+                                /** Format: date-time */
+                                expiresAt?: string;
                                 /** @default [] */
                                 requiredFields: {
                                     key: string;
@@ -7732,6 +7734,11 @@ export interface operations {
                             kycUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
+                            pendingSignature?: {
+                                unsignedXdr: string;
+                                /** @enum {string} */
+                                action: "sep10" | "withdraw_payment";
+                            };
                             depositInstructions?: {
                                 scannable?: {
                                     /** @enum {string} */

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -162,6 +162,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
 
   const directionRef = useRef(direction);
   directionRef.current = direction;
+  const applyResultRef = useRef<(result: RampResult) => Promise<void>>(async () => {});
 
   // Poll the anchor transaction status while on the status step until terminal.
   useEffect(() => {
@@ -178,6 +179,11 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         // depositInstructions is returned by REST providers (Bridge) - e.g. a Pix
         // `br_code` / bank details for on-ramp.
         if (tx.depositInstructions) setDepositInstructions(tx.depositInstructions);
+        if (tx.pendingSignature) {
+          clearInterval(id);
+          await applyResultRef.current(tx as RampResult);
+          return;
+        }
         if (TERMINAL.includes(tx.status)) clearInterval(id);
       } catch {
         /* transient - keep polling */
@@ -261,6 +267,7 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         if (tx.stellarTxHash) setStellarTxHash(tx.stellarTxHash);
         if (tx.kycUrl) setKycUrl(tx.kycUrl);
         if (tx.depositInstructions) setDepositInstructions(tx.depositInstructions);
+        if (tx.pendingSignature) await applyResult(tx as RampResult);
       }
     } catch {
       /* transient - leave the current data in place */
@@ -329,6 +336,13 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     setStep('status');
   }
 
+  // Polling is intentionally set up before the flow helpers below. Keep its
+  // callback pointed at the latest helper without rebuilding the interval on
+  // every render.
+  useEffect(() => {
+    applyResultRef.current = applyResult;
+  });
+
   async function handleFindRoute() {
     setStep('loading_quote');
     setIsLoading(true);
@@ -354,6 +368,12 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   // Each quote declares the fields it needs (`requiredFields`). If any are unset,
   // collect them in the 'contact' step first; otherwise start immediately.
   function handleSelectQuote(quote: RampQuote) {
+    if (quote.expiresAt && new Date(quote.expiresAt).getTime() <= Date.now()) {
+      setSelectedQuote(null);
+      setErrorMsg('This quote expired. Find a new route to get the current rate.');
+      setStep('error');
+      return;
+    }
     setSelectedQuote(quote);
     setErrorMsg(null);
     // The limits are per route, and the amount was typed before the routes were
@@ -380,6 +400,11 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   }
 
   async function startRamp(quote: RampQuote) {
+    if (quote.expiresAt && new Date(quote.expiresAt).getTime() <= Date.now()) {
+      setErrorMsg('This quote expired. Find a new route to get the current rate.');
+      setStep('error');
+      return;
+    }
     setIsLoading(true);
     setErrorMsg(null);
     try {

--- a/packages/react/src/components/ramp-widget/RouteDisplay.tsx
+++ b/packages/react/src/components/ramp-widget/RouteDisplay.tsx
@@ -42,7 +42,9 @@ export function RouteDisplay({ quote, busy = false, disabled = false, onSelect }
       <div className="pollar-ramp-route-left">
         <span className="pollar-ramp-route-provider">{quote.provider}</span>
         <span className="pollar-ramp-route-meta">
-          {busy ? 'Starting…' : `${RAIL_LABELS[quote.rail] ?? quote.rail} · ${quote.protocol} · ${quote.estimatedTime}`}
+          {busy
+            ? 'Starting…'
+            : `${RAIL_LABELS[quote.rail] ?? quote.rail} · ${quote.protocol} · ${quote.estimatedTime}${quote.expiresAt ? ' · short-lived quote' : ''}`}
         </span>
       </div>
       <div className="pollar-ramp-route-right">
@@ -50,7 +52,9 @@ export function RouteDisplay({ quote, busy = false, disabled = false, onSelect }
           <span className="pollar-spinner pollar-spinner-sm" />
         ) : (
           <>
-            <span className="pollar-ramp-route-fee">{quote.fee}% fee</span>
+            <span className="pollar-ramp-route-fee">
+              {quote.fee} {quote.feeCurrency} fee
+            </span>
             {quote.recommended && <span className="pollar-ramp-route-badge">Best rate</span>}
           </>
         )}


### PR DESCRIPTION
## Summary

- expose ramp quote expiry and Etherfuse's withdraw-payment pending signature in the public API schema
- reject a route whose short-lived quote has expired before starting it
- preserve the route-card busy state while showing the real absolute provider fee and fee currency instead of treating it as a percentage
- document the quote lifecycle fields for SDK consumers

## Verification

- `npm run lint -w @pollar/core` (passes with existing warnings only)
- `npm run build -w @pollar/core`
- `npm run lint -w @pollar/react` (passes with one existing hook warning)
- `npm run build -w @pollar/react`

## Related

- backend integration: https://github.com/pollar-xyz/pollar-platform/pull/4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for pending signatures from REST-based ramp providers, allowing transaction flows to resume when additional authorization is required.
  - Added quote expiration handling to prevent expired quotes from being used.
  - Displayed quote expiration status and the applicable fee currency in ramp route details.

- **Documentation**
  - Updated ramp provider documentation to include REST providers and first-time onramp claim signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->