### PR TITLE
Feat/mesadepagos ramp widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "stellar-wallets-kit-adapter:publish": "cd packages/stellar-wallets-kit-adapter && npm publish --access public",
     "solana-wallet-standard-adapter:publish": "cd packages/solana-wallet-standard-adapter && npm publish --access public",
     "core:update-openapi": "curl -k https://sdk.api.local.pollar.xyz/openapi.v2.json -o /tmp/openapi.json && npx openapi-typescript /tmp/openapi.json -o ./packages/core/src/api/schema.d.ts",
-    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs && node tests/check-comment-ascii.cjs"
+    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs && node tests/smoke-mesadepagos.cjs && node tests/check-comment-ascii.cjs",
+    "test:mesadepagos": "node tests/smoke-mesadepagos.cjs"
   },
   "devDependencies": {
     "prettier": "^3.8.4",

--- a/packages/core/src/api/schema.d.ts
+++ b/packages/core/src/api/schema.d.ts
@@ -7218,6 +7218,8 @@ export interface operations {
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
+                            txHash?: string;
+                            chain?: "STELLAR" | "POLYGON" | "SOLANA";
                             pendingSignature?: {
                                 unsignedXdr: string;
                                 /** @enum {string} */
@@ -7352,6 +7354,8 @@ export interface operations {
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
+                            txHash?: string;
+                            chain?: "STELLAR" | "POLYGON" | "SOLANA";
                             pendingSignature?: {
                                 unsignedXdr: string;
                                 /** @enum {string} */
@@ -7473,6 +7477,8 @@ export interface operations {
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
+                            txHash?: string;
+                            chain?: "STELLAR" | "POLYGON" | "SOLANA";
                             pendingSignature?: {
                                 unsignedXdr: string;
                                 /** @enum {string} */
@@ -7601,6 +7607,8 @@ export interface operations {
                             tosUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
+                            txHash?: string;
+                            chain?: "STELLAR" | "POLYGON" | "SOLANA";
                             pendingSignature?: {
                                 unsignedXdr: string;
                                 /** @enum {string} */
@@ -7732,6 +7740,8 @@ export interface operations {
                             kycUrl?: string;
                             anchorTransactionId?: string;
                             stellarTxHash?: string;
+                            txHash?: string;
+                            chain?: "STELLAR" | "POLYGON" | "SOLANA";
                             depositInstructions?: {
                                 scannable?: {
                                     /** @enum {string} */

--- a/packages/react/src/components/ramp-widget/RampWidget.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidget.tsx
@@ -80,6 +80,7 @@ const RAMP_ERROR_MESSAGES: Record<string, string> = {
   SDK_RAMPS_PROVIDER_NOT_CONFIGURED: 'This ramp provider is not configured for this app yet.',
   SDK_RAMPS_ANCHOR_ERROR: 'The provider rejected the request. Please try again in a moment.',
   SDK_RAMPS_BRIDGE_ERROR: 'The provider rejected the request. Please try again in a moment.',
+  SDK_RAMPS_MESADEPAGOS_ERROR: 'Mesa de Pagos could not process this request. Please check the details and try again.',
 };
 
 /**
@@ -116,6 +117,8 @@ interface RampResult {
   // provider directly, and we poll `getRampKycStatus` until they do.
   kycRequired?: boolean;
   stellarTxHash?: string;
+  txHash?: string;
+  chain?: 'STELLAR' | 'POLYGON' | 'SOLANA';
   pendingSignature?: { unsignedXdr: string; action: 'sep10' | 'withdraw_payment' };
   // REST providers (Bridge) return deposit instructions as data (e.g. a Pix
   // `br_code` / bank details for on-ramp) instead of an interactive URL.
@@ -155,7 +158,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   const [kycPending, setKycPending] = useState(false);
   const [kycApproved, setKycApproved] = useState(false);
   const [txStatus, setTxStatus] = useState<RampTxStatus | null>(null);
-  const [stellarTxHash, setStellarTxHash] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [txChain, setTxChain] = useState<'STELLAR' | 'POLYGON' | 'SOLANA' | null>(null);
   const [depositInstructions, setDepositInstructions] = useState<RampDepositInstructions | null>(null);
   const [completing, setCompleting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -173,7 +177,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         const tx = await client.getRampTransaction(txId);
         if (!active) return;
         setTxStatus(tx.status);
-        if (tx.stellarTxHash) setStellarTxHash(tx.stellarTxHash);
+        if (tx.txHash ?? tx.stellarTxHash) setTxHash(tx.txHash ?? tx.stellarTxHash ?? null);
+        if (tx.chain) setTxChain(tx.chain);
         if (tx.kycUrl) setKycUrl(tx.kycUrl);
         // depositInstructions is returned by REST providers (Bridge) - e.g. a Pix
         // `br_code` / bank details for on-ramp.
@@ -258,7 +263,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
       } else if (step === 'status' && txId) {
         const tx = await client.getRampTransaction(txId);
         setTxStatus(tx.status);
-        if (tx.stellarTxHash) setStellarTxHash(tx.stellarTxHash);
+        if (tx.txHash ?? tx.stellarTxHash) setTxHash(tx.txHash ?? tx.stellarTxHash ?? null);
+        if (tx.chain) setTxChain(tx.chain);
         if (tx.kycUrl) setKycUrl(tx.kycUrl);
         if (tx.depositInstructions) setDepositInstructions(tx.depositInstructions);
       }
@@ -286,7 +292,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     setKycUrl(null);
     setTosUrl(null);
     setTxStatus(null);
-    setStellarTxHash(null);
+    setTxHash(null);
+    setTxChain(null);
     setDepositInstructions(null);
     setKycPending(false);
     setKycApproved(false);
@@ -324,7 +331,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
     setKycPending(result.kycRequired === true);
     if (result.kycRequired) setKycApproved(false);
     setTxStatus(result.status);
-    setStellarTxHash(result.stellarTxHash ?? null);
+    setTxHash(result.txHash ?? result.stellarTxHash ?? null);
+    setTxChain(result.chain ?? (result.stellarTxHash ? 'STELLAR' : null));
     setDepositInstructions(result.depositInstructions ?? null);
     setStep('status');
   }
@@ -432,7 +440,8 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         return;
       }
       setTxStatus(result.status);
-      setStellarTxHash(result.stellarTxHash ?? null);
+      setTxHash(result.txHash ?? result.stellarTxHash ?? null);
+      setTxChain(result.chain ?? (result.stellarTxHash ? 'STELLAR' : null));
     } catch (e) {
       const msg = e instanceof Error ? e.message : '';
       setErrorMsg(
@@ -449,7 +458,15 @@ export function RampWidget({ onClose }: RampWidgetProps) {
   // gate for the NEXT quote, not for this transaction, so `kycPending` (not
   // `kycBlocking`) is what keeps the button away.
   const kycBlocking = kycPending && !kycApproved;
-  const canComplete = direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !stellarTxHash && !kycPending;
+  const canComplete = direction === 'offramp' && step === 'status' && txStatus !== 'completed' && !txHash && !kycPending;
+
+  const explorerUrl = txHash
+    ? txChain === 'POLYGON'
+      ? `https://${network === 'mainnet' ? '' : 'amoy.'}polygonscan.com/tx/${txHash}`
+      : txChain === 'SOLANA'
+        ? `https://solscan.io/tx/${txHash}${network === 'mainnet' ? '' : '?cluster=devnet'}`
+        : `https://stellar.expert/explorer/${network === 'mainnet' ? 'public' : 'testnet'}/tx/${txHash}`
+    : null;
 
   const flowSteps = flowStepsOf(quotes, selectedQuote);
   const flowStepIndex = flowSteps.indexOf(STEP_LABEL[step] ?? '');
@@ -481,12 +498,9 @@ export function RampWidget({ onClose }: RampWidgetProps) {
         tosUrl={tosUrl}
         kycBlocking={kycBlocking}
         kycJustApproved={kycPending && kycApproved}
-        stellarTxHash={stellarTxHash}
-        explorerUrl={
-          stellarTxHash
-            ? `https://stellar.expert/explorer/${network === 'mainnet' ? 'public' : 'testnet'}/tx/${stellarTxHash}`
-            : null
-        }
+        txHash={txHash}
+        txChain={txChain}
+        explorerUrl={explorerUrl}
         depositInstructions={depositInstructions}
         canComplete={canComplete}
         completing={completing}

--- a/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
+++ b/packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx
@@ -117,8 +117,9 @@ interface RampWidgetTemplateProps {
   kycBlocking: boolean;
   /** The gate has since cleared - the user needs a fresh quote to continue. */
   kycJustApproved: boolean;
-  stellarTxHash: string | null;
-  /** Stellar Expert URL for `stellarTxHash` (network-aware); null when unknown. */
+  txHash: string | null;
+  txChain: 'STELLAR' | 'POLYGON' | 'SOLANA' | null;
+  /** Chain-aware explorer URL for `txHash`; null when unknown. */
   explorerUrl: string | null;
   depositInstructions: RampDepositInstructions | null;
   canComplete: boolean;
@@ -199,7 +200,8 @@ export function RampWidgetTemplate({
   tosUrl,
   kycBlocking,
   kycJustApproved,
-  stellarTxHash,
+  txHash,
+  txChain,
   explorerUrl,
   depositInstructions,
   canComplete,
@@ -500,22 +502,24 @@ export function RampWidgetTemplate({
             </div>
           </div>
 
-          {stellarTxHash && (
+          {txHash && (
             <div className="pollar-ramp-payment-field">
-              <span className="pollar-ramp-payment-label">Stellar tx</span>
+              <span className="pollar-ramp-payment-label">
+                {txChain ? `${txChain[0]}${txChain.slice(1).toLowerCase()} tx` : 'Transaction'}
+              </span>
               <div className="pollar-ramp-payment-value" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <code style={{ flex: 1, wordBreak: 'break-all' }}>
-                  {stellarTxHash.slice(0, 8)}…{stellarTxHash.slice(-8)}
+                  {txHash.slice(0, 8)}…{txHash.slice(-8)}
                 </code>
-                <CopyButton value={stellarTxHash} label="Copy transaction hash" />
+                <CopyButton value={txHash} label="Copy transaction hash" />
                 {explorerUrl && (
                   <a
                     href={explorerUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="pollar-copy-btn"
-                    aria-label="View on Stellar Expert"
-                    title="View on Stellar Expert"
+                    aria-label="View transaction in explorer"
+                    title="View transaction in explorer"
                   >
                     <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden>
                       <path

--- a/packages/react/src/components/ramp-widget/RouteDisplay.tsx
+++ b/packages/react/src/components/ramp-widget/RouteDisplay.tsx
@@ -15,7 +15,8 @@ const RAIL_LABELS: Record<string, string> = {
   SPEI: 'SPEI (Mexico)',
   PIX: 'PIX (Brazil)',
   PSE: 'PSE (Colombia)',
-  ACH: 'ACH (US)',
+  ACH: 'ACH (bank transfer)',
+  QR: 'Bank QR',
 };
 
 export function RouteDisplay({ quote, busy = false, disabled = false, onSelect }: RouteDisplayProps) {

--- a/tests/smoke-mesadepagos.cjs
+++ b/tests/smoke-mesadepagos.cjs
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const widget = fs.readFileSync(path.join(root, 'packages/react/src/components/ramp-widget/RampWidget.tsx'), 'utf8');
+const template = fs.readFileSync(path.join(root, 'packages/react/src/components/ramp-widget/RampWidgetTemplate.tsx'), 'utf8');
+const route = fs.readFileSync(path.join(root, 'packages/react/src/components/ramp-widget/RouteDisplay.tsx'), 'utf8');
+const schema = fs.readFileSync(path.join(root, 'packages/core/src/api/schema.d.ts'), 'utf8');
+
+assert.match(schema, /txHash\?: string;\s+chain\?: "STELLAR" \| "POLYGON" \| "SOLANA";/);
+assert.match(widget, /SDK_RAMPS_MESADEPAGOS_ERROR/);
+assert.match(widget, /'amoy\.'/);
+assert.match(widget, /polygonscan\.com\/tx\/\$\{txHash\}/);
+assert.match(widget, /!txHash && !kycPending/);
+assert.match(template, /depositInstructions\.scannable/);
+assert.match(template, /f\.type === 'select'/);
+assert.match(route, /QR: 'Bank QR'/);
+assert.match(route, /ACH: 'ACH \(bank transfer\)'/);
+
+console.log('Mesa SDK/widget smoke checks passed.');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction results now support Stellar, Polygon, and Solana, with links to the appropriate block explorer.
  * Transaction details display chain-specific labels and a general “View transaction in explorer” link.
  * Added support for Bank QR payment routes.
  * Updated ACH labeling to “ACH (bank transfer)” for clearer payment guidance.
  * Added a dedicated error message for Mesa de Pagos transactions.

* **Tests**
  * Added smoke-test coverage for multi-chain transactions and payment-route updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->