### PR TITLE
feat(ramps): support server operator credentials for backend ramp creation and polling (closes #56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stellar-wallets-kit-adapter:publish": "cd packages/stellar-wallets-kit-adapter && npm publish --access public",
     "solana-wallet-standard-adapter:publish": "cd packages/solana-wallet-standard-adapter && npm publish --access public",
     "core:update-openapi": "curl -k https://sdk.api.local.pollar.xyz/openapi.v2.json -o /tmp/openapi.json && npx openapi-typescript /tmp/openapi.json -o ./packages/core/src/api/schema.d.ts",
-    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs && node tests/check-comment-ascii.cjs"
+    "test:smoke": "node tests/smoke-keys.cjs && node tests/smoke-client.cjs && node tests/smoke-providers.cjs && node tests/smoke-session-races.cjs && node tests/smoke-resume.cjs && node --expose-gc tests/smoke-lifecycle.cjs && node tests/smoke-invariants.cjs && node tests/smoke-cross-document.cjs && node tests/smoke-react.cjs && node tests/smoke-operator-credentials.cjs && node tests/check-comment-ascii.cjs"
   },
   "devDependencies": {
     "prettier": "^3.8.4",

--- a/packages/core/src/api/endpoints/ramps.ts
+++ b/packages/core/src/api/endpoints/ramps.ts
@@ -16,8 +16,11 @@ import type {
   RampsSignatureResponse,
   RampsTransactionResponse,
   RampTxStatus,
+  RampOperatorOptions,
 } from '../../types';
 import { PollarApiError } from '../../types';
+
+export type { RampOperatorOptions };
 
 /**
  * Wrap an error body into a {@link PollarApiError}, keeping every field the API
@@ -56,14 +59,31 @@ export async function getRampsQuote(api: PollarApiClient, query: RampsQuoteQuery
   return data.content;
 }
 
+function operatorHeaders(options?: RampOperatorOptions): Record<string, string> | undefined {
+  if (!options?.operatorKey) return undefined;
+  return {
+    Authorization: `Bearer ${options.operatorKey}`,
+    'X-Operator-Key': options.operatorKey,
+  };
+}
+
 /**
  * POST /ramps/onramp
  * Creates an onramp transaction.
  * For embedded users: backend orchestrates the full SEP-24 flow and returns payment instructions.
  * For external wallets: backend may return an unsigned XDR that the client must sign via a wallet adapter.
+ * For server/operator mode: pass `options.operatorKey` to authorize server-side without user OTP.
  */
-export async function createOnRamp(api: PollarApiClient, body: RampsOnrampBody): Promise<RampsOnrampResponse> {
-  const { data, error } = await api.POST('/ramps/onramp', { body });
+export async function createOnRamp(
+  api: PollarApiClient,
+  body: RampsOnrampBody,
+  options?: RampOperatorOptions,
+): Promise<RampsOnrampResponse> {
+  const headers = operatorHeaders(options);
+  const { data, error } = await api.POST('/ramps/onramp', {
+    body,
+    ...(headers ? { headers } : {}),
+  } as any);
   if (!data?.content || error) throw rampApiError(error, 'Failed to create onramp');
   return data.content;
 }
@@ -72,9 +92,18 @@ export async function createOnRamp(api: PollarApiClient, body: RampsOnrampBody):
  * POST /ramps/offramp
  * Creates an offramp transaction.
  * Backend initiates the bank transfer once the Stellar transaction is confirmed.
+ * For server/operator mode: pass `options.operatorKey` to authorize server-side without user OTP.
  */
-export async function createOffRamp(api: PollarApiClient, body: RampsOfframpBody): Promise<RampsOfframpResponse> {
-  const { data, error } = await api.POST('/ramps/offramp', { body });
+export async function createOffRamp(
+  api: PollarApiClient,
+  body: RampsOfframpBody,
+  options?: RampOperatorOptions,
+): Promise<RampsOfframpResponse> {
+  const headers = operatorHeaders(options);
+  const { data, error } = await api.POST('/ramps/offramp', {
+    body,
+    ...(headers ? { headers } : {}),
+  } as any);
   if (!data?.content || error) throw rampApiError(error, 'Failed to create offramp');
   return data.content;
 }
@@ -111,9 +140,18 @@ export async function submitRampSignature(
 /**
  * GET /ramps/transaction/{txId}
  * Returns the current status of a ramp transaction.
+ * Pass `options.operatorKey` to fetch transaction status with server credentials.
  */
-export async function getRampTransaction(api: PollarApiClient, txId: string): Promise<RampsTransactionResponse> {
-  const { data, error } = await api.GET('/ramps/transaction/{txId}', { params: { path: { txId } } });
+export async function getRampTransaction(
+  api: PollarApiClient,
+  txId: string,
+  options?: RampOperatorOptions,
+): Promise<RampsTransactionResponse> {
+  const headers = operatorHeaders(options);
+  const { data, error } = await api.GET('/ramps/transaction/{txId}', {
+    params: { path: { txId } },
+    ...(headers ? { headers } : {}),
+  } as any);
   if (!data?.content || error) throw rampApiError(error, 'Failed to get transaction');
   return data.content;
 }
@@ -163,11 +201,15 @@ export async function decodePixQr(api: PollarApiClient, qrCode: string): Promise
 export async function pollRampTransaction(
   api: PollarApiClient,
   txId: string,
-  { intervalMs = 5000, timeoutMs = 600_000 }: { intervalMs?: number; timeoutMs?: number } = {},
+  {
+    intervalMs = 5000,
+    timeoutMs = 600_000,
+    operatorKey,
+  }: { intervalMs?: number; timeoutMs?: number; operatorKey?: string } = {},
 ): Promise<RampTxStatus> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const { status } = await getRampTransaction(api, txId);
+    const { status } = await getRampTransaction(api, txId, operatorKey ? { operatorKey } : undefined);
     if (status === 'completed' || status === 'failed') return status;
     await new Promise((r) => setTimeout(r, intervalMs));
   }

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -79,6 +79,7 @@ import {
   RampsSignatureResponse,
   RampsTransactionResponse,
   RampTxStatus,
+  RampOperatorOptions,
   SessionInfo,
   SessionsState,
   Sep10Proof,
@@ -253,6 +254,7 @@ export class PollarClient {
     return this._apiKeyHash;
   }
 
+  private _operatorKey: string | null = null;
   private _session: PollarPersistedSession | null = null;
   private _profile: PollarUserProfile | null = null;
   /** Last `DPoP-Nonce` we saw from a server response. Carried into the next proof. */
@@ -481,6 +483,8 @@ export class PollarClient {
       this._walletAdapters.set(adapter.type, adapter);
     }
 
+    this._operatorKey = config.operatorKey ?? config.serverSecretKey ?? null;
+
     this._api = createApiClient(this.basePath, {
       timeoutMs: this._requestTimeoutMs,
       retry: config.retry,
@@ -501,7 +505,9 @@ export class PollarClient {
     this._networkState = { step: 'connected', network: config.stellarNetwork ?? 'testnet' };
 
     if (!isClientRuntime) {
-      warnServerSide('constructor');
+      if (!this._operatorKey) {
+        warnServerSide('constructor');
+      }
       this._initialized = Promise.resolve();
       return;
     }
@@ -557,6 +563,17 @@ export class PollarClient {
   /** Awaitable handle for the initial keypair + session restore. */
   ready(): Promise<void> {
     return this._initialized;
+  }
+
+  /**
+   * Optional server operator or backend secret key configured for server-side operator mode.
+   */
+  get operatorKey(): string | null {
+    return this._operatorKey;
+  }
+
+  setOperatorKey(key: string | null | undefined): void {
+    this._operatorKey = key ?? null;
   }
 
   // --- Lifecycle ------------------------------------------------------------
@@ -761,7 +778,13 @@ export class PollarClient {
         }
 
         const accessToken = self._session?.token?.accessToken;
-        if (!accessToken) return request;
+        if (!accessToken) {
+          if (self._operatorKey && !request.headers.has('Authorization')) {
+            request.headers.set('Authorization', `Bearer ${self._operatorKey}`);
+            request.headers.set('X-Operator-Key', self._operatorKey);
+          }
+          return request;
+        }
 
         const proof = await self._buildProofForRequest(request, accessToken);
         if (proof) {
@@ -990,7 +1013,10 @@ export class PollarClient {
     if (!request.headers.has('DPoP')) return request;
 
     const accessToken = this._session?.token?.accessToken;
-    if (!accessToken) return null;
+    if (!accessToken) {
+      if (this._operatorKey) return request;
+      return null;
+    }
 
     const proof = await this._buildProofForRequest(request, accessToken);
     if (!proof) return null;
@@ -1036,6 +1062,9 @@ export class PollarClient {
         } else {
           headers.set('Authorization', `Bearer ${accessToken}`);
         }
+      } else if (this._operatorKey) {
+        headers.set('Authorization', `Bearer ${this._operatorKey}`);
+        headers.set('X-Operator-Key', this._operatorKey);
       }
     }
 
@@ -3317,12 +3346,14 @@ export class PollarClient {
     return getRampCountries(this._api);
   }
 
-  createOnRamp(body: RampsOnrampBody): Promise<RampsOnrampResponse> {
-    return createOnRamp(this._api, body);
+  createOnRamp(body: RampsOnrampBody, options?: RampOperatorOptions): Promise<RampsOnrampResponse> {
+    const opts = options?.operatorKey ? options : this._operatorKey ? { operatorKey: this._operatorKey } : options;
+    return createOnRamp(this._api, body, opts);
   }
 
-  createOffRamp(body: RampsOfframpBody): Promise<RampsOfframpResponse> {
-    return createOffRamp(this._api, body);
+  createOffRamp(body: RampsOfframpBody, options?: RampOperatorOptions): Promise<RampsOfframpResponse> {
+    const opts = options?.operatorKey ? options : this._operatorKey ? { operatorKey: this._operatorKey } : options;
+    return createOffRamp(this._api, body, opts);
   }
 
   /** Complete an offramp once anchor KYC is done (build + sign + submit the withdraw payment). */
@@ -3335,12 +3366,17 @@ export class PollarClient {
     return submitRampSignature(this._api, txId, body);
   }
 
-  getRampTransaction(txId: string): Promise<RampsTransactionResponse> {
-    return getRampTransaction(this._api, txId);
+  getRampTransaction(txId: string, options?: RampOperatorOptions): Promise<RampsTransactionResponse> {
+    const opts = options?.operatorKey ? options : this._operatorKey ? { operatorKey: this._operatorKey } : options;
+    return getRampTransaction(this._api, txId, opts);
   }
 
-  pollRampTransaction(txId: string, opts?: { intervalMs?: number; timeoutMs?: number }): Promise<RampTxStatus> {
-    return pollRampTransaction(this._api, txId, opts);
+  pollRampTransaction(
+    txId: string,
+    opts?: { intervalMs?: number; timeoutMs?: number; operatorKey?: string },
+  ): Promise<RampTxStatus> {
+    const mergedOpts = opts?.operatorKey ? opts : this._operatorKey ? { ...opts, operatorKey: this._operatorKey } : opts;
+    return pollRampTransaction(this._api, txId, mergedOpts);
   }
 
   /**

--- a/packages/core/src/public.ts
+++ b/packages/core/src/public.ts
@@ -67,6 +67,7 @@ export {
   getRampKycStatus,
   decodePixQr,
 } from './api/endpoints/ramps';
+export type { RampOperatorOptions } from './api/endpoints/ramps';
 
 // --- Distribution endpoints ---------------------------------------------------
 export { listDistributionRules, claimDistributionRule } from './api/endpoints/distribution';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -297,6 +297,31 @@ export interface PollarClientConfig {
    * browser-only for now.
    */
   passkeySign?: PasskeySigner;
+  /**
+   * Optional server operator or backend credential key.
+   * When specified, enables server-side operator mode (e.g. for backend ramp
+   * creation/polling on `/ramps/onramp` and `/ramps/transaction/{txId}`) without
+   * requiring an interactive end-user OTP login session or browser DPoP proof.
+   *
+   * @see https://github.com/pollar-xyz/pollar/issues/56
+   */
+  operatorKey?: string | undefined;
+  /**
+   * Alias for {@link operatorKey}. Allows supplying a server-side secret key
+   * directly in backend environments.
+   */
+  serverSecretKey?: string | undefined;
+}
+
+/**
+ * Options for server-side operator mode execution on ramp operations.
+ */
+export interface RampOperatorOptions {
+  /**
+   * Optional server operator or backend secret key for authenticating
+   * server-side ramp requests without an interactive end-user OTP session.
+   */
+  operatorKey?: string | undefined;
 }
 
 /**

--- a/tests/smoke-operator-credentials.cjs
+++ b/tests/smoke-operator-credentials.cjs
@@ -1,0 +1,143 @@
+// @pollar smoke test — Server operator credential mode for /ramps.
+//
+// Closes issue #56: Server/operator credential mode for /ramps/onramp.
+
+const path = require('node:path');
+
+const SDK_DIST = path.resolve(__dirname, '../packages/core/dist/index.js');
+const sdk = require(SDK_DIST);
+
+let pass = 0;
+let fail = 0;
+function check(label, ok, extra) {
+  if (ok) {
+    pass++;
+    console.log(`  OK    ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${label}`, extra ?? '');
+  }
+}
+
+(async () => {
+  console.log('── 1. Server-Side Instantiation with Operator Credentials ──');
+
+  const operatorSecret = 'sk_live_op_secret_99887766';
+  const apiKey = 'pk_test_operator_ramp';
+
+  const client = new sdk.PollarClient({
+    apiKey,
+    operatorKey: operatorSecret,
+    stellarNetwork: 'testnet',
+    storage: sdk.createMemoryAdapter(),
+  });
+
+  await client.ready();
+  check('client.ready() resolves in operator mode', true);
+  check('client.operatorKey reflects configured operatorKey', client.operatorKey === operatorSecret);
+
+  // Dynamic setter
+  client.setOperatorKey('sk_live_op_secret_updated');
+  check('client.setOperatorKey updates the key', client.operatorKey === 'sk_live_op_secret_updated');
+  client.setOperatorKey(operatorSecret);
+
+  console.log('── 2. Request Header Injection for Ramps in Operator Mode ──');
+
+  let capturedRequests = [];
+  globalThis.fetch = async (input, init) => {
+    const req = input instanceof Request ? input : new Request(input, init);
+    capturedRequests.push({
+      url: req.url,
+      method: req.method,
+      headers: Object.fromEntries(req.headers.entries()),
+      body: req.method !== 'GET' ? await req.clone().text() : null,
+    });
+
+    if (req.url.includes('/ramps/onramp')) {
+      return new Response(
+        JSON.stringify({
+          status: 'success',
+          content: {
+            id: 'ramp_tx_123',
+            type: 'onramp',
+            status: 'pending_user_transfer',
+            depositAddress: 'GACCOUNT...',
+            instructions: 'Send USD to anchor account',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (req.url.includes('/ramps/transaction/ramp_tx_123')) {
+      return new Response(
+        JSON.stringify({
+          status: 'success',
+          content: {
+            id: 'ramp_tx_123',
+            status: 'completed',
+            cryptoAmount: '100',
+            fiatAmount: '100',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(JSON.stringify({ status: 'success', content: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  const onrampResult = await client.createOnRamp({
+    fiatAmount: '100',
+    fiatCurrency: 'USD',
+    cryptoAsset: 'USDC',
+    destinationAddress: 'GACCOUNT1234567890',
+  });
+
+  check('createOnRamp returns data in operator mode', onrampResult?.id === 'ramp_tx_123');
+  const onrampReq = capturedRequests[0];
+  check('createOnRamp includes Authorization: Bearer <operatorKey>', onrampReq.headers['authorization'] === `Bearer ${operatorSecret}`);
+  check('createOnRamp includes X-Operator-Key header', onrampReq.headers['x-operator-key'] === operatorSecret);
+  check('createOnRamp does not require DPoP header', onrampReq.headers['dpop'] === undefined);
+
+  console.log('── 3. GET /ramps/transaction/:id in Operator Mode ──');
+  capturedRequests = [];
+  const txStatus = await client.getRampTransaction('ramp_tx_123');
+  check('getRampTransaction returns status', txStatus?.status === 'completed');
+  const getReq = capturedRequests[0];
+  check('getRampTransaction includes Authorization header', getReq.headers['authorization'] === `Bearer ${operatorSecret}`);
+  check('getRampTransaction includes X-Operator-Key header', getReq.headers['x-operator-key'] === operatorSecret);
+
+  console.log('── 4. Per-Call Operator Key Override ──');
+  capturedRequests = [];
+  const customKey = 'sk_override_per_call_custom';
+  await client.createOnRamp(
+    {
+      fiatAmount: '50',
+      fiatCurrency: 'BRL',
+      cryptoAsset: 'USDC',
+      destinationAddress: 'GACCOUNT9876543210',
+    },
+    { operatorKey: customKey },
+  );
+
+  const overrideReq = capturedRequests[0];
+  check('Per-call operatorKey overrides client default Authorization', overrideReq.headers['authorization'] === `Bearer ${customKey}`);
+  check('Per-call operatorKey overrides X-Operator-Key header', overrideReq.headers['x-operator-key'] === customKey);
+
+  console.log('── 5. ServerSecretKey Config Alias Compatibility ──');
+  const secretKeyClient = new sdk.PollarClient({
+    apiKey,
+    serverSecretKey: 'sk_via_server_secret_key_alias',
+    stellarNetwork: 'testnet',
+    storage: sdk.createMemoryAdapter(),
+  });
+  await secretKeyClient.ready();
+  check('serverSecretKey is accepted as alias for operatorKey', secretKeyClient.operatorKey === 'sk_via_server_secret_key_alias');
+
+  console.log(`\n${pass} pass, ${fail} fail\n`);
+  if (fail > 0) process.exit(1);
+})();


### PR DESCRIPTION
## Summary
Closes #56

Adds server-side operator credential mode for creating and polling ramp transactions (`/ramps/onramp`, `/ramps/offramp`, `/ramps/transaction/{txId}`) without requiring an interactive end-user OTP login session or browser DPoP proof.

## Key Changes
- **Configuration & Types (`packages/core/src/types.ts`)**:
  - Added `operatorKey?: string` and `serverSecretKey?: string` (alias) to `PollarClientConfig`.
  - Exported `RampOperatorOptions` with optional `operatorKey` parameter.
- **Client Header Injection & Retry Middleware (`packages/core/src/client/client.ts`)**:
  - Added `_operatorKey` private property, getter `operatorKey`, and setter `setOperatorKey`.
  - In `onRequest`, when no user `accessToken` is present and `_operatorKey` is configured, automatically injects `Authorization: Bearer <operatorKey>` and `X-Operator-Key: <operatorKey>`.
  - In `_resignForRetry` and `_retryRequest`, preserves operator authentication headers across retries without DPoP session requirements.
  - Silences client-only console warnings when instantiated server-side with an operator key.
- **Ramps API & Client Methods (`packages/core/src/api/endpoints/ramps.ts`)**:
  - Updated `createOnRamp`, `createOffRamp`, `getRampTransaction`, and `pollRampTransaction` to accept optional `RampOperatorOptions` for per-request overrides.
  - Forwarded operator options from `PollarClient` instance methods to endpoints.
- **Verification & Smoke Tests (`tests/smoke-operator-credentials.cjs`)**:
  - Comprehensive smoke test suite covering server-side instantiation, header injection, per-call overrides, and alias compatibility.
  - All 13/13 operator credential tests and full 10-suite smoke test pass 100% green.

## Verification
- `npm run build`: Monorepo built successfully across all packages and adapters with 0 errors.
- `npm run test:smoke`: 100% pass across all 10 smoke test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional operator-key authentication for onramp creation, offramp creation, transaction retrieval, and transaction polling.
  - Added client configuration for operator credentials, including `operatorKey` and the `serverSecretKey` alias.
  - Added support for per-request operator-key overrides.
  - Operator credentials are automatically applied to eligible requests when no session token is available.
  - Exported the operator options type for package consumers.

- **Tests**
  - Added smoke test coverage for operator authentication, credential overrides, and compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->